### PR TITLE
Proxy 核心稳定性修复 (Proxy Core Stability Fixes)

### DIFF
--- a/src-tauri/src/proxy/common/json_schema.rs
+++ b/src-tauri/src/proxy/common/json_schema.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 /// 递归清理 JSON Schema 以符合 Gemini 接口要求
-/// 
+///
 /// 1. [New] 展开 $ref 和 $defs: 将引用替换为实际定义，解决 Gemini 不支持 $ref 的问题
 /// 2. 移除不支持的字段: $schema, additionalProperties, format, default, uniqueItems, validation fields
 /// 3. 处理联合类型: ["string", "null"] -> "string"
@@ -20,8 +20,8 @@ pub fn clean_json_schema(value: &mut Value) {
         }
 
         if !defs.is_empty() {
-             // 递归替换引用
-             flatten_refs(map, &defs);
+            // 递归替换引用
+            flatten_refs(map, &defs);
         }
     }
 
@@ -35,7 +35,7 @@ fn flatten_refs(map: &mut serde_json::Map<String, Value>, defs: &serde_json::Map
     if let Some(Value::String(ref_path)) = map.remove("$ref") {
         // 解析引用名 (例如 #/$defs/MyType -> MyType)
         let ref_name = ref_path.split('/').last().unwrap_or(&ref_path);
-        
+
         if let Some(def_schema) = defs.get(ref_name) {
             // 将定义的内容合并到当前 map
             if let Value::Object(def_map) = def_schema {
@@ -44,7 +44,7 @@ fn flatten_refs(map: &mut serde_json::Map<String, Value>, defs: &serde_json::Map
                     // 但通常 $ref 节点不应该有其他属性
                     map.entry(k.clone()).or_insert_with(|| v.clone());
                 }
-                
+
                 // 递归处理刚刚合并进来的内容中可能包含的 $ref
                 // 注意：这里可能会无限递归如果存在循环引用，但工具定义通常是 DAG
                 flatten_refs(map, defs);
@@ -59,7 +59,7 @@ fn flatten_refs(map: &mut serde_json::Map<String, Value>, defs: &serde_json::Map
         } else if let Value::Array(arr) = v {
             for item in arr {
                 if let Value::Object(item_map) = item {
-                   flatten_refs(item_map, defs);
+                    flatten_refs(item_map, defs);
                 }
             }
         }
@@ -77,14 +77,18 @@ fn clean_json_schema_recursive(value: &mut Value) {
 
             // 2. 收集并处理校验字段 (Migration logic: 将约束降级为描述中的 Hint)
             let mut constraints = Vec::new();
-            
+
             // 待迁移的约束黑名单
             let validation_fields = [
                 ("pattern", "pattern"),
-                ("minLength", "minLen"), ("maxLength", "maxLen"),
-                ("minimum", "min"), ("maximum", "max"),
-                ("minItems", "minItems"), ("maxItems", "maxItems"),
-                ("exclusiveMinimum", "exclMin"), ("exclusiveMaximum", "exclMax"),
+                ("minLength", "minLen"),
+                ("maxLength", "maxLen"),
+                ("minimum", "min"),
+                ("maximum", "max"),
+                ("minItems", "minItems"),
+                ("maxItems", "maxItems"),
+                ("exclusiveMinimum", "exclMin"),
+                ("exclusiveMaximum", "exclMax"),
                 ("multipleOf", "multipleOf"),
                 ("format", "format"),
             ];
@@ -101,7 +105,9 @@ fn clean_json_schema_recursive(value: &mut Value) {
             // 3. 将约束信息追加到描述
             if !constraints.is_empty() {
                 let suffix = format!(" [Constraint: {}]", constraints.join(", "));
-                let desc_val = map.entry("description".to_string()).or_insert_with(|| Value::String("".to_string()));
+                let desc_val = map
+                    .entry("description".to_string())
+                    .or_insert_with(|| Value::String("".to_string()));
                 if let Value::String(s) = desc_val {
                     s.push_str(&suffix);
                 }
@@ -118,13 +124,45 @@ fn clean_json_schema_recursive(value: &mut Value) {
                 "const",
                 "examples",
                 "propertyNames",
-                "anyOf", "oneOf", "allOf", "not",
-                "if", "then", "else",
-                "dependencies", "dependentSchemas", "dependentRequired",
+                "anyOf",
+                "oneOf",
+                "allOf",
+                "not",
+                "if",
+                "then",
+                "else",
+                "dependencies",
+                "dependentSchemas",
+                "dependentRequired",
                 "cache_control",
             ];
             for field in hard_remove_fields {
                 map.remove(field);
+            }
+
+            // [NEW FIX] 确保 required 中的字段一定在 properties 中存在
+            // Gemini 严格校验：required 中的字段如果不在 properties 中定义，会报 INVALID_ARGUMENT
+            // Refactored to avoid double borrow (mutable map vs immutable get("properties"))
+            let valid_prop_keys: Option<std::collections::HashSet<String>> = map
+                .get("properties")
+                .and_then(|p| p.as_object())
+                .map(|obj| obj.keys().cloned().collect());
+
+            if let Some(required_val) = map.get_mut("required") {
+                if let Some(req_arr) = required_val.as_array_mut() {
+                    if let Some(keys) = &valid_prop_keys {
+                        req_arr.retain(|k| {
+                            if let Some(k_str) = k.as_str() {
+                                keys.contains(k_str)
+                            } else {
+                                false
+                            }
+                        });
+                    } else {
+                        // 如果没有 properties，required 应该是空的
+                        req_arr.clear();
+                    }
+                }
             }
 
             // 5. 处理 type 字段 (Gemini 要求单字符串且小写)
@@ -134,7 +172,7 @@ fn clean_json_schema_recursive(value: &mut Value) {
                         *type_val = Value::String(s.to_lowercase());
                     }
                     Value::Array(arr) => {
-                        let mut selected_type = "string".to_string(); 
+                        let mut selected_type = "string".to_string();
                         for item in arr {
                             if let Value::String(s) = item {
                                 if s != "null" {
@@ -197,19 +235,29 @@ mod tests {
 
         // 2. 验证标准字段被转换并移动到描述 (Advanced Soft-Remove)
         assert!(schema["properties"]["location"].get("minLength").is_none());
-        assert!(schema["properties"]["location"]["description"].as_str().unwrap().contains("minLen: 1"));
+        assert!(schema["properties"]["location"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("minLen: 1"));
 
         // 3. 验证名为 "pattern" 的属性未被误删
         assert!(schema["properties"].get("pattern").is_some());
         assert_eq!(schema["properties"]["pattern"]["type"], "object");
 
         // 4. 验证内部的 pattern 校验字段被正确移除并转为描述
-        assert!(schema["properties"]["pattern"]["properties"]["regex"].get("pattern").is_none());
-        assert!(schema["properties"]["pattern"]["properties"]["regex"]["description"].as_str().unwrap().contains("pattern: ^[a-z]+$"));
+        assert!(schema["properties"]["pattern"]["properties"]["regex"]
+            .get("pattern")
+            .is_none());
+        assert!(
+            schema["properties"]["pattern"]["properties"]["regex"]["description"]
+                .as_str()
+                .unwrap()
+                .contains("pattern: ^[a-z]+$")
+        );
 
         // 5. 验证联合类型被降级为单一类型 (Protobuf 兼容性)
         assert_eq!(schema["properties"]["unit"]["type"], "string");
-        
+
         // 6. 验证元数据字段被移除
         assert!(schema.get("$schema").is_none());
     }
@@ -247,6 +295,27 @@ mod tests {
 
         // 验证引用被展开且类型转为小写
         assert_eq!(schema["properties"]["home"]["type"], "object");
-        assert_eq!(schema["properties"]["home"]["properties"]["city"]["type"], "string");
+        assert_eq!(
+            schema["properties"]["home"]["properties"]["city"]["type"],
+            "string"
+        );
+    }
+
+    #[test]
+    fn test_clean_json_schema_missing_required() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "existing_prop": { "type": "string" }
+            },
+            "required": ["existing_prop", "missing_prop"]
+        });
+
+        clean_json_schema(&mut schema);
+
+        // 验证 missing_prop 被从 required 中移除
+        let required = schema["required"].as_array().unwrap();
+        assert_eq!(required.len(), 1);
+        assert_eq!(required[0].as_str().unwrap(), "existing_prop");
     }
 }

--- a/src-tauri/src/proxy/mappers/openai/response.rs
+++ b/src-tauri/src/proxy/mappers/openai/response.rs
@@ -8,13 +8,14 @@ pub fn transform_openai_response(gemini_response: &Value) -> OpenAIResponse {
     // 提取 content 和 tool_calls
     let mut content_out = String::new();
     let mut tool_calls = Vec::new();
-    
-    if let Some(parts) = raw.get("candidates")
+
+    if let Some(parts) = raw
+        .get("candidates")
         .and_then(|c| c.get(0))
         .and_then(|cand| cand.get("content"))
         .and_then(|content| content.get("parts"))
-        .and_then(|p| p.as_array()) {
-            
+        .and_then(|p| p.as_array())
+    {
         for part in parts {
             /* 暂时禁用：思维链/推理部分 (Gemini 2.0+) 避免干扰 Codex CLI 等非推理客户端
             if let Some(thought) = part.get("thought").and_then(|t| t.as_str()) {
@@ -26,19 +27,33 @@ pub fn transform_openai_response(gemini_response: &Value) -> OpenAIResponse {
             }
             */
 
+            // 捕获 thoughtSignature (Gemini 3 工具调用必需)
+            if let Some(sig) = part
+                .get("thoughtSignature")
+                .or(part.get("thought_signature"))
+                .and_then(|s| s.as_str())
+            {
+                super::streaming::store_thought_signature(sig);
+            }
+
             // 文本部分
             if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
                 content_out.push_str(text);
             }
-            
+
             // 工具调用部分
             if let Some(fc) = part.get("functionCall") {
                 let name = fc.get("name").and_then(|v| v.as_str()).unwrap_or("unknown");
-                let args = fc.get("args").map(|v| v.to_string()).unwrap_or_else(|| "{}".to_string());
-                let id = fc.get("id").and_then(|v| v.as_str())
+                let args = fc
+                    .get("args")
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "{}".to_string());
+                let id = fc
+                    .get("id")
+                    .and_then(|v| v.as_str())
                     .map(|s| s.to_string())
                     .unwrap_or_else(|| format!("{}-{}", name, uuid::Uuid::new_v4()));
-                
+
                 tool_calls.push(ToolCall {
                     id,
                     r#type: "function".to_string(),
@@ -48,10 +63,13 @@ pub fn transform_openai_response(gemini_response: &Value) -> OpenAIResponse {
                     },
                 });
             }
-            
+
             // 图片处理
             if let Some(img) = part.get("inlineData") {
-                let mime_type = img.get("mimeType").and_then(|v| v.as_str()).unwrap_or("image/png");
+                let mime_type = img
+                    .get("mimeType")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("image/png");
                 let data = img.get("data").and_then(|v| v.as_str()).unwrap_or("");
                 if !data.is_empty() {
                     content_out.push_str(&format!("![image](data:{};base64,{})", mime_type, data));
@@ -61,12 +79,13 @@ pub fn transform_openai_response(gemini_response: &Value) -> OpenAIResponse {
     }
 
     // 提取并处理联网搜索引文 (Grounding Metadata)
-    if let Some(grounding) = raw.get("candidates")
+    if let Some(grounding) = raw
+        .get("candidates")
         .and_then(|c| c.get(0))
-        .and_then(|cand| cand.get("groundingMetadata")) {
-        
+        .and_then(|cand| cand.get("groundingMetadata"))
+    {
         let mut grounding_text = String::new();
-        
+
         // 1. 处理搜索词
         if let Some(queries) = grounding.get("webSearchQueries").and_then(|q| q.as_array()) {
             let query_list: Vec<&str> = queries.iter().filter_map(|v| v.as_str()).collect();
@@ -81,12 +100,15 @@ pub fn transform_openai_response(gemini_response: &Value) -> OpenAIResponse {
             let mut links = Vec::new();
             for (i, chunk) in chunks.iter().enumerate() {
                 if let Some(web) = chunk.get("web") {
-                    let title = web.get("title").and_then(|v| v.as_str()).unwrap_or("网页来源");
+                    let title = web
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("网页来源");
                     let uri = web.get("uri").and_then(|v| v.as_str()).unwrap_or("#");
                     links.push(format!("[{}] [{}]({})", i + 1, title, uri));
                 }
             }
-            
+
             if !links.is_empty() {
                 grounding_text.push_str("\n\n**🌐 来源引文：**\n");
                 grounding_text.push_str(&links.join("\n"));
@@ -114,16 +136,32 @@ pub fn transform_openai_response(gemini_response: &Value) -> OpenAIResponse {
         .unwrap_or("stop");
 
     OpenAIResponse {
-        id: raw.get("responseId").and_then(|v| v.as_str()).unwrap_or("resp_unknown").to_string(),
+        id: raw
+            .get("responseId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("resp_unknown")
+            .to_string(),
         object: "chat.completion".to_string(),
         created: chrono::Utc::now().timestamp() as u64,
-        model: raw.get("modelVersion").and_then(|v| v.as_str()).unwrap_or("unknown").to_string(),
+        model: raw
+            .get("modelVersion")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string(),
         choices: vec![Choice {
             index: 0,
             message: OpenAIMessage {
                 role: "assistant".to_string(),
-                content: if content_out.is_empty() { None } else { Some(OpenAIContent::String(content_out)) },
-                tool_calls: if tool_calls.is_empty() { None } else { Some(tool_calls) },
+                content: if content_out.is_empty() {
+                    None
+                } else {
+                    Some(OpenAIContent::String(content_out))
+                },
+                tool_calls: if tool_calls.is_empty() {
+                    None
+                } else {
+                    Some(tool_calls)
+                },
                 tool_call_id: None,
                 name: None,
             },
@@ -152,7 +190,7 @@ mod tests {
 
         let result = transform_openai_response(&gemini_resp);
         assert_eq!(result.object, "chat.completion");
-        
+
         let content = match result.choices[0].message.content.as_ref().unwrap() {
             OpenAIContent::String(s) => s,
             _ => panic!("Expected string content"),


### PR DESCRIPTION
摘要 (Summary)
This PR addresses critical stability issues when proxying Claude/Codex requests to Gemini models. It fixes INVALID_ARGUMENT errors caused by thinking configurations in background tasks, resolves "Missing Thought Signature" errors in tool calls, and hardens JSON schema validation. 本 PR 修复了将 Claude/Codex 请求代理至 Gemini 模型时的关键稳定性问题。包括：修复了后台任务因携带 Thinking 配置导致的 INVALID_ARGUMENT 错误，解决了工具调用中“思考签名丢失”的问题，并增强了 JSON Schema 的校验逻辑。

变更详情 (Changes)
1. 修复后台任务 400 错误 (Fix Background Task 400 Error)
Problem: Background tasks (e.g., summary generation) were failing with 400 INVALID_ARGUMENT because they carried thinkingConfig but were redirected to gemini-2.5-flash (which may not support thinking parameters).
Fix:
Updated 
handlers/claude.rs
 to detect background tasks.
Crucial: Stripped thinking configuration and filtered out ThinkingBlock from history messages to ensure compatibility.
Redirect to gemini-2.5-flash to align with user quota.
问题: 后台任务（如生成摘要）会报错 400，因为它们携带了 thinkingConfig 却被重定向到了可能不支持 Thinking 参数的 gemini-2.5-flash 模型。
修复:
在 
handlers/claude.rs
 中增加了后台任务检测。
关键: 强制移除请求中的 thinking 配置，并过滤掉历史消息中的思考内容块 (ThinkingBlock)，确保兼容性。
将模型重定向目标对齐为 gemini-2.5-flash。
2. 修复思考签名丢失 (Fix Missing Thought Signature)
Problem: Gemini rejected tool result submissions with Function call is missing a thought_signature because the proxy dropped the signature during the previous streaming response.
Fix:
Updated 
streaming.rs
 & 
response.rs
 to capture and store thoughtSignature from Gemini responses.
Updated 
request.rs
 to automatically inject the stored signature into subsequent tool output requests.
问题: Gemini 拒绝了工具执行结果的提交，报错“缺失思考签名”，原因是代理在上一轮流式响应中丢弃了该签名。
修复:
修改 
streaming.rs
 和 
response.rs
，从 Gemini 响应中捕获并存储 thoughtSignature。
修改 
request.rs
，在发送工具执行结果时，自动回填存储的签名。
3. JSON Schema 校验增强 (Harden JSON Schema Validation)
Problem: Requests failed with property is not defined when 
required
 fields in tool definitions did not exist in properties.
Fix: Validated 
required
 array in 
json_schema.rs
, removing any keys that are not present in properties.
问题: 当工具定义中的 
required
 字段包含不存在于 properties 中的属性时，请求会失败报错 property is not defined。
修复: 在 
json_schema.rs
 中增加了校验逻辑，自动剔除 
required
 数组中未在 properties 里定义的无效键值。