### PR TITLE
feat: add standalone web server mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ src-tauri/.env
 .env
 .env.*
 environment/
+build/

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,228 @@
+# Antigravity Manager - 服务器部署教程
+
+本指南介绍如何在服务器上部署 Antigravity Manager 的 Web 服务端版本。
+
+## 🔧 系统要求
+
+- **操作系统**: Linux (Ubuntu 20.04+, Debian 11+, CentOS 8+)
+- **内存**: 512MB+
+- **磁盘**: 100MB+
+- **网络**: 服务器需要能访问 Google API
+
+## 📦 安装步骤
+
+### 1. 安装依赖
+
+```bash
+# Ubuntu/Debian
+sudo apt update
+sudo apt install -y curl build-essential pkg-config libssl-dev
+
+# CentOS/RHEL
+sudo yum groupinstall -y "Development Tools"
+sudo yum install -y openssl-devel
+```
+
+### 2. 安装 Rust
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+```
+
+### 3. 安装 Node.js (用于构建前端)
+
+```bash
+# 使用 nvm 安装 (推荐)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+source ~/.bashrc
+nvm install 20
+nvm use 20
+```
+
+### 4. 克隆代码库
+
+```bash
+git clone <your-repo-url> antigravity-manager
+cd antigravity-manager
+```
+
+### 5. 构建前端
+
+```bash
+npm install
+npm run build
+```
+
+### 6. 构建后端
+
+```bash
+cd src-tauri
+cargo build --release --bin antigravity-server --no-default-features --features web-server
+```
+
+## 🚀 启动服务
+
+### 基本启动
+
+```bash
+cd src-tauri
+./target/release/antigravity-server \
+    --port 8765 \
+    --static-dir ../dist \
+    --data-dir ~/.antigravity
+```
+
+### 命令行参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `-p, --port` | 8765 | API 服务端口 |
+| `-h, --host` | 0.0.0.0 | 绑定地址 |
+| `-s, --static-dir` | ./dist | 前端静态文件目录 |
+| `-d, --data-dir` | ~/.antigravity | 数据存储目录 |
+
+### 后台运行 (推荐)
+
+使用 `nohup`:
+```bash
+cd /path/to/antigravity-manager/src-tauri
+nohup ./target/release/antigravity-server \
+    --port 8765 \
+    --static-dir ../dist \
+    --data-dir ~/.antigravity \
+    > /var/log/antigravity.log 2>&1 &
+```
+
+使用 `systemd` (推荐生产环境):
+```bash
+# 创建 systemd 服务文件
+sudo tee /etc/systemd/system/antigravity.service << 'EOF'
+[Unit]
+Description=Antigravity Manager Web Server
+After=network.target
+
+[Service]
+Type=simple
+User=your-username
+WorkingDirectory=/path/to/antigravity-manager/src-tauri
+ExecStart=/path/to/antigravity-manager/src-tauri/target/release/antigravity-server \
+    --port 8765 \
+    --static-dir /path/to/antigravity-manager/dist \
+    --data-dir /home/your-username/.antigravity
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# 启用并启动服务
+sudo systemctl daemon-reload
+sudo systemctl enable antigravity
+sudo systemctl start antigravity
+
+# 查看状态
+sudo systemctl status antigravity
+```
+
+## 🌐 访问服务
+
+浏览器访问: `http://<服务器IP>:8765`
+
+## 🔑 添加账号 (OAuth 登录)
+
+由于服务在远程，OAuth 回调无法自动处理，请使用以下方法：
+
+### 方法一：手动粘贴回调 URL（推荐）
+
+1. 打开 `http://<服务器IP>:8765`
+2. 点击"添加账号" → OAuth 标签页
+3. 点击"开始 OAuth" 并复制 OAuth 链接
+4. 在本地浏览器打开该链接，完成 Google 认证
+5. 认证后浏览器会跳转到 `http://localhost:9004/callback?code=xxx`
+6. **页面会显示"无法访问"，这是正常的**
+7. 复制地址栏中的完整 URL
+8. 回到服务器页面，在 OAuth 界面底部的输入框粘贴该 URL
+9. 点击"确认"完成登录
+
+### 方法二：使用 Refresh Token
+
+1. 通过其他方式获取 Google Refresh Token
+2. 在"添加账号" → Token 标签页粘贴
+
+## 🔒 安全建议
+
+### 配置反向代理 (Nginx)
+
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # SSE 支持
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+    }
+}
+```
+
+### 添加 HTTPS (Let's Encrypt)
+
+```bash
+sudo apt install certbot python3-certbot-nginx
+sudo certbot --nginx -d your-domain.com
+```
+
+### 防火墙配置
+
+```bash
+# 仅开放必要端口
+sudo ufw allow 22/tcp    # SSH
+sudo ufw allow 80/tcp    # HTTP
+sudo ufw allow 443/tcp   # HTTPS
+sudo ufw enable
+```
+
+## 📋 常见问题
+
+### Q: 构建时报错 "openssl not found"
+```bash
+sudo apt install libssl-dev  # Debian/Ubuntu
+sudo yum install openssl-devel  # CentOS
+```
+
+### Q: 启动时报错 "Address already in use"
+```bash
+# 检查端口占用
+lsof -i :8765
+# 或更换端口
+./target/release/antigravity-server --port 9000 ...
+```
+
+### Q: OAuth 登录失败
+确保：
+1. 服务器能访问 Google API (`curl https://oauth2.googleapis.com`)
+2. 正确复制了完整的回调 URL（包含 `?code=...`）
+
+## 🔄 更新部署
+
+```bash
+cd antigravity-manager
+git pull
+npm install && npm run build
+cd src-tauri
+cargo build --release --bin antigravity-server --no-default-features --features web-server
+sudo systemctl restart antigravity  # 如果使用 systemd
+```

