### PR TITLE
fix: align monitor middleware body limit with DefaultBodyLimit

### DIFF
--- a/src-tauri/src/proxy/middleware/monitor.rs
+++ b/src-tauri/src/proxy/middleware/monitor.rs
@@ -39,7 +39,7 @@ pub async fn monitor_middleware(
     let request_body_str;
     let request = if method == "POST" {
         let (parts, body) = request.into_parts();
-        match axum::body::to_bytes(body, 1024 * 1024).await {
+        match axum::body::to_bytes(body, 100 * 1024 * 1024).await {
             Ok(bytes) => {
                 if model.is_none() {
                     model = serde_json::from_slice::<Value>(&bytes).ok().and_then(|v|


### PR DESCRIPTION
## Problem
When using image generation models like `gemini-3-pro-image` with Cherry Studio and including a base64-encoded reference image, the request fails with:
```
Failed to parse the request body as JSON: EOF while parsing a value at line 1 column 0
```

## Cause

The [monitor_middleware](cci:1://file:///c:/Users/l/Desktop/Antigravity-Manager/src-tauri/src/proxy/middleware/monitor.rs:12:0-176:1) uses `axum::body::to_bytes(body, 1024 * 1024)` (1MB limit), while [server.rs](cci:7://file:///c:/Users/l/Desktop/Antigravity-Manager/src-tauri/src/proxy/server.rs:0:0-0:0) sets `DefaultBodyLimit::max(100 * 1024 * 1024)` (100MB).

When the request body exceeds 1MB, the monitor middleware fails to read it and replaces the body with `Body::empty()`, causing the downstream JSON parser to receive an empty body.

## Fix

Increase the monitor middleware body limit from 1MB to 100MB to match the global `DefaultBodyLimit` setting.

```diff
- match axum::body::to_bytes(body, 1024 * 1024).await {
+ match axum::body::to_bytes(body, 100 * 1024 * 1024).await {
```