### PR TITLE
Proxy: z.ai Anthropic passthrough + MCP endpoints

### DIFF
--- a/BRANCH-FROZEN-OUTDATED.md
+++ b/BRANCH-FROZEN-OUTDATED.md
@@ -1,0 +1,25 @@
+# FROZEN BRANCH - OUTDATED
+
+This branch is frozen as OUTDATED.
+Based on v2.0.0, main is now v3.5.0 (3+ versions ahead).
+
+Feature: z.ai Passthrough MCP Integration
+Status: OUTDATED - Functionality fully merged via other commits ⚠️
+Base Version: v2.0.0 (v3.3.8 in package.json)
+Main Version: v3.5.0
+
+## What was merged to main:
+- ✅ z.ai Anthropic provider (src-tauri/src/proxy/providers/zai_anthropic.rs)
+- ✅ z.ai Vision Tools (src-tauri/src/proxy/zai_vision_tools.rs)  
+- ✅ z.ai Web Tools (src-tauri/src/proxy/zai_web_tools.rs)
+- ✅ MCP handler with z.ai support (src-tauri/src/proxy/handlers/mcp.rs)
+- ✅ Model discovery and mapping for z.ai
+- ✅ Full z.ai documentation
+
+## Why not merged:
+52 files changed with massive divergence (v2.0.0 → v3.5.0).
+All functionality already implemented in main via newer commits.
+
+Do not make new commits to this branch.
+Use main branch for future development.
+See main commit history for z.ai implementation.


### PR DESCRIPTION
## English

### Summary
This PR extends the built-in API proxy with an optional **z.ai (GLM) upstream** for the **Claude/Anthropic protocol**, and exposes several **MCP endpoints** through the local proxy so client apps can use MCP without storing the upstream API key.

The proxy remains **multi-protocol** and can be used concurrently by multiple clients:
- Claude protocol (`/v1/messages`) can route to **z.ai** (configurable) or the existing Google-backed flow.
- Gemini protocol (`/v1beta/*`) and OpenAI-compatible routes (`/v1/*`) keep their existing behavior.

### Key features
- **z.ai provider (Anthropic-compatible passthrough)**
  - Config: `proxy.zai.*`
  - Dispatch modes: `off | exclusive | pooled | fallback`
  - Model rewriting for Claude-like model ids via `proxy.zai.models.*` and `proxy.zai.model_mapping`.
  - Routes affected: `POST /v1/messages`, `POST /v1/messages/count_tokens`.

- **MCP endpoints via local proxy** (optional toggles)
  - Global enable: `proxy.zai.mcp.enabled`
  - Per-server toggles:
    - `/mcp/web_search_prime/mcp` (reverse-proxy to z.ai MCP)
    - `/mcp/web_reader/mcp` (reverse-proxy to z.ai MCP, with optional URL normalization)
    - `/mcp/zread/mcp` (reverse-proxy to z.ai MCP)
    - `/mcp/zai-mcp-server/mcp` (built-in Vision MCP server)
  - The proxy injects upstream auth and forwards `mcp-session-id` response headers so Streamable HTTP MCP sessions work end-to-end.

- **Proxy authorization (global)**
  - Modes: `off | strict | all_except_health | auto`
  - When enabled, clients send `Authorization: Bearer <proxy.api_key>`.

- **Safe request access logging (optional)**
  - `proxy.access_log_enabled=true` logs method/path/status/latency only (no headers, bodies, or query strings).

- **Frontend error logging for troubleshooting**
  - Captures runtime UI errors (common “white screen” cases) and writes them into backend log files with best-effort redaction.

### Documentation
Developer docs are available in both English and Chinese:
- `docs/README.md`
- `docs/README.zh.md`

### Security notes
- No secrets are logged in access logs (no headers/bodies/queries).
- MCP upstream auth is injected by the proxy; MCP clients only authenticate to the local proxy (if proxy auth is enabled).

### Manual test checklist
1) Enable proxy auth (`strict` or `all_except_health`) and set `proxy.api_key`.
2) Configure z.ai (`proxy.zai.enabled=true`, set `proxy.zai.api_key`).
3) Set `proxy.zai.dispatch_mode=exclusive`, send `POST /v1/messages` and confirm it is served by z.ai.
4) Enable `proxy.zai.mcp.enabled` and the MCP toggles.
5) For each MCP endpoint:
   - `initialize` → read `mcp-session-id` → `tools/list` → `tools/call`.


---

## 中文

### 概述
该 PR 为内置 API Proxy 增加了可选的 **z.ai（GLM）上游**（仅作用于 **Claude/Anthropic 协议**），并通过本地代理暴露多个 **MCP 端点**，使客户端应用无需保存上游 API Key 即可使用 MCP。

该代理依然是 **多协议** 的，并支持多个客户端并发使用：
- Claude 协议（`/v1/messages`）可按配置路由到 **z.ai** 或沿用现有 Google 链路。
- Gemini（`/v1beta/*`）与 OpenAI 兼容路由（`/v1/*`）保持原有行为。

### 主要功能
- **z.ai provider（Anthropic 兼容 passthrough）**
  - 配置：`proxy.zai.*`
  - 分发模式：`off | exclusive | pooled | fallback`
  - 通过 `proxy.zai.models.*` 与 `proxy.zai.model_mapping` 支持 Claude-like model id → z.ai model id 的重写。
  - 影响路由：`POST /v1/messages`、`POST /v1/messages/count_tokens`。

- **通过本地代理暴露 MCP 端点**（可选开关）
  - 总开关：`proxy.zai.mcp.enabled`
  - 单项开关与端点：
    - `/mcp/web_search_prime/mcp`（反代到 z.ai MCP）
    - `/mcp/web_reader/mcp`（反代到 z.ai MCP，支持可选 URL 归一化）
    - `/mcp/zread/mcp`（反代到 z.ai MCP）
    - `/mcp/zai-mcp-server/mcp`（内置 Vision MCP server）
  - 代理注入上游鉴权，并转发 `mcp-session-id` 响应头，确保 Streamable HTTP MCP 会话可用。

- **代理全局鉴权**
  - 模式：`off | strict | all_except_health | auto`
  - 开启后客户端需发送：`Authorization: Bearer <proxy.api_key>`。

- **安全的访问日志（可选）**
  - `proxy.access_log_enabled=true` 仅记录 method/path/status/latency（不记录 header/body/query）。

- **前端错误日志（排障）**
  - 捕获 UI 运行时错误（常见“白屏”场景），并写入后端日志（带尽力脱敏）。

### 文档
开发者文档提供中英文版本：
- `docs/README.md`
- `docs/README.zh.md`

### 安全说明
- 访问日志不包含敏感信息（不记录 header/body/query）。
- MCP 上游鉴权由代理注入；MCP 客户端只需对本地代理鉴权（若开启）。

### 手工验证建议
1) 开启代理鉴权（`strict` 或 `all_except_health`）并设置 `proxy.api_key`。
2) 配置 z.ai（`proxy.zai.enabled=true`，设置 `proxy.zai.api_key`）。
3) 设置 `proxy.zai.dispatch_mode=exclusive`，发送 `POST /v1/messages` 并确认由 z.ai 响应。
4) 开启 `proxy.zai.mcp.enabled` 及各 MCP 单项开关。
5) 对每个 MCP 端点执行：`initialize` → 读取 `mcp-session-id` → `tools/list` → `tools/call`。
