### PR TITLE
fix(dashboard): exclude forbidden accounts from low quota statistics

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -45,6 +45,7 @@ function Dashboard() {
             .filter(q => q > 0);
 
         const lowQuotaCount = accounts.filter(a => {
+            if (a.quota?.is_forbidden) return false;
             const gemini = a.quota?.models.find(m => m.name.toLowerCase() === 'gemini-3-pro-high')?.percentage || 0;
             const claude = a.quota?.models.find(m => m.name.toLowerCase() === 'claude-sonnet-4-5')?.percentage || 0;
             return gemini < 20 || claude < 20;


### PR DESCRIPTION
## 1. Description
This PR fixes a logic issue in the Dashboard where accounts with `is_forbidden` status (403) were incorrectly counted as "Low Quota" accounts.

## 2. Motivation and Context
Currently, when an account is forbidden, its quota/percentage might default to 0. The existing filter `gemini < 20 || claude < 20` picks up these accounts, causing the "Low Quota" count to be inaccurate (false positives).

By excluding forbidden accounts, the dashboard reflects the true number of active accounts that need attention regarding their quota.

## 3. Changes
- Modified `src/pages/Dashboard.tsx`.
- Added a check `if (a.quota?.is_forbidden) return false;` inside the `lowQuotaCount` filter.

## 4. How Has This Been Tested?
- [x] Verified that accounts with `is_forbidden: true` are no longer included in the count.
- [x] Verified that normal accounts with low quota are still counted correctly.

## 5. Screenshots (Optional)
N/A (Logic change only)