### PR TITLE
feat: support OpenAI Structured Outputs (json_schema) for Gemini proxy

### DIFF
--- a/src-tauri/src/proxy/mappers/openai/models.rs
+++ b/src-tauri/src/proxy/mappers/openai/models.rs
@@ -33,6 +33,21 @@ pub struct OpenAIRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResponseFormat {
     pub r#type: String,
+    /// OpenAI Structured Outputs: json_schema field for type="json_schema"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_schema: Option<JsonSchemaFormat>,
+}
+
+/// OpenAI Structured Outputs json_schema format
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonSchemaFormat {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Problem

When using Antigravity as a proxy for applications that rely on OpenAI's Structured Outputs feature (like Honcho - https://github.com/plastic-labs/honcho), requests with `response_format.type = "json_schema"` fail because Gemini doesn't understand this format directly.

Honcho uses structured outputs for its "vllm" provider to extract user observations and build user representations. Without this feature, Honcho cannot use Gemini models through Antigravity for its deriver component.

## Solution

This PR adds automatic conversion from OpenAI's json_schema format to Gemini's native responseSchema:

1. Parse the `json_schema` field from OpenAI request's response_format
2. Clean the schema (remove unsupported fields like $schema, definitions)
3. Convert types to uppercase (OBJECT, STRING, etc.) as Gemini requires
4. Pass cleaned schema as Gemini's responseSchema parameter

## Example

OpenAI request:
{
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "name": "UserObservation",
      "schema": {"type": "object", "properties": {...}}
    }
  }
}

Gets converted to Gemini:
{
  "generationConfig": {
    "responseMimeType": "application/json",
    "responseSchema": {"type": "OBJECT", "properties": {...}}
  }
}

## Testing

Tested with Honcho v2 using vllm provider pointing to Antigravity -> Gemini 3 Pro. All components (deriver, peer_card, dialectic, summary) work correctly.