--- a/README.md
+++ b/README.md
@@ -137,6 +137,48 @@ brew install --cask --no-quarantine antigravity-tools
     brew install --cask --no-quarantine antigravity-tools
     ```
 
+### 选项 C: Web Server 模式部署 (Linux 服务器)
+
+除了桌面应用，本项目还支持**独立 Web 服务端**模式，可部署到远程服务器通过浏览器访问。
+
+#### 快速部署（本地编译后上传）
+
+```bash
+# 1. 本地打包（生成约 7MB 压缩包）
+./package-server.sh
+
+# 2. 上传到服务器
+scp build/antigravity-server-*.tar.gz user@server:/tmp/
+
+# 3. 服务器端解压并启动
+ssh user@server
+cd /tmp && tar -xzf antigravity-server-*.tar.gz
+sudo mv antigravity-server-* /opt/antigravity
+/opt/antigravity/start.sh
+```
+
+#### 服务器端编译
+
+```bash
+# 安装依赖 (Ubuntu/Debian)
+sudo apt install -y curl build-essential pkg-config libssl-dev
+
+# 安装 Rust & Node.js
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+
+# 构建
+npm install && npm run build
+cd src-tauri
+cargo build --release --bin antigravity-server --no-default-features --features web-server
+
+# 启动
+./target/release/antigravity-server --port 8765 --static-dir ../dist --data-dir ~/.antigravity
+```
+
+> 📖 详细部署文档请参考 [DEPLOYMENT.md](./DEPLOYMENT.md)
+
+
 ## 🔌 快速接入示例
 
 ### 🔐 OAuth 授权流程（添加账号）

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "antigravity-tools",
-  "version": "3.3.11",
+  "version": "3.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "antigravity-tools",
-      "version": "3.3.11",
+      "version": "3.3.15",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package-server.sh
+++ b/package-server.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Antigravity Manager 打包脚本
+# 用于创建可直接部署到服务器的压缩包
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION=$(grep '"version"' "$SCRIPT_DIR/package.json" | head -1 | sed 's/.*: "\(.*\)".*/\1/')
+PACKAGE_NAME="antigravity-server-${VERSION}-linux-amd64"
+BUILD_DIR="$SCRIPT_DIR/build/$PACKAGE_NAME"
+
+echo "📦 打包 Antigravity Manager v${VERSION}..."
+
+# 1. 构建前端
+echo "🔨 构建前端..."
+cd "$SCRIPT_DIR"
+npm run build
+
+# 2. 构建后端
+echo "🔨 构建后端..."
+cd "$SCRIPT_DIR/src-tauri"
+cargo build --release --bin antigravity-server --no-default-features --features web-server
+
+# 3. 创建打包目录
+echo "📁 创建部署包..."
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+# 复制文件
+cp target/release/antigravity-server "$BUILD_DIR/"
+cp -r ../dist "$BUILD_DIR/"
+cp ../DEPLOYMENT.md "$BUILD_DIR/README.md"
+
+# 创建启动脚本
+cat > "$BUILD_DIR/start.sh" << 'EOF'
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+./antigravity-server --port 8765 --static-dir ./dist --data-dir ~/.antigravity "$@"
+EOF
+chmod +x "$BUILD_DIR/start.sh"
+
+# 创建 systemd 服务模板
+cat > "$BUILD_DIR/antigravity.service" << 'EOF'
+[Unit]
+Description=Antigravity Manager Web Server
+After=network.target
+
+[Service]
+Type=simple
+User=REPLACE_WITH_YOUR_USERNAME
+WorkingDirectory=/opt/antigravity
+ExecStart=/opt/antigravity/antigravity-server --port 8765 --static-dir /opt/antigravity/dist --data-dir /home/REPLACE_WITH_YOUR_USERNAME/.antigravity
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# 4. 创建压缩包
+echo "📦 压缩..."
+cd "$SCRIPT_DIR/build"
+tar -czvf "${PACKAGE_NAME}.tar.gz" "$PACKAGE_NAME"
+
+echo ""
+echo "✅ 打包完成！"
+echo "📦 文件位置: $SCRIPT_DIR/build/${PACKAGE_NAME}.tar.gz"
+echo ""
+echo "📋 部署步骤:"
+echo "  1. scp build/${PACKAGE_NAME}.tar.gz user@server:/tmp/"
+echo "  2. ssh user@server"
+echo "  3. cd /tmp && tar -xzf ${PACKAGE_NAME}.tar.gz"
+echo "  4. sudo mv ${PACKAGE_NAME} /opt/antigravity"
+echo "  5. /opt/antigravity/start.sh"
+echo ""
+echo "或使用 systemd:"
+echo "  sudo cp /opt/antigravity/antigravity.service /etc/systemd/system/"
+echo "  sudo sed -i 's/REPLACE_WITH_YOUR_USERNAME/your-user/g' /etc/systemd/system/antigravity.service"
+echo "  sudo systemctl daemon-reload"
+echo "  sudo systemctl enable --now antigravity"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2059,6 +2059,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,6 +2754,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -5597,10 +5613,18 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5802,6 +5826,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,12 +15,39 @@ edition = "2021"
 name = "antigravity_tools_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+# 独立 Web 服务端入口
+[[bin]]
+name = "antigravity-server"
+path = "src/bin/main_server.rs"
+
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "2", features = [], optional = true }
+
+[features]
+default = ["tauri-app"]
+# Tauri 桌面应用模式
+tauri-app = [
+    "dep:tauri",
+    "dep:tauri-plugin-opener",
+    "dep:tauri-plugin-dialog",
+    "dep:tauri-plugin-fs",
+    "dep:tauri-plugin-single-instance",
+    "dep:tauri-plugin-autostart",
+    "dep:tauri-build",
+]
+# 独立 Web 服务端模式
+web-server = []
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "image-png"] }
-tauri-plugin-opener = "2"
+# Tauri 相关 (可选)
+tauri = { version = "2", features = ["tray-icon", "image-png"], optional = true }
+tauri-plugin-opener = { version = "2", optional = true }
+tauri-plugin-dialog = { version = "2.4.2", optional = true }
+tauri-plugin-fs = { version = "2.4.4", optional = true }
+tauri-plugin-single-instance = { version = "2.3.6", features = ["deep-link"], optional = true }
+tauri-plugin-autostart = { version = "2.5.1", optional = true }
+
+# 核心依赖 (共享)
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1.10", features = ["v4", "serde"] }
@@ -34,8 +61,6 @@ base64 = "0.22"
 sysinfo = "0.31"
 tokio = { version = "1", features = ["full"] }
 url = "2.5.7"
-tauri-plugin-dialog = "2.4.2"
-tauri-plugin-fs = "2.4.4"
 image = "0.25.9"
 thiserror = "2.0.17"
 
@@ -46,7 +71,7 @@ tokio-stream = { version = "0.1.17", features = ["sync"] }
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 tower = "0.4"
-tower-http = { version = "0.5", features = ["cors", "trace"] }
+tower-http = { version = "0.5", features = ["cors", "trace", "fs"] }
 eventsource-stream = "0.2"
 dashmap = "6.1"
 anyhow = "1.0"
@@ -57,8 +82,7 @@ regex = "1.12.2"                    # Duration 解析
 once_cell = "1.19"                  # 静态初始化 (模型映射表)
 pin-project = "1.1"                 # Pin 投影辅助
 bytes = "1.5"                       # SSE 字节操作
-tauri-plugin-single-instance = { version = "2.3.6", features = ["deep-link"] }
 tracing-appender = "0.2.4"
 tracing-log = "0.2.0"
-tauri-plugin-autostart = "2.5.1"
 sha2 = "0.10"
+

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,4 @@
 fn main() {
-    tauri_build::build()
+    #[cfg(feature = "tauri-app")]
+    tauri_build::build();
 }

--- a/src-tauri/src/bin/main_server.rs
+++ b/src-tauri/src/bin/main_server.rs
@@ -1,0 +1,185 @@
+//! Antigravity Manager - 独立 Web 服务端入口
+//!
+//! 用法:
+//!   antigravity-server [OPTIONS]
+//!
+//! OPTIONS:
+//!   --port <PORT>           API 服务端口 (默认: 8765)
+//!   --static-dir <PATH>     前端静态文件目录 (默认: ./dist)
+//!   --data-dir <PATH>       数据目录 (默认: ~/.antigravity)
+//!   --host <HOST>           绑定地址 (默认: 0.0.0.0)
+
+use axum::{
+    http::{header, Method, StatusCode},
+    response::IntoResponse,
+    Router,
+};
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower_http::{
+    cors::{Any, CorsLayer},
+    services::ServeDir,
+    trace::TraceLayer,
+};
+use tracing::{info, error};
+
+// 导入库中的模块
+use antigravity_tools_lib::modules::logger;
+use antigravity_tools_lib::web_api::{create_api_router, WebApiState};
+
+/// 命令行参数
+struct Args {
+    port: u16,
+    host: String,
+    static_dir: PathBuf,
+    data_dir: Option<PathBuf>,
+}
+
+impl Args {
+    fn parse() -> Self {
+        let mut args = std::env::args().skip(1);
+        let mut port = 8765u16;
+        let mut host = "0.0.0.0".to_string();
+        let mut static_dir = PathBuf::from("./dist");
+        let mut data_dir: Option<PathBuf> = None;
+
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--port" | "-p" => {
+                    if let Some(val) = args.next() {
+                        port = val.parse().unwrap_or(8765);
+                    }
+                }
+                "--host" | "-h" => {
+                    if let Some(val) = args.next() {
+                        host = val;
+                    }
+                }
+                "--static-dir" | "-s" => {
+                    if let Some(val) = args.next() {
+                        static_dir = PathBuf::from(val);
+                    }
+                }
+                "--data-dir" | "-d" => {
+                    if let Some(val) = args.next() {
+                        data_dir = Some(PathBuf::from(val));
+                    }
+                }
+                "--help" => {
+                    print_help();
+                    std::process::exit(0);
+                }
+                _ => {}
+            }
+        }
+
+        Self {
+            port,
+            host,
+            static_dir,
+            data_dir,
+        }
+    }
+}
+
+fn print_help() {
+    println!(
+        r#"Antigravity Manager - Web Server Mode
+
+用法:
+  antigravity-server [OPTIONS]
+
+OPTIONS:
+  -p, --port <PORT>         API 服务端口 (默认: 8765)
+  -h, --host <HOST>         绑定地址 (默认: 0.0.0.0)
+  -s, --static-dir <PATH>   前端静态文件目录 (默认: ./dist)
+  -d, --data-dir <PATH>     数据目录 (默认: ~/.antigravity)
+      --help                显示帮助信息
+
+示例:
+  antigravity-server --port 8080 --static-dir ./web
+  antigravity-server -p 9000 -d /data/antigravity
+"#
+    );
+}
+
+#[tokio::main]
+async fn main() {
+    // 解析命令行参数
+    let args = Args::parse();
+
+    // 设置数据目录环境变量 (如果指定)
+    if let Some(ref data_dir) = args.data_dir {
+        std::env::set_var("ANTIGRAVITY_DATA_DIR", data_dir);
+    }
+
+    // 初始化日志
+    logger::init_logger();
+
+    info!("Antigravity Manager Web Server starting...");
+    info!("  Port: {}", args.port);
+    info!("  Host: {}", args.host);
+    info!("  Static dir: {:?}", args.static_dir);
+    if let Some(ref data_dir) = args.data_dir {
+        info!("  Data dir: {:?}", data_dir);
+    }
+
+    // 创建共享状态
+    let state = Arc::new(WebApiState::new());
+
+    // 创建 API 路由
+    let api_router = create_api_router(state.clone());
+
+    // 创建 CORS 配置
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
+
+    // 创建 fallback 用于 SPA 路由
+    let static_dir_clone = args.static_dir.clone();
+    let index_path = args.static_dir.join("index.html");
+    let fallback = move || {
+        let index_path = index_path.clone();
+        async move {
+            match tokio::fs::read_to_string(&index_path).await {
+                Ok(content) => axum::response::Html(content).into_response(),
+                Err(_) => StatusCode::NOT_FOUND.into_response(),
+            }
+        }
+    };
+
+    // 组合路由
+    let app = Router::new()
+        .merge(api_router)
+        .fallback_service(
+            ServeDir::new(&static_dir_clone)
+                .append_index_html_on_directories(true)
+                .fallback(axum::routing::get(fallback)),
+        )
+        .layer(cors)
+        .layer(TraceLayer::new_for_http());
+
+
+    // 启动服务器
+    let addr: SocketAddr = format!("{}:{}", args.host, args.port)
+        .parse()
+        .expect("Invalid address");
+
+    info!("Server listening on http://{}", addr);
+    info!("Open http://localhost:{} in your browser", args.port);
+
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    
+    axum::serve(listener, app)
+        .await
+        .expect("Server error");
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -12,6 +12,7 @@ pub enum AppError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
+    #[cfg(feature = "tauri-app")]
     #[error("Tauri error: {0}")]
     Tauri(#[from] tauri::Error),
 
@@ -40,3 +41,4 @@ impl Serialize for AppError {
 
 // 为 Result 实现别名，简化使用
 pub type AppResult<T> = Result<T, AppError>;
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,20 +1,31 @@
-mod models;
-mod modules;
-mod commands;
-mod utils;
-mod proxy;  // 反代服务模块
+// 核心模块 (共享)
+pub mod models;
+pub mod modules;
+pub mod utils;
+pub mod proxy;  // 反代服务模块
 pub mod error;
 
+// Tauri 命令模块 (仅 Tauri 模式编译)
+#[cfg(feature = "tauri-app")]
+pub mod commands;
+
+// Web API 模块 (共享)
+pub mod web_api;
+
+#[cfg(feature = "tauri-app")]
 use tauri::Manager;
 use modules::logger;
+#[cfg(feature = "tauri-app")]
 use tracing::{info, error};
 
 // 测试命令
+#[cfg(feature = "tauri-app")]
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+#[cfg(feature = "tauri-app")]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // 初始化日志
@@ -133,3 +144,4 @@ pub fn run() {
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
+

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -5,8 +5,10 @@ pub mod logger;
 pub mod db;
 pub mod process;
 pub mod oauth;
+#[cfg(feature = "tauri-app")]
 pub mod oauth_server;
 pub mod migration;
+#[cfg(feature = "tauri-app")]
 pub mod tray;
 pub mod i18n;
 pub mod proxy_db;
@@ -24,3 +26,4 @@ pub use logger::*;
 pub async fn fetch_quota(access_token: &str, email: &str) -> crate::error::AppResult<(models::QuotaData, Option<String>)> {
     quota::fetch_quota(access_token, email).await
 }
+

--- a/src-tauri/src/modules/oauth_server.rs
+++ b/src-tauri/src/modules/oauth_server.rs
@@ -1,3 +1,10 @@
+//! OAuth server functionality (Tauri desktop app only)
+//! 
+//! This module provides OAuth callback server for desktop app.
+//! In web mode, users should use refresh token instead.
+
+#![cfg(feature = "tauri-app")]
+
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -5,6 +12,7 @@ use tokio::sync::watch;
 use std::sync::{Mutex, OnceLock};
 use tauri::Url;
 use crate::modules::oauth;
+
 
 struct OAuthFlowState {
     auth_url: String,

--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -1,3 +1,7 @@
+//! System tray functionality (Tauri desktop app only)
+
+#![cfg(feature = "tauri-app")]
+
 use tauri::{
     image::Image,
     menu::{Menu, MenuItem, PredefinedMenuItem},
@@ -5,6 +9,7 @@ use tauri::{
     Manager, Runtime, Emitter, Listener,
 };
 use crate::modules;
+
 
 pub fn create_tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
     // 1. 加载配置获取语言设置

--- a/src-tauri/src/proxy/monitor.rs
+++ b/src-tauri/src/proxy/monitor.rs
@@ -1,6 +1,7 @@
 use serde::{Serialize, Deserialize};
 use std::collections::VecDeque;
 use tokio::sync::RwLock;
+#[cfg(feature = "tauri-app")]
 use tauri::Emitter;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -32,10 +33,15 @@ pub struct ProxyMonitor {
     pub stats: RwLock<ProxyStats>,
     pub max_logs: usize,
     pub enabled: AtomicBool,
+    #[cfg(feature = "tauri-app")]
     app_handle: Option<tauri::AppHandle>,
+    /// SSE broadcast sender for web mode
+    #[cfg(not(feature = "tauri-app"))]
+    _phantom: std::marker::PhantomData<()>,
 }
 
 impl ProxyMonitor {
+    #[cfg(feature = "tauri-app")]
     pub fn new(max_logs: usize, app_handle: Option<tauri::AppHandle>) -> Self {
         // Initialize DB
         if let Err(e) = crate::modules::proxy_db::init_db() {
@@ -46,10 +52,27 @@ impl ProxyMonitor {
             logs: RwLock::new(VecDeque::with_capacity(max_logs)),
             stats: RwLock::new(ProxyStats::default()),
             max_logs,
-            enabled: AtomicBool::new(false), // Default to disabled
+            enabled: AtomicBool::new(false),
             app_handle,
         }
     }
+
+    #[cfg(not(feature = "tauri-app"))]
+    pub fn new(max_logs: usize, _app_handle: Option<()>) -> Self {
+        // Initialize DB
+        if let Err(e) = crate::modules::proxy_db::init_db() {
+            tracing::error!("Failed to initialize proxy DB: {}", e);
+        }
+
+        Self {
+            logs: RwLock::new(VecDeque::with_capacity(max_logs)),
+            stats: RwLock::new(ProxyStats::default()),
+            max_logs,
+            enabled: AtomicBool::new(false),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
 
     pub fn set_enabled(&self, enabled: bool) {
         self.enabled.store(enabled, Ordering::Relaxed);
@@ -92,11 +115,13 @@ impl ProxyMonitor {
             }
         });
 
-        // Emit event
+        // Emit event (Tauri only)
+        #[cfg(feature = "tauri-app")]
         if let Some(app) = &self.app_handle {
              let _ = app.emit("proxy://request", &log);
         }
     }
+
 
     pub async fn get_logs(&self, limit: usize) -> Vec<ProxyRequestLog> {
         // Try to get from DB first for true history

--- a/src-tauri/src/web_api.rs
+++ b/src-tauri/src/web_api.rs
@@ -1,0 +1,1240 @@
+//! Web API 层 - 将 Tauri 命令封装为 HTTP REST API
+//! 
+//! 此模块提供独立运行的 Web 服务端 API，复用现有业务逻辑。
+
+use axum::{
+    extract::{Path, Query, State, rejection::JsonRejection, FromRequest, Request},
+    http::StatusCode,
+    response::{IntoResponse, Response, Json, Sse},
+    routing::{delete, get, post, put},
+    Router,
+};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use futures::stream::Stream;
+use std::convert::Infallible;
+use std::time::Duration;
+
+
+use crate::models::{Account, AppConfig, QuotaData};
+use crate::modules;
+use crate::proxy::{ProxyConfig, TokenManager};
+use crate::proxy::monitor::{ProxyMonitor, ProxyRequestLog, ProxyStats};
+
+// ============================================================================
+// 共享状态
+// ============================================================================
+
+/// Web API 共享状态
+pub struct WebApiState {
+    /// 反代服务实例
+    pub proxy_instance: Arc<RwLock<Option<ProxyServiceInstance>>>,
+    /// 监控器
+    pub monitor: Arc<RwLock<Option<Arc<ProxyMonitor>>>>,
+    /// SSE 广播通道
+    pub sse_tx: tokio::sync::broadcast::Sender<SseEvent>,
+}
+
+/// 反代服务实例 (复用自 commands/proxy.rs)
+pub struct ProxyServiceInstance {
+    pub config: ProxyConfig,
+    pub token_manager: Arc<TokenManager>,
+    pub axum_server: crate::proxy::AxumServer,
+    pub server_handle: tokio::task::JoinHandle<()>,
+}
+
+/// SSE 事件类型
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type", content = "data")]
+pub enum SseEvent {
+    ProxyRequest(ProxyRequestLog),
+    ConfigUpdated,
+    AccountSwitched,
+}
+
+impl WebApiState {
+    pub fn new() -> Self {
+        let (sse_tx, _) = tokio::sync::broadcast::channel(256);
+        Self {
+            proxy_instance: Arc::new(RwLock::new(None)),
+            monitor: Arc::new(RwLock::new(None)),
+            sse_tx,
+        }
+    }
+}
+
+// ============================================================================
+// API 响应类型
+// ============================================================================
+
+#[derive(Serialize)]
+struct ApiResponse<T> {
+    success: bool,
+    data: Option<T>,
+    error: Option<String>,
+}
+
+impl<T: Serialize> ApiResponse<T> {
+    fn ok(data: T) -> Json<Self> {
+        Json(Self {
+            success: true,
+            data: Some(data),
+            error: None,
+        })
+    }
+
+    fn err(error: impl ToString) -> Json<Self> {
+        Json(Self {
+            success: false,
+            data: None,
+            error: Some(error.to_string()),
+        })
+    }
+}
+
+// ============================================================================
+// 自定义 JSON 提取器 (返回 JSON 格式错误而非纯文本)
+// ============================================================================
+
+
+/// 自定义 JSON 提取器，确保反序列化错误也返回 JSON 格式
+pub struct AppJson<T>(pub T);
+
+#[axum::async_trait]
+impl<S, T> FromRequest<S> for AppJson<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        match axum::extract::Json::<T>::from_request(req, state).await {
+            Ok(Json(value)) => Ok(AppJson(value)),
+            Err(rejection) => {
+                let error_message = match &rejection {
+                    JsonRejection::JsonDataError(e) => format!("JSON 解析错误: {}", e),
+                    JsonRejection::JsonSyntaxError(e) => format!("JSON 语法错误: {}", e),
+                    JsonRejection::MissingJsonContentType(e) => format!("缺少 Content-Type: {}", e),
+                    _ => format!("请求体错误: {}", rejection),
+                };
+                
+                let body = serde_json::json!({
+                    "success": false,
+                    "data": null,
+                    "error": error_message
+                });
+                
+                Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(body),
+                ).into_response())
+            }
+        }
+    }
+}
+
+// ============================================================================
+// 路由构建
+// ============================================================================
+
+
+/// 创建 Web API 路由
+pub fn create_api_router(state: Arc<WebApiState>) -> Router {
+    Router::new()
+        // 账号管理
+        .route("/api/accounts", get(list_accounts))
+        .route("/api/accounts", post(add_account))
+        .route("/api/accounts/current", get(get_current_account))
+        .route("/api/accounts/:id", delete(delete_account))
+        .route("/api/accounts/batch-delete", post(delete_accounts))
+        .route("/api/accounts/:id/switch", post(switch_account))
+        .route("/api/accounts/:id/quota", post(fetch_account_quota))
+        .route("/api/accounts/refresh-all", post(refresh_all_quotas))
+        .route("/api/accounts/reorder", post(reorder_accounts))
+        .route("/api/accounts/:id/proxy-status", post(toggle_proxy_status))
+        // 配置
+        .route("/api/config", get(load_config))
+        .route("/api/config", put(save_config))
+        // 反代服务
+        .route("/api/proxy/start", post(start_proxy_service))
+        .route("/api/proxy/stop", post(stop_proxy_service))
+        .route("/api/proxy/status", get(get_proxy_status))
+        .route("/api/proxy/stats", get(get_proxy_stats))
+        .route("/api/proxy/logs", get(get_proxy_logs))
+        .route("/api/proxy/logs", delete(clear_proxy_logs))
+        .route("/api/proxy/monitor", post(set_proxy_monitor_enabled))
+        .route("/api/proxy/reload-accounts", post(reload_proxy_accounts))
+        .route("/api/proxy/model-mapping", put(update_model_mapping))
+        .route("/api/proxy/scheduling", get(get_proxy_scheduling_config))
+        .route("/api/proxy/scheduling", put(update_proxy_scheduling_config))
+        .route("/api/proxy/sessions", delete(clear_proxy_session_bindings))
+        .route("/api/proxy/zai-models", post(fetch_zai_models))
+        .route("/api/proxy/generate-api-key", post(generate_api_key))
+        // OAuth (Web 模式简化版)
+        .route("/api/oauth/prepare-url", post(prepare_oauth_url))
+        .route("/api/oauth/process-callback", post(process_oauth_callback))
+        // 导入
+
+        .route("/api/import/v1", post(import_v1_accounts))
+        .route("/api/import/db", post(import_from_db))
+        .route("/api/import/custom-db", post(import_custom_db))
+        .route("/api/sync/db", post(sync_account_from_db))
+        // 系统
+        .route("/api/system/data-dir", get(get_data_dir_path))
+        .route("/api/system/check-updates", get(check_for_updates))
+        .route("/api/system/clear-logs", post(clear_log_cache))
+        // SSE 事件流
+        .route("/api/events", get(sse_handler))
+        // 健康检查
+        .route("/api/health", get(health_check))
+        .with_state(state)
+}
+
+// ============================================================================
+// 账号管理 API
+// ============================================================================
+
+async fn list_accounts(
+    State(_state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    match modules::list_accounts() {
+        Ok(accounts) => ApiResponse::ok(accounts),
+        Err(e) => ApiResponse::<Vec<Account>>::err(e),
+    }
+}
+
+#[derive(Deserialize)]
+struct AddAccountRequest {
+    email: String,
+    refresh_token: String,
+}
+
+async fn add_account(
+    State(state): State<Arc<WebApiState>>,
+    AppJson(req): AppJson<AddAccountRequest>,
+) -> impl IntoResponse {
+    // 复用 commands/mod.rs 中的逻辑
+    let result = async {
+        // 1. 使用 refresh_token 获取 access_token
+        let token_res = modules::oauth::refresh_access_token(&req.refresh_token).await?;
+
+        // 2. 获取用户信息
+        let user_info = modules::oauth::get_user_info(&token_res.access_token).await?;
+
+        // 3. 构造 TokenData
+        let token = crate::models::TokenData::new(
+            token_res.access_token,
+            req.refresh_token,
+            token_res.expires_in,
+            Some(user_info.email.clone()),
+            None,
+            None,
+        );
+
+        // 4. 添加或更新账号
+        let account = modules::upsert_account(
+            user_info.email.clone(),
+            user_info.get_display_name(),
+            token,
+        )?;
+
+        modules::logger::log_info(&format!("添加账号成功: {}", account.email));
+
+        // 5. 如果反代服务正在运行，重新加载账号池
+        reload_proxy_accounts_internal(&state).await;
+
+        Ok::<_, String>(account)
+    }
+    .await;
+
+    match result {
+        Ok(account) => ApiResponse::ok(account),
+        Err(e) => ApiResponse::<Account>::err(e),
+    }
+}
+
+async fn get_current_account(
+    State(_state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    let result = || -> Result<Option<Account>, String> {
+        let account_id = modules::get_current_account_id()?;
+        if let Some(id) = account_id {
+            modules::load_account(&id).map(Some)
+        } else {
+            Ok(None)
+        }
+    };
+
+    match result() {
+        Ok(account) => ApiResponse::ok(account),
+        Err(e) => ApiResponse::<Option<Account>>::err(e),
+    }
+}
+
+async fn delete_account(
+    State(state): State<Arc<WebApiState>>,
+    Path(account_id): Path<String>,
+) -> impl IntoResponse {
+    match modules::delete_account(&account_id) {
+        Ok(()) => {
+            reload_proxy_accounts_internal(&state).await;
+            ApiResponse::ok(())
+        }
+        Err(e) => ApiResponse::<()>::err(e),
+    }
+}
+
+#[derive(Deserialize)]
+struct DeleteAccountsRequest {
+    account_ids: Vec<String>,
+}
+
+async fn delete_accounts(
+    State(state): State<Arc<WebApiState>>,
+    AppJson(req): AppJson<DeleteAccountsRequest>,
+) -> impl IntoResponse {
+    match modules::account::delete_accounts(&req.account_ids) {
+        Ok(()) => {
+            reload_proxy_accounts_internal(&state).await;
+            ApiResponse::ok(())
+        }
+        Err(e) => ApiResponse::<()>::err(e),
+    }
+}
+
+async fn switch_account(
+    State(state): State<Arc<WebApiState>>,
+    Path(account_id): Path<String>,
+) -> impl IntoResponse {
+    match modules::switch_account(&account_id).await {
+        Ok(()) => {
+            // 广播账号切换事件
+            let _ = state.sse_tx.send(SseEvent::AccountSwitched);
+            ApiResponse::ok(())
+        }
+        Err(e) => ApiResponse::<()>::err(e),
+    }
+}
+
+async fn fetch_account_quota(
+    State(_state): State<Arc<WebApiState>>,
+    Path(account_id): Path<String>,
+) -> impl IntoResponse {
+    let result = async {
+        let mut account = modules::load_account(&account_id)?;
+        let quota = modules::account::fetch_quota_with_retry(&mut account)
+            .await
+            .map_err(|e| e.to_string())?;
+        modules::update_account_quota(&account_id, quota.clone())?;
+        Ok::<_, String>(quota)
+    }
+    .await;
+
+    match result {
+        Ok(quota) => ApiResponse::ok(quota),
+        Err(e) => ApiResponse::<QuotaData>::err(e),
+    }
+}
+
+#[derive(Serialize)]
+struct RefreshStats {
+    total: usize,
+    success: usize,
+    failed: usize,
+    details: Vec<String>,
+}
+
+async fn refresh_all_quotas(
+    State(_state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    let result = async {
+        let accounts = modules::list_accounts()?;
+        let mut success = 0;
+        let mut failed = 0;
+        let mut details = Vec::new();
+
+        for mut account in accounts {
+            if account.disabled {
+                continue;
+            }
+            if let Some(ref q) = account.quota {
+                if q.is_forbidden {
+                    continue;
+                }
+            }
+
+            match modules::account::fetch_quota_with_retry(&mut account).await {
+                Ok(quota) => {
+                    if modules::update_account_quota(&account.id, quota).is_ok() {
+                        success += 1;
+                    } else {
+                        failed += 1;
+                    }
+                }
+                Err(e) => {
+                    failed += 1;
+                    details.push(format!("{}: {}", account.email, e));
+                }
+            }
+        }
+
+        Ok::<_, String>(RefreshStats {
+            total: success + failed,
+            success,
+            failed,
+            details,
+        })
+    }
+    .await;
+
+    match result {
+        Ok(stats) => ApiResponse::ok(stats),
+        Err(e) => ApiResponse::<RefreshStats>::err(e),
+    }
+}
+
+#[derive(Deserialize)]
+struct ReorderRequest {
+    account_ids: Vec<String>,
+}
+
+async fn reorder_accounts(
+    State(_state): State<Arc<WebApiState>>,
+    AppJson(req): AppJson<ReorderRequest>,
+) -> impl IntoResponse {
+    match modules::account::reorder_accounts(&req.account_ids) {
+        Ok(()) => ApiResponse::ok(()),
+        Err(e) => ApiResponse::<()>::err(e),
+    }
+}
+
+#[derive(Deserialize)]
+struct ToggleProxyStatusRequest {
+    enable: bool,
+    reason: Option<String>,
+}
+
+async fn toggle_proxy_status(
+    State(state): State<Arc<WebApiState>>,
+    Path(account_id): Path<String>,
+    AppJson(req): AppJson<ToggleProxyStatusRequest>,
+) -> impl IntoResponse {
+    // 简化版：直接修改账号文件
+    let result = || -> Result<(), String> {
+        let data_dir = modules::account::get_data_dir()?;
+        let account_path = data_dir.join("accounts").join(format!("{}.json", account_id));
+
+        if !account_path.exists() {
+            return Err(format!("账号文件不存在: {}", account_id));
+        }
+
+        let content = std::fs::read_to_string(&account_path)
+            .map_err(|e| format!("读取账号文件失败: {}", e))?;
+
+        let mut account_json: serde_json::Value = serde_json::from_str(&content)
+            .map_err(|e| format!("解析账号文件失败: {}", e))?;
+
+        if req.enable {
+            account_json["proxy_disabled"] = serde_json::Value::Bool(false);
+            account_json["proxy_disabled_reason"] = serde_json::Value::Null;
+            account_json["proxy_disabled_at"] = serde_json::Value::Null;
+        } else {
+            let now = chrono::Utc::now().timestamp();
+            account_json["proxy_disabled"] = serde_json::Value::Bool(true);
+            account_json["proxy_disabled_at"] = serde_json::Value::Number(now.into());
+            account_json["proxy_disabled_reason"] = serde_json::Value::String(
+                req.reason.unwrap_or_else(|| "用户手动禁用".to_string()),
+            );
+        }
+
+        std::fs::write(&account_path, serde_json::to_string_pretty(&account_json).unwrap())
+            .map_err(|e| format!("写入账号文件失败: {}", e))?;
+
+        Ok(())
+    };
+
+    match result() {
+        Ok(()) => {
+            reload_proxy_accounts_internal(&state).await;
+            ApiResponse::ok(())
+        }
+        Err(e) => ApiResponse::<()>::err(e),
+    }
+}
+
+// ============================================================================
+// 配置 API
+// ============================================================================
+
+async fn load_config(
+    State(_state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    match modules::load_app_config() {
+        Ok(config) => ApiResponse::ok(config),
+        Err(e) => ApiResponse::<AppConfig>::err(e),
+    }
+}
+
+async fn save_config(
+    State(state): State<Arc<WebApiState>>,
+    AppJson(config): AppJson<AppConfig>,
+) -> impl IntoResponse {
+    match modules::save_app_config(&config) {
+        Ok(()) => {
+            // 广播配置更新事件
+            let _ = state.sse_tx.send(SseEvent::ConfigUpdated);
+
+            // 热更新正在运行的反代服务
+            let instance_lock = state.proxy_instance.read().await;
+            if let Some(instance) = instance_lock.as_ref() {
+                instance.axum_server.update_mapping(&config.proxy).await;
+                instance
+                    .axum_server
+                    .update_proxy(config.proxy.upstream_proxy.clone())
+                    .await;
+                instance.axum_server.update_security(&config.proxy).await;
+                instance.axum_server.update_zai(&config.proxy).await;
+            }
+
+            ApiResponse::ok(())
+        }
+        Err(e) => ApiResponse::<()>::err(e),
+    }
+}
+
+// ============================================================================
+// 反代服务 API
+// ============================================================================
+
+#[derive(Serialize)]
+struct ProxyStatus {
+    running: bool,
+    port: u16,
+    base_url: String,
+    active_accounts: usize,
+}
+
+async fn start_proxy_service(
+    State(state): State<Arc<WebApiState>>,
+    AppJson(config): AppJson<ProxyConfig>,
+) -> impl IntoResponse {
+    let mut instance_lock = state.proxy_instance.write().await;
+
+    if instance_lock.is_some() {
+        return ApiResponse::<ProxyStatus>::err("服务已在运行中");
+    }
+
+    // 确保 monitor 存在
+    {
+        let mut monitor_lock = state.monitor.write().await;
+        if monitor_lock.is_none() {
+            // Web 模式下创建不带 app_handle 的 monitor
+            *monitor_lock = Some(Arc::new(ProxyMonitor::new(1000, None)));
+        }
+        if let Some(monitor) = monitor_lock.as_ref() {
+            monitor.set_enabled(config.enable_logging);
+        }
+    }
+
+    let monitor = state.monitor.read().await.as_ref().unwrap().clone();
+
+    // 初始化 Token 管理器
+    let app_data_dir = match modules::account::get_data_dir() {
+        Ok(dir) => dir,
+        Err(e) => return ApiResponse::<ProxyStatus>::err(e),
+    };
+    let _ = modules::account::get_accounts_dir();
+
+    let token_manager = Arc::new(TokenManager::new(app_data_dir.clone()));
+    token_manager
+        .update_sticky_config(config.scheduling.clone())
+        .await;
+
+    // 加载账号
+    let active_accounts = match token_manager.load_accounts().await {
+        Ok(count) => count,
+        Err(e) => return ApiResponse::<ProxyStatus>::err(format!("加载账号失败: {}", e)),
+    };
+
+    if active_accounts == 0 {
+        let zai_enabled = config.zai.enabled
+            && !matches!(
+                config.zai.dispatch_mode,
+                crate::proxy::ZaiDispatchMode::Off
+            );
+        if !zai_enabled {
+            return ApiResponse::<ProxyStatus>::err("没有可用账号，请先添加账号");
+        }
+    }
+
+    // 启动 Axum 服务器
+    let result = crate::proxy::AxumServer::start(
+        config.get_bind_address().to_string(),
+        config.port,
+        token_manager.clone(),
+        config.anthropic_mapping.clone(),
+        config.openai_mapping.clone(),
+        config.custom_mapping.clone(),
+        config.request_timeout,
+        config.upstream_proxy.clone(),
+        crate::proxy::ProxySecurityConfig::from_proxy_config(&config),
+        config.zai.clone(),
+        monitor.clone(),
+    )
+    .await;
+
+    match result {
+        Ok((axum_server, server_handle)) => {
+            let instance = ProxyServiceInstance {
+                config: config.clone(),
+                token_manager,
+                axum_server,
+                server_handle,
+            };
+
+            *instance_lock = Some(instance);
+
+            // 保存配置
+            if let Ok(mut app_config) = modules::config::load_app_config() {
+                app_config.proxy = config.clone();
+                let _ = modules::config::save_app_config(&app_config);
+            }
+
+            ApiResponse::ok(ProxyStatus {
+                running: true,
+                port: config.port,
+                base_url: format!("http://127.0.0.1:{}", config.port),
+                active_accounts,
+            })
+        }
+        Err(e) => ApiResponse::<ProxyStatus>::err(format!("启动服务器失败: {}", e)),
+    }
+}
+
+async fn stop_proxy_service(
+    State(state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    let mut instance_lock = state.proxy_instance.write().await;
+
+    if instance_lock.is_none() {
+        return ApiResponse::<()>::err("服务未运行");
+    }
+
+    if let Some(instance) = instance_lock.take() {
+        instance.axum_server.stop();
+        instance.server_handle.await.ok();
+    }
+
+    ApiResponse::ok(())
+}
+
+async fn get_proxy_status(
+    State(state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    let instance_lock = state.proxy_instance.read().await;
+
+    match instance_lock.as_ref() {
+        Some(instance) => ApiResponse::ok(ProxyStatus {
+            running: true,
+            port: instance.config.port,
+            base_url: format!("http://127.0.0.1:{}", instance.config.port),
+            active_accounts: instance.token_manager.len(),
+        }),
+        None => ApiResponse::ok(ProxyStatus {
+            running: false,
+            port: 0,
+            base_url: String::new(),
+            active_accounts: 0,
+        }),
+    }
+}
+
+async fn get_proxy_stats(
+    State(state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    let monitor_lock = state.monitor.read().await;
+    if let Some(monitor) = monitor_lock.as_ref() {
+        ApiResponse::ok(monitor.get_stats().await)
+    } else {
+        ApiResponse::ok(ProxyStats::default())
+    }
+}
+
+#[derive(Deserialize)]
+struct LogsQuery {
+    limit: Option<usize>,
+}
+
+async fn get_proxy_logs(
+    State(state): State<Arc<WebApiState>>,
+    Query(query): Query<LogsQuery>,
+) -> impl IntoResponse {
+    let monitor_lock = state.monitor.read().await;
+    if let Some(monitor) = monitor_lock.as_ref() {
+        ApiResponse::ok(monitor.get_logs(query.limit.unwrap_or(100)).await)
+    } else {
+        ApiResponse::ok(Vec::<ProxyRequestLog>::new())
+    }
+}
+
+async fn clear_proxy_logs(
+    State(state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    let monitor_lock = state.monitor.read().await;
+    if let Some(monitor) = monitor_lock.as_ref() {
+        monitor.clear().await;
+    }
+    ApiResponse::ok(())
+}
+
+#[derive(Deserialize)]
+struct SetMonitorRequest {
+    enabled: bool,
+}
+
+async fn set_proxy_monitor_enabled(
+    State(state): State<Arc<WebApiState>>,
+    AppJson(req): AppJson<SetMonitorRequest>,
+) -> impl IntoResponse {
+    let monitor_lock = state.monitor.read().await;
+    if let Some(monitor) = monitor_lock.as_ref() {
+        monitor.set_enabled(req.enabled);
+    }
+    ApiResponse::ok(())
+}
+
+async fn reload_proxy_accounts(
+    State(state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    let instance_lock = state.proxy_instance.read().await;
+
+    if let Some(instance) = instance_lock.as_ref() {
+        match instance.token_manager.load_accounts().await {
+            Ok(count) => ApiResponse::ok(count),
+            Err(e) => ApiResponse::<usize>::err(format!("重新加载账号失败: {}", e)),
+        }
+    } else {
+        ApiResponse::<usize>::err("服务未运行")
+    }
+}
+
+/// 内部辅助函数：重新加载账号池
+async fn reload_proxy_accounts_internal(state: &WebApiState) {
+    let instance_lock = state.proxy_instance.read().await;
+    if let Some(instance) = instance_lock.as_ref() {
+        let _ = instance.token_manager.load_accounts().await;
+    }
+}
+
+async fn update_model_mapping(
+    State(state): State<Arc<WebApiState>>,
+    AppJson(config): AppJson<ProxyConfig>,
+) -> impl IntoResponse {
+    let instance_lock = state.proxy_instance.read().await;
+    if let Some(instance) = instance_lock.as_ref() {
+        instance.axum_server.update_mapping(&config).await;
+    }
+
+    // 保存到配置
+    if let Ok(mut app_config) = modules::config::load_app_config() {
+        app_config.proxy.anthropic_mapping = config.anthropic_mapping;
+        app_config.proxy.openai_mapping = config.openai_mapping;
+        app_config.proxy.custom_mapping = config.custom_mapping;
+        let _ = modules::config::save_app_config(&app_config);
+    }
+
+    ApiResponse::ok(())
+}
+
+async fn get_proxy_scheduling_config(
+    State(state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    let instance_lock = state.proxy_instance.read().await;
+    if let Some(instance) = instance_lock.as_ref() {
+        ApiResponse::ok(instance.token_manager.get_sticky_config().await)
+    } else {
+        ApiResponse::ok(crate::proxy::sticky_config::StickySessionConfig::default())
+    }
+}
+
+async fn update_proxy_scheduling_config(
+    State(state): State<Arc<WebApiState>>,
+    AppJson(config): AppJson<crate::proxy::sticky_config::StickySessionConfig>,
+) -> impl IntoResponse {
+    let instance_lock = state.proxy_instance.read().await;
+    if let Some(instance) = instance_lock.as_ref() {
+        instance.token_manager.update_sticky_config(config).await;
+        ApiResponse::ok(())
+    } else {
+        ApiResponse::<()>::err("服务未运行")
+    }
+}
+
+async fn clear_proxy_session_bindings(
+    State(state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    let instance_lock = state.proxy_instance.read().await;
+    if let Some(instance) = instance_lock.as_ref() {
+        instance.token_manager.clear_all_sessions();
+        ApiResponse::ok(())
+    } else {
+        ApiResponse::<()>::err("服务未运行")
+    }
+}
+
+#[derive(Deserialize)]
+struct FetchZaiModelsRequest {
+    zai: crate::proxy::ZaiConfig,
+    upstream_proxy: crate::proxy::config::UpstreamProxyConfig,
+    request_timeout: u64,
+}
+
+// Helper functions for fetch_zai_models (inlined from commands/proxy.rs)
+fn join_base_url(base: &str, path: &str) -> String {
+    let base = base.trim_end_matches('/');
+    let path = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{}", path)
+    };
+    format!("{}{}", base, path)
+}
+
+fn extract_model_ids(value: &serde_json::Value) -> Vec<String> {
+    let mut out = Vec::new();
+
+    fn push_from_item(out: &mut Vec<String>, item: &serde_json::Value) {
+        match item {
+            serde_json::Value::String(s) => out.push(s.to_string()),
+            serde_json::Value::Object(map) => {
+                if let Some(id) = map.get("id").and_then(|v| v.as_str()) {
+                    out.push(id.to_string());
+                } else if let Some(name) = map.get("name").and_then(|v| v.as_str()) {
+                    out.push(name.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    match value {
+        serde_json::Value::Array(arr) => {
+            for item in arr {
+                push_from_item(&mut out, item);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            if let Some(data) = map.get("data") {
+                if let serde_json::Value::Array(arr) = data {
+                    for item in arr {
+                        push_from_item(&mut out, item);
+                    }
+                }
+            }
+            if let Some(models) = map.get("models") {
+                match models {
+                    serde_json::Value::Array(arr) => {
+                        for item in arr {
+                            push_from_item(&mut out, item);
+                        }
+                    }
+                    other => push_from_item(&mut out, other),
+                }
+            }
+        }
+        _ => {}
+    }
+
+    out
+}
+
+async fn fetch_zai_models(
+    State(_state): State<Arc<WebApiState>>,
+    AppJson(req): AppJson<FetchZaiModelsRequest>,
+) -> impl IntoResponse {
+    let result = async {
+        if req.zai.base_url.trim().is_empty() {
+            return Err("z.ai base_url is empty".to_string());
+        }
+        if req.zai.api_key.trim().is_empty() {
+            return Err("z.ai api_key is not set".to_string());
+        }
+
+        let url = join_base_url(&req.zai.base_url, "/v1/models");
+
+        let mut builder = reqwest::Client::builder()
+            .timeout(Duration::from_secs(req.request_timeout.max(5)));
+        if req.upstream_proxy.enabled && !req.upstream_proxy.url.is_empty() {
+            let proxy = reqwest::Proxy::all(&req.upstream_proxy.url)
+                .map_err(|e| format!("Invalid upstream proxy url: {}", e))?;
+            builder = builder.proxy(proxy);
+        }
+        let client = builder
+            .build()
+            .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
+
+        let resp = client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", req.zai.api_key))
+            .header("x-api-key", &req.zai.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| format!("Upstream request failed: {}", e))?;
+
+        let status = resp.status();
+        let text = resp.text().await.map_err(|e| format!("Failed to read response: {}", e))?;
+
+        if !status.is_success() {
+            let preview = if text.len() > 4000 { &text[..4000] } else { &text };
+            return Err(format!("Upstream returned {}: {}", status, preview));
+        }
+
+        let json: serde_json::Value =
+            serde_json::from_str(&text).map_err(|e| format!("Invalid JSON response: {}", e))?;
+        let mut models = extract_model_ids(&json);
+        models.retain(|s| !s.trim().is_empty());
+        models.sort();
+        models.dedup();
+        Ok(models)
+    }
+    .await;
+
+    match result {
+        Ok(models) => ApiResponse::ok(models),
+        Err(e) => ApiResponse::<Vec<String>>::err(e),
+    }
+}
+
+
+async fn generate_api_key(
+    State(_state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    ApiResponse::ok(format!("sk-{}", uuid::Uuid::new_v4().simple()))
+}
+
+// ============================================================================
+// OAuth API (简化版)
+// ============================================================================
+
+/// OAuth URL 响应
+#[derive(Serialize)]
+struct OAuthUrlResponse {
+    url: String,
+    redirect_uri: String,
+}
+
+async fn prepare_oauth_url(
+    State(_state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    // Web 模式下返回 OAuth URL，由用户手动在浏览器中打开
+    // 使用固定的 redirect_uri (用户需要手动复制回调 URL)
+    let redirect_uri = "http://localhost:9004/callback".to_string();
+    let url = modules::oauth::get_auth_url(&redirect_uri);
+    
+    ApiResponse::ok(OAuthUrlResponse {
+        url,
+        redirect_uri,
+    })
+}
+
+/// 处理手动粘贴的 OAuth 回调 URL
+#[derive(Deserialize)]
+struct ProcessCallbackRequest {
+    callback_url: String,
+}
+
+async fn process_oauth_callback(
+    State(state): State<Arc<WebApiState>>,
+    AppJson(req): AppJson<ProcessCallbackRequest>,
+) -> impl IntoResponse {
+    let result = async {
+        // 1. 解析回调 URL 中的 code 参数
+        let url = url::Url::parse(&req.callback_url)
+            .map_err(|e| format!("无效的回调 URL: {}", e))?;
+        
+        let code = url.query_pairs()
+            .find(|(k, _)| k == "code")
+            .map(|(_, v)| v.to_string())
+            .ok_or_else(|| "回调 URL 中未找到 code 参数".to_string())?;
+        
+        // 获取 redirect_uri (从 URL 中提取 scheme://host:port/path)
+        let redirect_uri = format!(
+            "{}://{}{}",
+            url.scheme(),
+            url.host_str().unwrap_or("localhost"),
+            if let Some(port) = url.port() { format!(":{}", port) } else { String::new() }
+        ) + url.path();
+        
+        // 2. 使用 code 交换 token
+        let token_res = modules::oauth::exchange_code(&code, &redirect_uri).await?;
+        
+        // 3. 检查是否返回了 refresh_token
+        let refresh_token = token_res.refresh_token.ok_or_else(|| {
+            "OAuth 未返回 Refresh Token。可能原因：\n\
+             1. 此 Google 账号之前已授权过此应用\n\
+             2. 请访问 https://myaccount.google.com/permissions 撤销授权后重试"
+                .to_string()
+        })?;
+        
+        // 4. 获取用户信息
+        let user_info = modules::oauth::get_user_info(&token_res.access_token).await?;
+        
+        // 5. 构造 TokenData 并保存账号
+        let token_data = crate::models::TokenData::new(
+            token_res.access_token,
+            refresh_token,
+            token_res.expires_in,
+            Some(user_info.email.clone()),  // email: Option<String>
+            None,  // project_id
+            None,  // session_id
+        );
+        
+        // 6. 创建并保存账号
+        let account_id = uuid::Uuid::new_v4().to_string();
+        let mut account = crate::models::Account::new(
+            account_id,
+            user_info.email.clone(),
+            token_data,
+        );
+        account.name = user_info.get_display_name();
+
+        
+        modules::account::save_account(&account)?;
+        let _ = modules::account::set_current_account_id(&account.id);
+        
+        // 7. 重新加载反代账号
+        reload_proxy_accounts_internal(&state).await;
+        
+        Ok::<_, String>(account)
+    }.await;
+    
+    match result {
+        Ok(account) => ApiResponse::ok(account),
+        Err(e) => ApiResponse::<Account>::err(e),
+    }
+}
+
+// ============================================================================
+// 导入 API
+// ============================================================================
+
+
+async fn import_v1_accounts(
+    State(_state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    match modules::migration::import_from_v1().await {
+        Ok(accounts) => ApiResponse::ok(accounts),
+        Err(e) => ApiResponse::<Vec<Account>>::err(e),
+    }
+}
+
+async fn import_from_db(
+    State(state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    match modules::migration::import_from_db().await {
+        Ok(mut account) => {
+            // 设为当前账号
+            let _ = modules::account::set_current_account_id(&account.id);
+            reload_proxy_accounts_internal(&state).await;
+            ApiResponse::ok(account)
+        }
+        Err(e) => ApiResponse::<Account>::err(e),
+    }
+}
+
+#[derive(Deserialize)]
+struct ImportCustomDbRequest {
+    path: String,
+}
+
+async fn import_custom_db(
+    State(state): State<Arc<WebApiState>>,
+    AppJson(req): AppJson<ImportCustomDbRequest>,
+) -> impl IntoResponse {
+    match modules::migration::import_from_custom_db_path(req.path).await {
+        Ok(mut account) => {
+            let _ = modules::account::set_current_account_id(&account.id);
+            reload_proxy_accounts_internal(&state).await;
+            ApiResponse::ok(account)
+        }
+        Err(e) => ApiResponse::<Account>::err(e),
+    }
+}
+
+async fn sync_account_from_db(
+    State(state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    let result = async {
+        let db_refresh_token = modules::migration::get_refresh_token_from_db()?;
+        let curr_account = modules::account::get_current_account()?;
+
+        if let Some(acc) = curr_account {
+            if acc.token.refresh_token == db_refresh_token {
+                return Ok(None);
+            }
+        }
+
+        let account = modules::migration::import_from_db().await?;
+        let _ = modules::account::set_current_account_id(&account.id);
+        Ok::<_, String>(Some(account))
+    }
+    .await;
+
+    match result {
+        Ok(account) => {
+            if account.is_some() {
+                reload_proxy_accounts_internal(&state).await;
+            }
+            ApiResponse::ok(account)
+        }
+        Err(e) => ApiResponse::<Option<Account>>::err(e),
+    }
+}
+
+// ============================================================================
+// 系统 API
+// ============================================================================
+
+async fn get_data_dir_path(
+    State(_state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    match modules::account::get_data_dir() {
+        Ok(path) => ApiResponse::ok(path.to_string_lossy().to_string()),
+        Err(e) => ApiResponse::<String>::err(e),
+    }
+}
+
+#[derive(Serialize)]
+struct UpdateInfo {
+    has_update: bool,
+    latest_version: String,
+    current_version: String,
+    download_url: String,
+}
+
+async fn check_for_updates(
+    State(_state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+    const GITHUB_API_URL: &str =
+        "https://api.github.com/repos/lbjlaq/Antigravity-Manager/releases/latest";
+
+    let result = async {
+        let client = crate::utils::http::create_client(15);
+        let response = client
+            .get(GITHUB_API_URL)
+            .header("User-Agent", "Antigravity-Tools")
+            .send()
+            .await
+            .map_err(|e| format!("请求失败: {}", e))?;
+
+        if !response.status().is_success() {
+            return Err(format!("GitHub API 返回错误: {}", response.status()));
+        }
+
+        let json: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| format!("解析响应失败: {}", e))?;
+
+        let latest_version = json["tag_name"]
+            .as_str()
+            .ok_or("无法获取版本号")?
+            .trim_start_matches('v');
+
+        let download_url = json["html_url"]
+            .as_str()
+            .unwrap_or("https://github.com/lbjlaq/Antigravity-Manager/releases")
+            .to_string();
+
+        let has_update = compare_versions(latest_version, CURRENT_VERSION);
+
+        Ok(UpdateInfo {
+            has_update,
+            latest_version: format!("v{}", latest_version),
+            current_version: format!("v{}", CURRENT_VERSION),
+            download_url,
+        })
+    }
+    .await;
+
+    match result {
+        Ok(info) => ApiResponse::ok(info),
+        Err(e) => ApiResponse::<UpdateInfo>::err(e),
+    }
+}
+
+fn compare_versions(latest: &str, current: &str) -> bool {
+    let parse_version =
+        |v: &str| -> Vec<u32> { v.split('.').filter_map(|s| s.parse::<u32>().ok()).collect() };
+
+    let latest_parts = parse_version(latest);
+    let current_parts = parse_version(current);
+
+    for i in 0..3 {
+        let l = latest_parts.get(i).unwrap_or(&0);
+        let c = current_parts.get(i).unwrap_or(&0);
+        if l > c {
+            return true;
+        } else if l < c {
+            return false;
+        }
+    }
+
+    false
+}
+
+async fn clear_log_cache(
+    State(_state): State<Arc<WebApiState>>,
+) -> impl IntoResponse {
+    match modules::logger::clear_logs() {
+        Ok(()) => ApiResponse::ok(()),
+        Err(e) => ApiResponse::<()>::err(e),
+    }
+}
+
+// ============================================================================
+// SSE 事件流
+// ============================================================================
+
+async fn sse_handler(
+    State(state): State<Arc<WebApiState>>,
+) -> Sse<impl Stream<Item = Result<axum::response::sse::Event, Infallible>>> {
+    let rx = state.sse_tx.subscribe();
+
+    let stream = async_stream::stream! {
+        let mut rx = rx;
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    let data = serde_json::to_string(&event).unwrap_or_default();
+                    yield Ok(axum::response::sse::Event::default().data(data));
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+            }
+        }
+    };
+
+    Sse::new(stream).keep_alive(
+        axum::response::sse::KeepAlive::new()
+            .interval(Duration::from_secs(30))
+            .text("ping"),
+    )
+}
+
+// ============================================================================
+// 健康检查
+// ============================================================================
+
+async fn health_check() -> impl IntoResponse {
+    Json(serde_json::json!({
+        "status": "ok",
+        "version": env!("CARGO_PKG_VERSION"),
+        "mode": "web"
+    }))
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,8 @@ import { useEffect } from 'react';
 import { useConfigStore } from './stores/useConfigStore';
 import { useAccountStore } from './stores/useAccountStore';
 import { useTranslation } from 'react-i18next';
-import { listen } from '@tauri-apps/api/event';
+import { listen } from './utils/tauriCompat';
+
 
 const router = createBrowserRouter([
   {

--- a/src/components/common/ThemeManager.tsx
+++ b/src/components/common/ThemeManager.tsx
@@ -1,7 +1,8 @@
 
 import { useEffect } from 'react';
 import { useConfigStore } from '../../stores/useConfigStore';
-import { getCurrentWindow } from '@tauri-apps/api/window';
+import { getCurrentWindow } from '../../utils/tauriCompat';
+
 
 export default function ThemeManager() {
     const { config, loadConfig } = useConfigStore();
@@ -12,7 +13,8 @@ export default function ThemeManager() {
             await loadConfig();
             // Show window after a short delay to ensure React has painted
             setTimeout(async () => {
-                await getCurrentWindow().show();
+                const win = await getCurrentWindow();
+                await win.show();
             }, 100);
         };
         init();
@@ -29,7 +31,8 @@ export default function ThemeManager() {
             // Set Tauri window background color
             try {
                 const bgColor = isDark ? '#1d232a' : '#FAFBFC';
-                await getCurrentWindow().setBackgroundColor(bgColor);
+                const win = await getCurrentWindow();
+                await win.setBackgroundColor(bgColor);
             } catch (e) {
                 console.error('Failed to set window background color:', e);
             }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,7 @@
 import { Outlet } from 'react-router-dom';
-import { getCurrentWindow } from '@tauri-apps/api/window';
+import { getCurrentWindow } from '../../utils/tauriCompat';
+import { isTauri } from '../../utils/request';
+
 import Navbar from './Navbar';
 import BackgroundTaskRunner from '../common/BackgroundTaskRunner';
 import ToastContainer from '../common/ToastContainer';
@@ -7,21 +9,24 @@ import ToastContainer from '../common/ToastContainer';
 function Layout() {
     return (
         <div className="h-screen flex flex-col bg-[#FAFBFC] dark:bg-base-300">
-            {/* 全局窗口拖拽区域 - 使用 JS 手动触发拖拽，解决 HTML 属性失效问题 */}
-            <div
-                className="fixed top-0 left-0 right-0 h-9"
-                style={{
-                    zIndex: 9999,
-                    backgroundColor: 'rgba(0,0,0,0.001)',
-                    cursor: 'default',
-                    userSelect: 'none',
-                    WebkitUserSelect: 'none'
-                }}
-                data-tauri-drag-region
-                onMouseDown={() => {
-                    getCurrentWindow().startDragging();
-                }}
-            />
+            {/* 全局窗口拖拽区域 - 仅在 Tauri 模式下启用 */}
+            {isTauri && (
+                <div
+                    className="fixed top-0 left-0 right-0 h-9"
+                    style={{
+                        zIndex: 9999,
+                        backgroundColor: 'rgba(0,0,0,0.001)',
+                        cursor: 'default',
+                        userSelect: 'none',
+                        WebkitUserSelect: 'none'
+                    }}
+                    data-tauri-drag-region
+                    onMouseDown={async () => {
+                        const win = await getCurrentWindow();
+                        (win as any).startDragging?.();
+                    }}
+                />
+            )}
             <BackgroundTaskRunner />
             <ToastContainer />
             <Navbar />
@@ -33,3 +38,4 @@ function Layout() {
 }
 
 export default Layout;
+

--- a/src/components/proxy/ProxyMonitor.tsx
+++ b/src/components/proxy/ProxyMonitor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { listen } from '@tauri-apps/api/event';
+import { listen } from '../../utils/tauriCompat';
+
 import ModalDialog from '../common/ModalDialog';
 import { useTranslation } from 'react-i18next';
 import { request as invoke } from '../../utils/request';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { invoke } from "@tauri-apps/api/core";
+import { isTauri, request } from "./utils/request";
 
 import App from './App';
 import './i18n'; // Import i18n config
 import "./App.css";
 
-// 启动时显式调用 Rust 命令显示窗口
+// 启动时显式调用 Rust 命令显示窗口 (仅 Tauri 模式)
 // 配合 visible:false 使用，解决启动黑屏问题
-invoke("show_main_window").catch(console.error);
+if (isTauri) {
+  request("show_main_window").catch(console.error);
+}
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
@@ -16,3 +18,4 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 
   </React.StrictMode>,
 );
+

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { save } from '@tauri-apps/plugin-dialog';
+import { save, join } from '../utils/tauriCompat';
 import { request as invoke } from '../utils/request';
-import { join } from '@tauri-apps/api/path';
+
 import { Search, RefreshCw, Download, Trash2, LayoutGrid, List, ToggleLeft, ToggleRight } from 'lucide-react';
 import { useAccountStore } from '../stores/useAccountStore';
 import { useConfigStore } from '../stores/useConfigStore';

--- a/src/pages/ApiProxy.tsx
+++ b/src/pages/ApiProxy.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { invoke } from '@tauri-apps/api/core';
+import { request as invoke } from '../utils/request';
+
 import {
     Power,
     Copy,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,7 +6,8 @@ import { useAccountStore } from '../stores/useAccountStore';
 import CurrentAccount from '../components/dashboard/CurrentAccount';
 import BestAccounts from '../components/dashboard/BestAccounts';
 import AddAccountDialog from '../components/accounts/AddAccountDialog';
-import { save } from '@tauri-apps/plugin-dialog';
+import { save } from '../utils/tauriCompat';
+
 import { request as invoke } from '../utils/request';
 import { showToast } from '../components/common/ToastContainer';
 import { Account } from '../types/account';

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { Save, Github, User, MessageCircle, ExternalLink, RefreshCw, Sparkles } from 'lucide-react';
 import { request as invoke } from '../utils/request';
-import { open } from '@tauri-apps/plugin-dialog';
+import { open } from '../utils/tauriCompat';
+
 import { useConfigStore } from '../stores/useConfigStore';
 import { AppConfig } from '../types/config';
 import ModalDialog from '../components/common/ModalDialog';

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,10 +1,173 @@
-import { invoke } from '@tauri-apps/api/core';
+/**
+ * 环境感知的请求适配器
+ * 
+ * - Tauri 模式：使用原生 IPC (invoke)
+ * - Web 模式：使用 HTTP API
+ */
 
+// 运行时环境检测
+export const isTauri = typeof window !== 'undefined' && '__TAURI__' in window;
+
+// Web 模式下的 API 基础路径
+const API_BASE = import.meta.env.VITE_API_BASE || '';
+
+// 命令名称到 HTTP 端点的映射
+// unwrapKey: 可选，指定从 args 中提取哪个键作为请求体（解包 Tauri 调用参数）
+type EndpointConfig = { 
+  method: string; 
+  path: string | ((args: any) => string); 
+  unwrapKey?: string;
+};
+
+const COMMAND_ENDPOINTS: Record<string, EndpointConfig> = {
+  // 账号管理
+  list_accounts: { method: 'GET', path: '/api/accounts' },
+  add_account: { method: 'POST', path: '/api/accounts' },
+  get_current_account: { method: 'GET', path: '/api/accounts/current' },
+  delete_account: { method: 'DELETE', path: (args) => `/api/accounts/${args.account_id || args.id}` },
+  delete_accounts: { method: 'POST', path: '/api/accounts/batch-delete' },
+  switch_account: { method: 'POST', path: (args) => `/api/accounts/${args.account_id || args.id}/switch` },
+  fetch_account_quota: { method: 'POST', path: (args) => `/api/accounts/${args.account_id || args.id}/quota` },
+  refresh_all_quotas: { method: 'POST', path: '/api/accounts/refresh-all' },
+  reorder_accounts: { method: 'POST', path: '/api/accounts/reorder' },
+  toggle_proxy_status: { method: 'POST', path: (args) => `/api/accounts/${args.account_id || args.id}/proxy-status` },
+
+  // 配置
+  load_config: { method: 'GET', path: '/api/config' },
+  save_config: { method: 'PUT', path: '/api/config', unwrapKey: 'config' },
+
+  // 反代服务
+  start_proxy_service: { method: 'POST', path: '/api/proxy/start', unwrapKey: 'config' },
+  stop_proxy_service: { method: 'POST', path: '/api/proxy/stop' },
+  get_proxy_status: { method: 'GET', path: '/api/proxy/status' },
+  get_proxy_stats: { method: 'GET', path: '/api/proxy/stats' },
+  get_proxy_logs: { method: 'GET', path: '/api/proxy/logs' },
+  clear_proxy_logs: { method: 'DELETE', path: '/api/proxy/logs' },
+  set_proxy_monitor_enabled: { method: 'POST', path: '/api/proxy/monitor' },
+  reload_proxy_accounts: { method: 'POST', path: '/api/proxy/reload-accounts' },
+  update_model_mapping: { method: 'PUT', path: '/api/proxy/model-mapping', unwrapKey: 'config' },
+  get_proxy_scheduling_config: { method: 'GET', path: '/api/proxy/scheduling' },
+  update_proxy_scheduling_config: { method: 'PUT', path: '/api/proxy/scheduling', unwrapKey: 'config' },
+  clear_proxy_session_bindings: { method: 'DELETE', path: '/api/proxy/sessions' },
+  fetch_zai_models: { method: 'POST', path: '/api/proxy/zai-models' },
+  generate_api_key: { method: 'POST', path: '/api/proxy/generate-api-key' },
+
+  // OAuth
+  prepare_oauth_url: { method: 'POST', path: '/api/oauth/prepare-url' },
+  process_oauth_callback: { method: 'POST', path: '/api/oauth/process-callback' },
+  start_oauth_login: { method: 'POST', path: '/api/oauth/prepare-url' }, // Web 模式下同上
+  complete_oauth_login: { method: 'POST', path: '/api/oauth/prepare-url' },
+  cancel_oauth_login: { method: 'POST', path: '/api/oauth/prepare-url' },
+
+
+  // 导入
+  import_v1_accounts: { method: 'POST', path: '/api/import/v1' },
+  import_from_db: { method: 'POST', path: '/api/import/db' },
+  import_custom_db: { method: 'POST', path: '/api/import/custom-db' },
+  sync_account_from_db: { method: 'POST', path: '/api/sync/db' },
+
+  // 系统
+  get_data_dir_path: { method: 'GET', path: '/api/system/data-dir' },
+  check_for_updates: { method: 'GET', path: '/api/system/check-updates' },
+  clear_log_cache: { method: 'POST', path: '/api/system/clear-logs' },
+};
+
+// camelCase 转 snake_case
+function toSnakeCase(str: string): string {
+  return str.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+}
+
+// 转换对象键名为 snake_case
+function convertKeysToSnakeCase(obj: any): any {
+  if (obj === null || obj === undefined) return obj;
+  if (Array.isArray(obj)) return obj.map(convertKeysToSnakeCase);
+  if (typeof obj !== 'object') return obj;
+
+  const converted: Record<string, any> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    converted[toSnakeCase(key)] = convertKeysToSnakeCase(value);
+  }
+
+  return converted;
+}
+
+// Web 模式下的 HTTP 请求实现
+async function httpRequest<T>(cmd: string, args?: any): Promise<T> {
+  const endpoint = COMMAND_ENDPOINTS[cmd];
+
+  if (!endpoint) {
+    console.warn(`[Web API] Unknown command: ${cmd}, trying generic POST`);
+    const response = await fetch(`${API_BASE}/api/${cmd.replace(/_/g, '-')}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: args ? JSON.stringify(convertKeysToSnakeCase(args)) : undefined,
+    });
+    const data = await response.json();
+    if (!data.success) throw new Error(data.error || 'Request failed');
+    return data.data;
+  }
+
+  const path = typeof endpoint.path === 'function' 
+    ? endpoint.path(args) 
+    : endpoint.path;
+
+  const url = `${API_BASE}${path}`;
+  const options: RequestInit = {
+    method: endpoint.method,
+    headers: { 'Content-Type': 'application/json' },
+  };
+
+  // GET/DELETE 请求不发送 body（路径参数已在 path 中）
+  if (endpoint.method !== 'GET' && endpoint.method !== 'DELETE' && args) {
+    // 如果定义了 unwrapKey，从 args 中提取该键的值作为请求体
+    let bodyArgs = args;
+    if (endpoint.unwrapKey && args[endpoint.unwrapKey] !== undefined) {
+      bodyArgs = args[endpoint.unwrapKey];
+    } else {
+      // 过滤掉已用于路径的参数
+      bodyArgs = { ...args };
+      delete bodyArgs.account_id;
+      delete bodyArgs.id;
+    }
+    
+    if (bodyArgs && (typeof bodyArgs === 'object' ? Object.keys(bodyArgs).length > 0 : true)) {
+      options.body = JSON.stringify(convertKeysToSnakeCase(bodyArgs));
+    }
+  }
+
+  const response = await fetch(url, options);
+  const data = await response.json();
+
+  if (!data.success) {
+    throw new Error(data.error || `HTTP ${response.status}`);
+  }
+
+  return data.data;
+}
+
+
+/**
+ * 统一的请求函数 - 自动根据运行环境选择 IPC 或 HTTP
+ */
 export async function request<T>(cmd: string, args?: any): Promise<T> {
-  try {
-    return await invoke<T>(cmd, args);
-  } catch (error) {
-    console.error(`API Error [${cmd}]:`, error);
-    throw error;
+  if (isTauri) {
+    // Tauri 模式：使用原生 IPC
+    const { invoke } = await import('@tauri-apps/api/core');
+    try {
+      return await invoke<T>(cmd, args);
+    } catch (error) {
+      console.error(`[Tauri API] Error [${cmd}]:`, error);
+      throw error;
+    }
+  } else {
+    // Web 模式：使用 HTTP API
+    try {
+      return await httpRequest<T>(cmd, args);
+    } catch (error) {
+      console.error(`[Web API] Error [${cmd}]:`, error);
+      throw error;
+    }
   }
 }
+
+export default request;

--- a/src/utils/tauriCompat.ts
+++ b/src/utils/tauriCompat.ts
@@ -1,0 +1,290 @@
+/**
+ * Tauri API 兼容层
+ * 
+ * 提供 Web 模式下 Tauri 特有 API 的替代实现
+ */
+
+import { isTauri } from './request';
+
+// ============================================================================
+// 事件系统兼容 - 使用 SSE 替代 Tauri emit/listen
+// ============================================================================
+
+// SSE 事件源管理
+let eventSource: EventSource | null = null;
+const eventListeners: Map<string, Set<(payload: any) => void>> = new Map();
+
+/**
+ * 初始化 SSE 事件监听（Web 模式）
+ */
+function initSSE() {
+  if (eventSource || isTauri) return;
+
+  const API_BASE = import.meta.env.VITE_API_BASE || '';
+  eventSource = new EventSource(`${API_BASE}/api/events`);
+
+  eventSource.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      const eventType = data.type;
+      const payload = data.data;
+
+      // 分发事件给监听器
+      const handlers = eventListeners.get(eventType) || eventListeners.get('*');
+      handlers?.forEach(handler => handler(payload));
+
+      // 映射 SSE 事件类型到 Tauri 事件名称
+      if (eventType === 'ProxyRequest') {
+        eventListeners.get('proxy://request')?.forEach(h => h(payload));
+      } else if (eventType === 'ConfigUpdated') {
+        eventListeners.get('config://updated')?.forEach(h => h(null));
+      } else if (eventType === 'AccountSwitched') {
+        eventListeners.get('tray://account-switched')?.forEach(h => h(null));
+      }
+    } catch (e) {
+      console.error('[SSE] Parse error:', e);
+    }
+  };
+
+  eventSource.onerror = (error) => {
+    console.error('[SSE] Connection error:', error);
+    // 尝试重连
+    setTimeout(() => {
+      eventSource?.close();
+      eventSource = null;
+      initSSE();
+    }, 5000);
+  };
+}
+
+/**
+ * 事件监听 - 兼容 @tauri-apps/api/event
+ */
+export async function listen<T>(
+  event: string,
+  handler: (event: { payload: T }) => void
+): Promise<() => void> {
+  if (isTauri) {
+    // Tauri 模式：使用原生 listen
+    const { listen: tauriListen } = await import('@tauri-apps/api/event');
+    return tauriListen(event, handler);
+  } else {
+    // Web 模式：使用 SSE
+    initSSE();
+
+    const wrappedHandler = (payload: T) => handler({ payload });
+
+    if (!eventListeners.has(event)) {
+      eventListeners.set(event, new Set());
+    }
+    eventListeners.get(event)!.add(wrappedHandler);
+
+    // 返回 unlisten 函数
+    return () => {
+      eventListeners.get(event)?.delete(wrappedHandler);
+    };
+  }
+}
+
+// ============================================================================
+// 窗口 API 兼容 - Web 模式下提供 no-op 实现
+// ============================================================================
+
+/**
+ * 获取当前窗口 - 兼容 @tauri-apps/api/window
+ */
+export async function getCurrentWindow(): Promise<{
+  show: () => Promise<void>;
+  hide: () => Promise<void>;
+  setFocus: () => Promise<void>;
+  setBackgroundColor: (color: string) => Promise<void>;
+}> {
+  if (isTauri) {
+    const { getCurrentWindow: tauriGetCurrentWindow } = await import('@tauri-apps/api/window');
+    return tauriGetCurrentWindow();
+  } else {
+    // Web 模式：返回可安全调用但无操作的对象
+    return {
+      show: async () => {},
+      hide: async () => {},
+      setFocus: async () => {},
+      setBackgroundColor: async (color: string) => {
+        // 使用 CSS 设置背景色
+        document.documentElement.style.backgroundColor = color;
+      },
+    };
+  }
+}
+
+// ============================================================================
+// 对话框 API 兼容 - 使用浏览器原生方法
+// ============================================================================
+
+export interface SaveDialogOptions {
+  title?: string;
+  filters?: { name: string; extensions: string[] }[];
+  defaultPath?: string;
+}
+
+export interface OpenDialogOptions {
+  title?: string;
+  filters?: { name: string; extensions: string[] }[];
+  multiple?: boolean;
+  directory?: boolean;
+}
+
+/**
+ * 保存文件对话框 - 兼容 @tauri-apps/plugin-dialog
+ */
+export async function save(options?: SaveDialogOptions): Promise<string | null> {
+  if (isTauri) {
+    const { save: tauriSave } = await import('@tauri-apps/plugin-dialog');
+    return tauriSave(options);
+  } else {
+    // Web 模式：返回 null，让调用方自行处理
+    console.warn('[Web] File save dialog not available in web mode');
+    return null;
+  }
+}
+
+/**
+ * 打开文件对话框 - 兼容 @tauri-apps/plugin-dialog
+ */
+export async function open(options?: OpenDialogOptions): Promise<string | string[] | null> {
+  if (isTauri) {
+    const { open: tauriOpen } = await import('@tauri-apps/plugin-dialog');
+    return tauriOpen(options);
+  } else {
+    // Web 模式：使用 input[type=file] + FileReader
+    return new Promise((resolve) => {
+      const input = document.createElement('input');
+      input.type = 'file';
+      if (options?.multiple) input.multiple = true;
+      if (options?.directory) input.webkitdirectory = true;
+      if (options?.filters) {
+        input.accept = options.filters
+          .flatMap(f => f.extensions.map(ext => `.${ext}`))
+          .join(',');
+      }
+
+      input.onchange = (e) => {
+        const files = (e.target as HTMLInputElement).files;
+        if (!files || files.length === 0) {
+          resolve(null);
+          return;
+        }
+
+        if (options?.multiple) {
+          resolve(Array.from(files).map(f => f.name));
+        } else {
+          resolve(files[0].name);
+        }
+      };
+
+      input.oncancel = () => resolve(null);
+      input.click();
+    });
+  }
+}
+
+// ============================================================================
+// 路径 API 兼容
+// ============================================================================
+
+/**
+ * 路径拼接 - 兼容 @tauri-apps/api/path
+ */
+export async function join(...paths: string[]): Promise<string> {
+  if (isTauri) {
+    const { join: tauriJoin } = await import('@tauri-apps/api/path');
+    return tauriJoin(...paths);
+  } else {
+    // Web 模式：简单的路径拼接
+    return paths
+      .map(p => p.replace(/^\/|\/$/g, ''))
+      .filter(Boolean)
+      .join('/');
+  }
+}
+
+// ============================================================================
+// 自启动 API 兼容
+// ============================================================================
+
+/**
+ * 检查自启动状态 - Web 模式下始终返回 false
+ */
+export async function isAutoLaunchEnabled(): Promise<boolean> {
+  if (isTauri) {
+    const { request } = await import('./request');
+    return request<boolean>('is_auto_launch_enabled');
+  } else {
+    return false;
+  }
+}
+
+/**
+ * 切换自启动 - Web 模式下 no-op
+ */
+export async function toggleAutoLaunch(enable: boolean): Promise<boolean> {
+  if (isTauri) {
+    const { request } = await import('./request');
+    return request<boolean>('toggle_auto_launch', { enable });
+  } else {
+    console.warn('[Web] Auto launch not available in web mode');
+    return false;
+  }
+}
+
+// ============================================================================
+// Opener API 兼容
+// ============================================================================
+
+/**
+ * 打开 URL - 兼容 @tauri-apps/plugin-opener
+ */
+export async function openUrl(url: string): Promise<void> {
+  if (isTauri) {
+    const { openUrl: tauriOpenUrl } = await import('@tauri-apps/plugin-opener');
+    await tauriOpenUrl(url);
+  } else {
+    // Web 模式：使用 window.open
+    window.open(url, '_blank');
+  }
+}
+
+
+/**
+ * 打开数据文件夹 - Web 模式下不支持
+ */
+export async function openDataFolder(): Promise<void> {
+  if (isTauri) {
+    const { request } = await import('./request');
+    await request('open_data_folder');
+  } else {
+    console.warn('[Web] Cannot open local folder in web mode');
+  }
+}
+
+// ============================================================================
+// 文件系统 API 兼容
+// ============================================================================
+
+/**
+ * 保存文本文件
+ */
+export async function saveTextFile(content: string, filename: string): Promise<void> {
+  if (isTauri) {
+    const { request } = await import('./request');
+    await request('save_text_file', { content, filename });
+  } else {
+    // Web 模式：使用 Blob + download
+    const blob = new Blob([content], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+}


### PR DESCRIPTION
- Add axum-based REST API layer (web_api.rs)
- Add standalone server binary (antigravity-server)
- Add frontend Tauri compatibility layer (tauriCompat.ts)
- Add HTTP request adapter with endpoint mapping (request.ts)
- Update all components to use compatibility APIs
- Add manual OAuth callback URL support for remote deployment
- Add deployment documentation (DEPLOYMENT.md)
- Add packaging script (package-server.sh)

⚠️ 本 PR 不影响默认 Tauri 桌面应用的编译和运行。Web Server 模式需要显式指定 --features web-server。

## 🚀 功能: 独立 Web 服务端模式

### 概述
本 PR 为 Antigravity Manager 添加了独立 Web 服务端模式，允许将应用部署到远程 Linux 服务器通过浏览器访问，无需 Tauri 桌面环境。

### 主要改动

#### 后端
- 新增 [web_api.rs](cci:7://file:///home/fch/mydata/Antigravity-Manager/src-tauri/src/web_api.rs:0:0-0:0): axum REST API 层，封装所有 Tauri 命令为 HTTP 端点 (~40 个端点 + SSE)
- 新增 [main_server.rs](cci:7://file:///home/fch/mydata/Antigravity-Manager/src-tauri/src/bin/main_server.rs:0:0-0:0): 独立二进制入口，支持命令行参数配置
- 条件编译: 使用 feature flags (`tauri-app` / `web-server`) 分离代码路径

#### 前端
- 新增 [tauriCompat.ts](cci:7://file:///home/fch/mydata/Antigravity-Manager/src/utils/tauriCompat.ts:0:0-0:0): Tauri API 兼容层 (事件/窗口/对话框/路径/opener)
- 重构 [request.ts](cci:7://file:///home/fch/mydata/Antigravity-Manager/src/utils/request.ts:0:0-0:0): 自动检测运行环境，Tauri 用 IPC，Web 用 HTTP
- 手动 OAuth 回调: 支持远程部署时粘贴回调 URL 完成登录

#### 文档
- 新增 [DEPLOYMENT.md](cci:7://file:///home/fch/mydata/Antigravity-Manager/DEPLOYMENT.md:0:0-0:0): 完整服务器部署教程
- 更新 [README.md](cci:7://file:///home/fch/mydata/Antigravity-Manager/README.md:0:0-0:0): 添加 Web Server 模式说明
- 新增 [package-server.sh](cci:7://file:///home/fch/mydata/Antigravity-Manager/package-server.sh:0:0-0:0): 一键打包脚本

### 使用方式
```bash
# 编译
cargo build --release --bin antigravity-server --no-default-features --features web-server

# 启动
./antigravity-server --port 8765 --static-dir ../dist --data-dir ~/.antigravity