### PR TITLE
feat: add configurable LAN access toggle for proxy server

### DIFF
--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -71,8 +71,9 @@ pub async fn start_proxy_service(
     }
     
     // 启动 Axum 服务器
-    let (axum_server, server_handle) = 
+    let (axum_server, server_handle) =
         match crate::proxy::AxumServer::start(
+            config.get_bind_address().to_string(),
             config.port,
             token_manager.clone(),
             config.anthropic_mapping.clone(),
@@ -104,7 +105,7 @@ pub async fn start_proxy_service(
     Ok(ProxyStatus {
         running: true,
         port: config.port,
-        base_url: format!("http://localhost:{}", config.port),
+        base_url: format!("http://127.0.0.1:{}", config.port),
         active_accounts,
     })
 }
@@ -141,7 +142,7 @@ pub async fn get_proxy_status(
         Some(instance) => Ok(ProxyStatus {
             running: true,
             port: instance.config.port,
-            base_url: format!("http://localhost:{}", instance.config.port),
+            base_url: format!("http://127.0.0.1:{}", instance.config.port),
             active_accounts: instance.token_manager.len(),
         }),
         None => Ok(ProxyStatus {

--- a/src-tauri/src/proxy/config.rs
+++ b/src-tauri/src/proxy/config.rs
@@ -1,33 +1,39 @@
 use serde::{Deserialize, Serialize};
-// use std::path::PathBuf;
+use std::collections::HashMap;
 
 /// 反代服务配置
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProxyConfig {
     /// 是否启用反代服务
     pub enabled: bool,
-    
+
+    /// 是否允许局域网访问
+    /// - false: 仅本机访问 127.0.0.1（默认，隐私优先）
+    /// - true: 允许局域网访问 0.0.0.0
+    #[serde(default)]
+    pub allow_lan_access: bool,
+
     /// 监听端口
     pub port: u16,
-    
+
     /// API 密钥
     pub api_key: String,
-    
+
 
     /// 是否自动启动
     pub auto_start: bool,
 
     /// Anthropic 模型映射表 (key: Claude模型名, value: Gemini模型名)
     #[serde(default)]
-    pub anthropic_mapping: std::collections::HashMap<String, String>,
+    pub anthropic_mapping: HashMap<String, String>,
 
     /// OpenAI 模型映射表 (key: OpenAI模型组, value: Gemini模型名)
     #[serde(default)]
-    pub openai_mapping: std::collections::HashMap<String, String>,
+    pub openai_mapping: HashMap<String, String>,
 
     /// 自定义精确模型映射表 (key: 原始模型名, value: 目标模型名)
     #[serde(default)]
-    pub custom_mapping: std::collections::HashMap<String, String>,
+    pub custom_mapping: HashMap<String, String>,
 
     /// API 请求超时时间(秒)
     #[serde(default = "default_request_timeout")]
@@ -51,18 +57,32 @@ impl Default for ProxyConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            allow_lan_access: false, // 默认仅本机访问，隐私优先
             port: 8045,
             api_key: format!("sk-{}", uuid::Uuid::new_v4().simple()),
             auto_start: false,
-            anthropic_mapping: std::collections::HashMap::new(),
-            openai_mapping: std::collections::HashMap::new(),
-            custom_mapping: std::collections::HashMap::new(),
+            anthropic_mapping: HashMap::new(),
+            openai_mapping: HashMap::new(),
+            custom_mapping: HashMap::new(),
             request_timeout: default_request_timeout(),
             upstream_proxy: UpstreamProxyConfig::default(),
         }
     }
 }
 
+impl ProxyConfig {
+    /// 获取实际的监听地址
+    /// - allow_lan_access = false: 返回 "127.0.0.1"（默认，隐私优先）
+    /// - allow_lan_access = true: 返回 "0.0.0.0"（允许局域网访问）
+    pub fn get_bind_address(&self) -> &str {
+        if self.allow_lan_access {
+            "0.0.0.0"
+        } else {
+            "127.0.0.1"
+        }
+    }
+}
+
 fn default_request_timeout() -> u64 {
-    120  // 默认 120 秒,原来 60 秒太短
+    120
 }

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -61,6 +61,7 @@ impl AxumServer {
     }
     /// 启动 Axum 服务器
     pub async fn start(
+        host: String,
         port: u16,
         token_manager: Arc<TokenManager>,
         anthropic_mapping: std::collections::HashMap<String, String>,
@@ -111,10 +112,10 @@ impl AxumServer {
             .with_state(state);
         
         // 绑定地址
-        let addr = format!("127.0.0.1:{}", port);
+        let addr = format!("{}:{}", host, port);
         let listener = tokio::net::TcpListener::bind(&addr)
             .await
-            .map_err(|e| format!("端口 {} 绑定失败: {}", port, e))?;
+            .map_err(|e| format!("地址 {} 绑定失败: {}", addr, e))?;
         
         tracing::info!("反代服务器启动在 http://{}", addr);
         

--- a/src/pages/ApiProxy.tsx
+++ b/src/pages/ApiProxy.tsx
@@ -456,6 +456,43 @@ print(response.text)`;
                                 </div>
                             </div>
 
+                            {/* 局域网访问开关 */}
+                            <div className="border-t border-gray-200 dark:border-base-300 pt-3 mt-3">
+                                <label className="flex items-start gap-3 cursor-pointer">
+                                    <div className="relative flex-shrink-0 mt-0.5">
+                                        <input
+                                            type="checkbox"
+                                            className="sr-only"
+                                            checked={appConfig.proxy.allow_lan_access || false}
+                                            onChange={(e) => updateProxyConfig({ allow_lan_access: e.target.checked })}
+                                            disabled={status.running}
+                                        />
+                                        <div className={`block w-10 h-6 rounded-full transition-colors ${(appConfig.proxy.allow_lan_access || false) ? 'bg-blue-500' : 'bg-gray-300 dark:bg-base-300'}`}></div>
+                                        <div className={`dot absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition-transform ${(appConfig.proxy.allow_lan_access || false) ? 'transform translate-x-4' : ''}`}></div>
+                                    </div>
+                                    <div className="flex-1">
+                                        <span className="text-xs font-medium text-gray-900 dark:text-base-content">
+                                            允许局域网访问
+                                        </span>
+                                        <p className="mt-0.5 text-[10px] text-gray-500 dark:text-gray-400">
+                                            {(appConfig.proxy.allow_lan_access || false)
+                                                ? '🌐 监听 0.0.0.0，局域网设备可访问'
+                                                : '🔒 仅监听 127.0.0.1，仅本机可访问（隐私优先）'}
+                                        </p>
+                                        {(appConfig.proxy.allow_lan_access || false) && (
+                                            <p className="mt-1 text-[10px] text-amber-600 dark:text-amber-500">
+                                                ⚠️ 开启后局域网内其他设备可访问，请确保 API 密钥安全
+                                            </p>
+                                        )}
+                                        {status.running && (
+                                            <p className="mt-1 text-[10px] text-blue-600 dark:text-blue-400">
+                                                ℹ️ 需要重启服务后生效
+                                            </p>
+                                        )}
+                                    </div>
+                                </label>
+                            </div>
+
                             {/* API 密钥 */}
                             {/* API 密钥 */}
                             <div>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -5,6 +5,7 @@ export interface UpstreamProxyConfig {
 
 export interface ProxyConfig {
     enabled: boolean;
+    allow_lan_access?: boolean;
     port: number;
     api_key: string;
     auto_start: boolean;


### PR DESCRIPTION
Add privacy-first network binding control with optional LAN access:

Backend (Rust):
- Add `allow_lan_access` boolean field to ProxyConfig (defaults to false)
- Implement `get_bind_address()` method to return 127.0.0.1 or 0.0.0.0
- Update AxumServer::start() to accept dynamic host parameter
- Ensure base_url always returns 127.0.0.1 for client display

Frontend (TypeScript):
- Add `allow_lan_access` field to ProxyConfig interface
- Add LAN access toggle UI with security warnings
- Show contextual hints based on toggle state

Default behavior: binds to 127.0.0.1 (localhost-only, privacy-first)
When enabled: binds to 0.0.0.0 (allows LAN access)

![photo_2025-12-26_22-43-03](https://github.com/user-attachments/assets/a3e4da64-eca4-4c1b-911b-be61111c47b2)
