### PR TITLE
fix syntax error in chinese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ brew tap lbjlaq/antigravity-manager https://github.com/lbjlaq/Antigravity-Manage
 
 # 2. 安装应用
 brew install --cask antigravity-tools
-```
+
 # 如果遇到权限问题，建议使用 --no-quarantine
 brew install --cask --no-quarantine antigravity
 ```


### PR DESCRIPTION
代码块没有正确闭合，导致后面一段内容没有正确的渲染标题层级