### PR TITLE
docs(readme): fix duplicated codeblock ending markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ brew tap lbjlaq/antigravity-manager https://github.com/lbjlaq/Antigravity-Manage
 
 # 2. 安装应用
 brew install --cask antigravity-tools
-```
+
 # 如果遇到权限问题，建议使用 --no-quarantine
 brew install --cask --no-quarantine antigravity-tools
 ```


### PR DESCRIPTION
中文 readme 多输入了一组 ```` ``` ```` 导致代码块提前终止并影响后续，如图所示：

<img width="1040" height="784" alt="image" src="https://github.com/user-attachments/assets/f06ce644-7b73-4ef3-bd22-fb48e3aedd3a" />

英文 readme 没有这个问题。此 PR 修复后如图所示：

<img width="1036" height="786" alt="image" src="https://github.com/user-attachments/assets/0acdc438-d7ae-4ec0-b29a-ef76e2054b4e" />
