### PR TITLE
feat: Add reasoning_content field for thinking process display for Gemini3

### DIFF
--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -30,6 +30,7 @@ pub async fn handle_chat_completions(
                 content: Some(crate::proxy::mappers::openai::OpenAIContent::String(
                     " ".to_string(),
                 )),
+                reasoning_content: None,
                 tool_calls: None,
                 tool_call_id: None,
                 name: None,
@@ -508,6 +509,7 @@ pub async fn handle_completions(
                 content: Some(crate::proxy::mappers::openai::OpenAIContent::String(
                     " ".to_string(),
                 )),
+                reasoning_content: None,
                 tool_calls: None,
                 tool_call_id: None,
                 name: None,

--- a/src-tauri/src/proxy/mappers/openai/models.rs
+++ b/src-tauri/src/proxy/mappers/openai/models.rs
@@ -79,6 +79,8 @@ pub struct OpenAIMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<OpenAIContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCall>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_call_id: Option<String>,

--- a/src-tauri/src/proxy/mappers/openai/request.rs
+++ b/src-tauri/src/proxy/mappers/openai/request.rs
@@ -403,6 +403,7 @@ mod tests {
                         detail: None 
                     } }
                 ])),
+                reasoning_content: None,
                 tool_calls: None,
                 tool_call_id: None,
                 name: None,


### PR DESCRIPTION
### 修改内容

在 OpenAI 兼容格式中添加 `reasoning_content` 字段支持，使 Gemini 3 模型的思考过程能够被 Cherry Studio 等客户端正确折叠显示。

### 具体改动

1. **streaming.rs**: 根据 `thought:true` 标记分离思考内容，输出到 `reasoning_content` 字段
2. **response.rs**: 非流式响应同样支持 `reasoning_content`
3. **models.rs**: 在 `OpenAIMessage` 结构体中添加 `reasoning_content` 字段
4. **修复 bug**: 当仅有思考内容时 chunk 被错误跳过的问题

### 兼容性

- `thoughtSignature` 捕获逻辑未受影响
- 同时支持非流式

### 对照

## 以前

<img width="500" alt="Before" src="https://github.com/user-attachments/assets/2e2e1cd9-2da0-40b9-8a8f-dfd9e707d919" />

## 以后

<img width="500" alt="After" src="https://github.com/user-attachments/assets/364edfec-50ef-4046-b964-9edb9149aff5" />

## 非流式(特殊的)

<img width="500" alt="416c883a8a8c0e126023063c03426c55" src="https://github.com/user-attachments/assets/6d56fc83-1fc9-461d-945b-700bb4d268d5" />

### 思考过程展开框与正文倒置，但这其实是Cherry Studio的问题，
### 因为使用SiliconFlow的Deepseek也会遇到一样的问题：
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b1d7260e-91db-4c4c-805a-3d26a6994225" />
