### PR TITLE
fix(ci): install create-dmg for macOS DMG bundling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install dependencies (macOS)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          brew install create-dmg
+
       - name: Install dependencies (Linux x86_64)
         if: matrix.platform == 'ubuntu-22.04' && matrix.args == ''
         run: |


### PR DESCRIPTION
## Summary

  修复 macOS 平台 Release 构建时因缺少 `create-dmg` 工具导致 DMG 打包失败的问题。

 ## Changes

  - 在 macOS 构建流程中添加 `brew install create-dmg` 步骤
  - 确保 DMG 文件能够正常生成

 ## Related Issue

  Fixes CI build failure on macOS platform.