### PR TITLE
fix(macos): handle RunEvent::Reopen to show window on dock icon click

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,6 +130,18 @@ pub fn run() {
             commands::autostart::toggle_auto_launch,
             commands::autostart::is_auto_launch_enabled,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            // Handle macOS dock icon click to reopen window
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen { .. } = event {
+                if let Some(window) = app_handle.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.unminimize();
+                    let _ = window.set_focus();
+                    app_handle.set_activation_policy(tauri::ActivationPolicy::Regular).unwrap_or(());
+                }
+            }
+        });
 }


### PR DESCRIPTION
## Summary

- Fix macOS window not reopening when clicking Dock icon after closing the window (without quitting)
- Add `RunEvent::Reopen` handler to show, unminimize and focus the main window
- Set activation policy back to `Regular` when window is reopened

## Root Cause

The app was using `.run(tauri::generate_context!())` which doesn't provide access to `RunEvent`. On macOS, when the Dock icon is clicked after all windows are closed, Tauri emits `RunEvent::Reopen` but no handler existed to show the window.

## Solution

Changed to `.build().run()` pattern and added a `RunEvent::Reopen` handler that:
1. Shows the hidden main window
2. Unminimizes it (in case it was minimized)
3. Sets focus to the window
4. Restores `ActivationPolicy::Regular` so the app appears in the Dock properly

## Testing

1. Launch the app
2. Close the main window (⌘+W or click red close button)
3. Click the Dock icon
4. **Expected**: Window reappears ✅

Fixes #471