### PR TITLE
fix(linux): avoid EPERM/zombie blocking antigravity shutdown

### DIFF
--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -1,7 +1,103 @@
-use sysinfo::System;
+#[cfg(target_os = "linux")]
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::path::Path;
 use std::process::Command;
 use std::thread;
 use std::time::Duration;
+use sysinfo::System;
+
+fn lowercase_os_str(value: &OsStr) -> String {
+    value.to_string_lossy().to_lowercase()
+}
+
+fn format_pid_list(pids: &[u32], limit: usize) -> String {
+    if pids.len() <= limit {
+        format!("{:?}", pids)
+    } else {
+        format!("{:?}...(+{})", &pids[..limit], pids.len() - limit)
+    }
+}
+
+fn is_zombie_process(process: &sysinfo::Process) -> bool {
+    matches!(process.status(), sysinfo::ProcessStatus::Zombie)
+}
+
+#[cfg(target_os = "linux")]
+fn current_effective_uid(system: &System) -> Option<sysinfo::Uid> {
+    system
+        .process(sysinfo::Pid::from_u32(std::process::id()))
+        .and_then(|p| p.effective_user_id().or(p.user_id()))
+        .cloned()
+}
+
+#[cfg(target_os = "linux")]
+fn is_same_user_or_unknown(process: &sysinfo::Process, current_uid: &Option<sysinfo::Uid>) -> bool {
+    let Some(current_uid) = current_uid else {
+        return true;
+    };
+    match process.effective_user_id().or(process.user_id()) {
+        Some(uid) => uid == current_uid,
+        None => true,
+    }
+}
+
+fn process_exe_basename_lower(process: &sysinfo::Process) -> Option<String> {
+    process
+        .exe()
+        .and_then(|p| p.file_name())
+        .map(lowercase_os_str)
+}
+
+fn process_cmd0_basename_lower(process: &sysinfo::Process) -> Option<String> {
+    process
+        .cmd()
+        .first()
+        .and_then(|cmd0| Path::new(cmd0).file_name())
+        .map(lowercase_os_str)
+}
+
+fn is_antigravity_process(process: &sysinfo::Process) -> bool {
+    let name_lower = lowercase_os_str(process.name());
+    let exe_basename_lower = process_exe_basename_lower(process);
+    let cmd0_basename_lower = process_cmd0_basename_lower(process);
+
+    #[cfg(target_os = "macos")]
+    {
+        let exe_path_lower = process
+            .exe()
+            .map(|p| lowercase_os_str(p.as_os_str()))
+            .unwrap_or_default();
+        return exe_path_lower.contains("antigravity.app");
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return name_lower == "antigravity.exe"
+            || exe_basename_lower.as_deref() == Some("antigravity.exe")
+            || cmd0_basename_lower.as_deref() == Some("antigravity.exe");
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if name_lower == "antigravity"
+            || exe_basename_lower.as_deref() == Some("antigravity")
+            || cmd0_basename_lower.as_deref() == Some("antigravity")
+        {
+            return true;
+        }
+
+        // AppImage: `Antigravity.AppImage` 通常会出现在 cmd[0] 中
+        if let Some(cmd0) = cmd0_basename_lower {
+            return cmd0.ends_with(".appimage") && cmd0.contains("antigravity");
+        }
+
+        return false;
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
 
 /// 检查 Antigravity 是否在运行
 pub fn is_antigravity_running() -> bool {
@@ -10,40 +106,34 @@ pub fn is_antigravity_running() -> bool {
     system.refresh_processes(sysinfo::ProcessesToUpdate::All);
 
     let current_pid = std::process::id();
+    #[cfg(target_os = "linux")]
+    let current_uid = current_effective_uid(&system);
 
     for (pid, process) in system.processes() {
         if pid.as_u32() == current_pid {
             continue;
         }
 
-        #[allow(unused_variables)]
-        let name = process.name().to_string_lossy().to_lowercase();
-        let exe_path = process.exe()
-            .and_then(|p| p.to_str())
-            .unwrap_or("")
-            .to_lowercase();
-
-        #[cfg(target_os = "macos")]
-        {
-            if exe_path.contains("antigravity.app") {
-                return true;
-            }
-        }
-
-        #[cfg(target_os = "windows")]
-        {
-            // 严格匹配进程名，避免 false positive (如 esbuild.exe 在 antigravity 目录下)
-            if name == "antigravity.exe" {
-                 crate::modules::logger::log_info(&format!("检测到 Antigravity 进程: {} (PID: {}) Path: {}", name, pid, exe_path));
-                 return true;
-            }
-        }
-
         #[cfg(target_os = "linux")]
-        {
-            if name == "antigravity" || exe_path.contains("antigravity") {
-                return true;
+        let same_user = is_same_user_or_unknown(process, &current_uid);
+        #[cfg(not(target_os = "linux"))]
+        let same_user = true;
+
+        // Zombie 进程已经“死了”，只是还没被父进程回收；不能再阻塞关闭流程
+        if is_antigravity_process(process) && !is_zombie_process(process) && same_user {
+            #[cfg(target_os = "windows")]
+            {
+                let name = process.name().to_string_lossy().to_lowercase();
+                let exe_path = process
+                    .exe()
+                    .map(|p| p.as_os_str().to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                crate::modules::logger::log_info(&format!(
+                    "检测到 Antigravity 进程: {} (PID: {}) Path: {}",
+                    name, pid, exe_path
+                ));
             }
+            return true;
         }
     }
 
@@ -54,50 +144,72 @@ pub fn is_antigravity_running() -> bool {
 fn get_antigravity_pids() -> Vec<u32> {
     let mut system = System::new();
     system.refresh_processes(sysinfo::ProcessesToUpdate::All);
-    
+
     let current_pid = std::process::id();
     let mut pids = Vec::new();
-    
+    let mut zombie_pids = Vec::new();
+    #[cfg(target_os = "linux")]
+    let mut foreign_pids = Vec::new();
+    #[cfg(target_os = "linux")]
+    let current_uid = current_effective_uid(&system);
+
     for (pid, process) in system.processes() {
         // 排除当前进程
         if pid.as_u32() == current_pid {
             continue;
         }
-        
-        let exe_path = process.exe()
-            .and_then(|p| p.to_str())
-            .unwrap_or("")
-            .to_lowercase();
-        
-        #[cfg(target_os = "macos")]
-        {
-            // 匹配所有 Antigravity 相关进程（主进程 + Helper 进程）
-            if exe_path.contains("antigravity.app") {
-                pids.push(pid.as_u32());
+
+        if is_antigravity_process(process) {
+            #[cfg(target_os = "linux")]
+            {
+                if !is_same_user_or_unknown(process, &current_uid) {
+                    foreign_pids.push(pid.as_u32());
+                    continue;
+                }
             }
-        }
-        
-        #[cfg(target_os = "windows")]
-        {
-            let name = process.name().to_string_lossy().to_lowercase();
-            if name.starts_with("antigravity") && name.ends_with(".exe") {
-                pids.push(pid.as_u32());
-            }
-        }
-        
-        #[cfg(target_os = "linux")]
-        {
-            let name = process.name().to_string_lossy().to_lowercase();
-            if name == "antigravity" || exe_path.contains("antigravity") {
+            if is_zombie_process(process) {
+                zombie_pids.push(pid.as_u32());
+            } else {
                 pids.push(pid.as_u32());
             }
         }
     }
-    
+
+    // 保证顺序稳定，避免 HashMap 迭代顺序导致“随机挑中 helper PID”
+    pids.sort_unstable();
+    pids.dedup();
+    zombie_pids.sort_unstable();
+    zombie_pids.dedup();
+
     if !pids.is_empty() {
-        crate::modules::logger::log_info(&format!("找到 {} 个 Antigravity 进程: {:?}", pids.len(), pids));
+        crate::modules::logger::log_info(&format!(
+            "找到 {} 个 Antigravity 进程 (排除 Zombie): {}",
+            pids.len(),
+            format_pid_list(&pids, 80)
+        ));
     }
-    
+
+    if !zombie_pids.is_empty() {
+        crate::modules::logger::log_warn(&format!(
+            "检测到 {} 个 Antigravity Zombie 进程 (已退出未回收): {}",
+            zombie_pids.len(),
+            format_pid_list(&zombie_pids, 80)
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        foreign_pids.sort_unstable();
+        foreign_pids.dedup();
+        if !foreign_pids.is_empty() {
+            crate::modules::logger::log_warn(&format!(
+                "检测到 {} 个 Antigravity 进程属于其他用户/权限不足，无法结束: {}",
+                foreign_pids.len(),
+                format_pid_list(&foreign_pids, 50)
+            ));
+        }
+    }
+
     pids
 }
 
@@ -113,7 +225,7 @@ pub fn close_antigravity(timeout_secs: u64) -> Result<(), String> {
         let _ = Command::new("taskkill")
             .args(["/F", "/IM", "Antigravity.exe"])
             .output();
-            
+
         // 给一点点时间让系统清理 PID
         thread::sleep(Duration::from_millis(200));
     }
@@ -122,16 +234,16 @@ pub fn close_antigravity(timeout_secs: u64) -> Result<(), String> {
     {
         // macOS: 优化关闭策略，避免"窗口意外终止"弹窗
         // 策略：仅向主进程发送 SIGTERM，让其自行协调关闭子进程
-        
+
         let pids = get_antigravity_pids();
         if !pids.is_empty() {
             // 1. 识别主进程 (PID)
             // 策略：Electron/Tauri 的主进程没有 `--type` 参数，而 Helper 进程都有 `--type=renderer/gpu/utility` 等
             let mut system = System::new();
             system.refresh_processes(sysinfo::ProcessesToUpdate::All);
-            
+
             let mut main_pid = None;
-            
+
             crate::modules::logger::log_info("正在分析进程列表以识别主进程:");
             for pid_u32 in &pids {
                 let pid = sysinfo::Pid::from_u32(*pid_u32);
@@ -139,56 +251,76 @@ pub fn close_antigravity(timeout_secs: u64) -> Result<(), String> {
                     let name = process.name().to_string_lossy();
                     let args = process.cmd();
                     // sysinfo 0.31 returns &[OsString], so we need to convert to String
-                    let args_str = args.iter()
+                    let args_str = args
+                        .iter()
                         .map(|arg| arg.to_string_lossy().into_owned())
                         .collect::<Vec<String>>()
                         .join(" ");
-                    
-                    crate::modules::logger::log_info(&format!(" - PID: {} | Name: {} | Args: {}", pid_u32, name, args_str));
-                    
+
+                    crate::modules::logger::log_info(&format!(
+                        " - PID: {} | Name: {} | Args: {}",
+                        pid_u32, name, args_str
+                    ));
+
                     // 主进程通常没有 --type 参数，或者 args 很少
                     // 注意：开发环境下 (cargo tauri dev) 可能会有 cargo 相关的进程，需要小心
                     // 但这里 pids 列表已经通过 exe_path 过滤过了，应该是 Antigravity 的相关进程
-                    
-                    let is_helper_by_name = name.to_lowercase().contains("helper") 
+
+                    let is_helper_by_name = name.to_lowercase().contains("helper")
                         || name.to_lowercase().contains("crashpad")
                         || name.to_lowercase().contains("language_server");
-                        
+
                     let is_helper_by_args = args_str.contains("--type=");
-                    
+
                     if !is_helper_by_name && !is_helper_by_args {
                         if main_pid.is_none() {
                             main_pid = Some(pid_u32);
-                            crate::modules::logger::log_info(&format!("   => 识别为主进程 (Name/Args排除匹配)"));
+                            crate::modules::logger::log_info(&format!(
+                                "   => 识别为主进程 (Name/Args排除匹配)"
+                            ));
                         } else {
-                            crate::modules::logger::log_warn(&format!("   => 发现多个疑似主进程，保留第一个"));
+                            crate::modules::logger::log_warn(&format!(
+                                "   => 发现多个疑似主进程，保留第一个"
+                            ));
                         }
                     } else {
-                         crate::modules::logger::log_info(&format!("   => 识别为辅助进程 (Helper/Args)"));
+                        crate::modules::logger::log_info(&format!(
+                            "   => 识别为辅助进程 (Helper/Args)"
+                        ));
                     }
                 }
             }
-            
+
             // 阶段 1: 优雅退出 (SIGTERM)
             if let Some(pid) = main_pid {
-                crate::modules::logger::log_info(&format!("决定向主进程 PID: {} 发送 SIGTERM", pid));
+                crate::modules::logger::log_info(&format!(
+                    "决定向主进程 PID: {} 发送 SIGTERM",
+                    pid
+                ));
                 let output = Command::new("kill")
                     .args(["-15", &pid.to_string()])
                     .output();
-                    
+
                 if let Ok(result) = output {
                     if !result.status.success() {
                         let error = String::from_utf8_lossy(&result.stderr);
-                        crate::modules::logger::log_warn(&format!("主进程 SIGTERM 失败: {}", error));
+                        crate::modules::logger::log_warn(&format!(
+                            "主进程 SIGTERM 失败: {}",
+                            error
+                        ));
                     }
                 }
             } else {
-                crate::modules::logger::log_warn("未识别出明确的主进程，将尝试对所有进程发送 SIGTERM (可能导致弹窗)");
+                crate::modules::logger::log_warn(
+                    "未识别出明确的主进程，将尝试对所有进程发送 SIGTERM (可能导致弹窗)",
+                );
                 for pid in &pids {
-                    let _ = Command::new("kill").args(["-15", &pid.to_string()]).output();
+                    let _ = Command::new("kill")
+                        .args(["-15", &pid.to_string()])
+                        .output();
                 }
             }
-            
+
             // 等待优雅退出（最多 timeout_secs 的 70%）
             let graceful_timeout = (timeout_secs * 7) / 10;
             let start = std::time::Instant::now();
@@ -199,29 +331,34 @@ pub fn close_antigravity(timeout_secs: u64) -> Result<(), String> {
                 }
                 thread::sleep(Duration::from_millis(500));
             }
-            
+
             // 阶段 2: 强制杀死 (SIGKILL) - 针对残留的所有进程 (Helpers)
             if is_antigravity_running() {
                 let remaining_pids = get_antigravity_pids();
                 if !remaining_pids.is_empty() {
-                    crate::modules::logger::log_warn(&format!("优雅关闭超时，强制杀死 {} 个残留进程 (SIGKILL)", remaining_pids.len()));
+                    crate::modules::logger::log_warn(&format!(
+                        "优雅关闭超时，强制杀死 {} 个残留进程 (SIGKILL)",
+                        remaining_pids.len()
+                    ));
                     for pid in &remaining_pids {
-                        let output = Command::new("kill")
-                            .args(["-9", &pid.to_string()])
-                            .output();
-                        
+                        let output = Command::new("kill").args(["-9", &pid.to_string()]).output();
+
                         if let Ok(result) = output {
                             if !result.status.success() {
                                 let error = String::from_utf8_lossy(&result.stderr);
-                                if !error.contains("No such process") { // "No matching processes" for killall, "No such process" for kill
-                                    crate::modules::logger::log_error(&format!("SIGKILL 进程 {} 失败: {}", pid, error));
+                                if !error.contains("No such process") {
+                                    // "No matching processes" for killall, "No such process" for kill
+                                    crate::modules::logger::log_error(&format!(
+                                        "SIGKILL 进程 {} 失败: {}",
+                                        pid, error
+                                    ));
                                 }
                             }
                         }
                     }
                     thread::sleep(Duration::from_secs(1));
                 }
-                
+
                 // 再次检查
                 if !is_antigravity_running() {
                     crate::modules::logger::log_info("所有进程已在强制清理后退出");
@@ -238,15 +375,43 @@ pub fn close_antigravity(timeout_secs: u64) -> Result<(), String> {
 
     #[cfg(target_os = "linux")]
     {
+        fn kill_pid(signal: &str, pid: u32) {
+            match Command::new("kill")
+                .args([signal, &pid.to_string()])
+                .output()
+            {
+                Ok(result) => {
+                    if !result.status.success() {
+                        let err = String::from_utf8_lossy(&result.stderr);
+                        if !err.contains("No such process") {
+                            crate::modules::logger::log_warn(&format!(
+                                "kill {} PID {} 失败: {}",
+                                signal, pid, err
+                            ));
+                        }
+                    }
+                }
+                Err(e) => {
+                    crate::modules::logger::log_warn(&format!(
+                        "无法执行 kill {} PID {}: {}",
+                        signal, pid, e
+                    ));
+                }
+            };
+        }
+
         // Linux: 使用 PID 精确控制
         let pids = get_antigravity_pids();
         if !pids.is_empty() {
-            let pid = pids[0]; // 使用第一个找到的进程
-            crate::modules::logger::log_info(&format!("尝试优雅关闭进程 {} (SIGTERM)", pid));
-            let _ = Command::new("kill")
-                .args(["-15", &pid.to_string()])
-                .output();
-            
+            crate::modules::logger::log_info(&format!(
+                "尝试优雅关闭 {} 个进程 (SIGTERM): {}",
+                pids.len(),
+                format_pid_list(&pids, 80)
+            ));
+            for pid in &pids {
+                kill_pid("-15", *pid);
+            }
+
             // 等待优雅退出
             let graceful_timeout = (timeout_secs * 7) / 10;
             let start = std::time::Instant::now();
@@ -257,24 +422,88 @@ pub fn close_antigravity(timeout_secs: u64) -> Result<(), String> {
                 }
                 thread::sleep(Duration::from_millis(500));
             }
-            
-            // 强制杀死
+
+            // 强制杀死：重新获取仍存活的 PID，避免只杀到 helper
             if is_antigravity_running() {
-                crate::modules::logger::log_warn(&format!("优雅关闭超时，强制杀死进程 {} (SIGKILL)", pid));
-                let _ = Command::new("kill")
-                    .args(["-9", &pid.to_string()])
-                    .output();
+                let remaining_pids = get_antigravity_pids();
+                if !remaining_pids.is_empty() {
+                    crate::modules::logger::log_warn(&format!(
+                        "优雅关闭超时，强制杀死 {} 个残留进程 (SIGKILL): {}",
+                        remaining_pids.len(),
+                        format_pid_list(&remaining_pids, 80)
+                    ));
+                    for pid in &remaining_pids {
+                        kill_pid("-9", *pid);
+                    }
+                }
                 thread::sleep(Duration::from_secs(1));
             }
         } else {
             crate::modules::logger::log_warn("未找到 Antigravity 进程 PID，尝试使用 pkill");
-            let _ = Command::new("pkill")
-                .args(["-9", "antigravity"])
-                .output();
+            let output = Command::new("pkill").args(["-9", "antigravity"]).output();
+            if let Ok(result) = output {
+                if !result.status.success() {
+                    let err = String::from_utf8_lossy(&result.stderr);
+                    crate::modules::logger::log_warn(&format!("pkill 失败: {}", err));
+                }
+            } else if let Err(e) = output {
+                crate::modules::logger::log_warn(&format!("无法执行 pkill: {}", e));
+            }
             thread::sleep(Duration::from_secs(1));
         }
+
+        // 额外诊断：如果仍然“在运行”，输出状态分布与部分命令行，便于定位是权限不足/被守护拉起/卡死(D) 等
+        if is_antigravity_running() {
+            let mut system = System::new();
+            system.refresh_processes(sysinfo::ProcessesToUpdate::All);
+
+            let mut status_counts: BTreeMap<String, usize> = BTreeMap::new();
+            let mut samples: Vec<String> = Vec::new();
+
+            for (pid, process) in system.processes() {
+                if pid.as_u32() == std::process::id() {
+                    continue;
+                }
+                if !is_antigravity_process(process) || is_zombie_process(process) {
+                    continue;
+                }
+
+                let status = format!("{:?}", process.status());
+                *status_counts.entry(status).or_insert(0) += 1;
+
+                if samples.len() < 25 {
+                    let name = process.name().to_string_lossy();
+                    let cmd = process
+                        .cmd()
+                        .iter()
+                        .map(|s| s.to_string_lossy())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    samples.push(format!(
+                        "PID {} | {:?} | {} | {}",
+                        pid,
+                        process.status(),
+                        name,
+                        cmd
+                    ));
+                }
+            }
+
+            crate::modules::logger::log_error(&format!(
+                "关闭后仍检测到 Antigravity 非 Zombie 进程，状态分布: {:?}，示例: {}",
+                status_counts,
+                samples.join(" ; ")
+            ));
+
+            // 给出更明确的错误提示（D 状态/IO 卡死通常 SIGKILL 无效）
+            if status_counts.contains_key("Dead")
+                || status_counts.contains_key("UninterruptibleDiskSleep")
+            {
+                return Err("无法关闭 Antigravity：检测到进程处于不可中断睡眠(D)/IO 卡死状态，SIGKILL 可能无效，需先排查挂载/磁盘/驱动或重启系统".to_string());
+            }
+        }
     }
-    
+
     // 最终检查
     if is_antigravity_running() {
         return Err("无法关闭 Antigravity 进程，请手动关闭后重试".to_string());
@@ -295,10 +524,13 @@ pub fn start_antigravity() -> Result<(), String> {
             .args(["-a", "Antigravity"])
             .output()
             .map_err(|e| format!("无法执行 open 命令: {}", e))?;
-            
+
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("启动失败 (open exited with {}): {}", output.status, error));
+            return Err(format!(
+                "启动失败 (open exited with {}): {}",
+                output.status, error
+            ));
         }
     }
 
@@ -308,7 +540,7 @@ pub fn start_antigravity() -> Result<(), String> {
         let result = Command::new("cmd")
             .args(["/C", "start", "antigravity://"])
             .spawn();
-        
+
         if result.is_err() {
             return Err("启动失败，请手动打开 Antigravity".to_string());
         }
@@ -326,7 +558,7 @@ pub fn start_antigravity() -> Result<(), String> {
 }
 
 /// 获取 Antigravity 可执行文件路径（跨平台）
-/// 
+///
 /// 查找策略（优先级从高到低）：
 /// 1. 从运行中的进程获取路径（最可靠，支持任意安装位置）
 /// 2. 遍历标准安装位置
@@ -336,48 +568,23 @@ pub fn get_antigravity_executable_path() -> Option<std::path::PathBuf> {
     if let Some(path) = get_path_from_running_process() {
         return Some(path);
     }
-    
+
     // 策略2: 检查标准安装位置
     check_standard_locations()
 }
 
 /// 从运行中的进程获取 Antigravity 可执行文件路径
-/// 
+///
 /// 这是最可靠的方法，可以找到任意位置的安装
 fn get_path_from_running_process() -> Option<std::path::PathBuf> {
     let mut system = System::new_all();
     system.refresh_all();
-    
+
     for process in system.processes().values() {
-        #[allow(unused_variables)]
-        let name = process.name().to_string_lossy().to_lowercase();
-        
         // 获取可执行文件路径
         if let Some(exe) = process.exe() {
-            let exe_path = exe.to_str().unwrap_or("").to_lowercase();
-            
-            #[cfg(target_os = "macos")]
-            {
-                // macOS: 检查 Antigravity.app
-                if exe_path.contains("antigravity.app") {
-                    return Some(exe.to_path_buf());
-                }
-            }
-            
-            #[cfg(target_os = "windows")]
-            {
-                // Windows: 严格匹配进程名
-                if name == "antigravity.exe" {
-                    return Some(exe.to_path_buf());
-                }
-            }
-            
-            #[cfg(target_os = "linux")]
-            {
-                // Linux: 检查进程名或路径包含 antigravity
-                if name.contains("antigravity") || exe_path.contains("antigravity") {
-                    return Some(exe.to_path_buf());
-                }
+            if is_antigravity_process(process) {
+                return Some(exe.to_path_buf());
             }
         }
     }
@@ -393,44 +600,44 @@ fn check_standard_locations() -> Option<std::path::PathBuf> {
             return Some(path);
         }
     }
-    
+
     #[cfg(target_os = "windows")]
     {
         use std::env;
-        
+
         // 获取环境变量
         let local_appdata = env::var("LOCALAPPDATA").ok();
-        let program_files = env::var("ProgramFiles")
-            .unwrap_or_else(|_| "C:\\Program Files".to_string());
-        let program_files_x86 = env::var("ProgramFiles(x86)")
-            .unwrap_or_else(|_| "C:\\Program Files (x86)".to_string());
-        
+        let program_files =
+            env::var("ProgramFiles").unwrap_or_else(|_| "C:\\Program Files".to_string());
+        let program_files_x86 =
+            env::var("ProgramFiles(x86)").unwrap_or_else(|_| "C:\\Program Files (x86)".to_string());
+
         let mut possible_paths = Vec::new();
-        
+
         // 用户安装位置（优先）
         if let Some(local) = local_appdata {
             possible_paths.push(
                 std::path::PathBuf::from(&local)
                     .join("Programs")
                     .join("Antigravity")
-                    .join("Antigravity.exe")
+                    .join("Antigravity.exe"),
             );
         }
-        
+
         // 系统安装位置
         possible_paths.push(
             std::path::PathBuf::from(&program_files)
                 .join("Antigravity")
-                .join("Antigravity.exe")
+                .join("Antigravity.exe"),
         );
-        
+
         // 32位兼容位置
         possible_paths.push(
             std::path::PathBuf::from(&program_files_x86)
                 .join("Antigravity")
-                .join("Antigravity.exe")
+                .join("Antigravity.exe"),
         );
-        
+
         // 返回第一个存在的路径
         for path in possible_paths {
             if path.exists() {
@@ -438,7 +645,7 @@ fn check_standard_locations() -> Option<std::path::PathBuf> {
             }
         }
     }
-    
+
     #[cfg(target_os = "linux")]
     {
         let possible_paths = vec![
@@ -446,7 +653,7 @@ fn check_standard_locations() -> Option<std::path::PathBuf> {
             std::path::PathBuf::from("/opt/Antigravity/antigravity"),
             std::path::PathBuf::from("/usr/share/antigravity/antigravity"),
         ];
-        
+
         // 用户本地安装
         if let Some(home) = dirs::home_dir() {
             let user_local = home.join(".local/bin/antigravity");
@@ -454,13 +661,13 @@ fn check_standard_locations() -> Option<std::path::PathBuf> {
                 return Some(user_local);
             }
         }
-        
+
         for path in possible_paths {
             if path.exists() {
                 return Some(path);
             }
         }
     }
-    
+
     None
 }


### PR DESCRIPTION
  - 更稳健地识别 Antigravity 进程（基于 exe / cmd[0] 的 basename，而不是仅靠路径包含）
  - Linux：在“是否仍在运行 / PID 列表”判断中忽略僵尸进程（Zombie），避免卡死
  - Linux：只尝试结束当前进程有效用户（effective uid）拥有的 Antigravity 进程，避免 kill: 不允许的操作(EPERM)
  - 不再只杀第一个 PID：对所有匹配 PID 批量 SIGTERM/SIGKILL，并补充更清晰的诊断日志（残留状态分布/示例命令行等）