### PR TITLE
fix(openai): Fix OpenAI Thinking Content Collection for Non-Streaming Responses and Claude Models

### DIFF
--- a/src-tauri/src/proxy/mappers/openai/collector.rs
+++ b/src-tauri/src/proxy/mappers/openai/collector.rs
@@ -69,6 +69,7 @@ where
     };
 
     let mut content = String::new();
+    let mut reasoning_content = String::new();
     let mut tool_calls: Vec<ToolCall> = Vec::new();
     let mut finish_reason: Option<String> = None;
 
@@ -91,6 +92,11 @@ where
                     // 累积 content
                     if let Some(text) = delta.get("content").and_then(|v| v.as_str()) {
                         content.push_str(text);
+                    }
+
+                    // 累积 reasoning_content (思考过程)
+                    if let Some(reasoning) = delta.get("reasoning_content").and_then(|v| v.as_str()) {
+                        reasoning_content.push_str(reasoning);
                     }
 
                     // 累积 tool_calls
@@ -141,7 +147,7 @@ where
             role: "assistant".to_string(),
             content: if content.is_empty() { None } else { Some(OpenAIContent::String(content)) },
             tool_calls: Some(tool_calls),
-            reasoning_content: None,
+            reasoning_content: if reasoning_content.is_empty() { None } else { Some(reasoning_content) },
             tool_call_id: None,
             name: None,
         }
@@ -150,7 +156,7 @@ where
             role: "assistant".to_string(),
             content: Some(OpenAIContent::String(content)),
             tool_calls: None,
-            reasoning_content: None,
+            reasoning_content: if reasoning_content.is_empty() { None } else { Some(reasoning_content) },
             tool_call_id: None,
             name: None,
         }


### PR DESCRIPTION
## 问题

通过 OpenAI 协议访问时，以下模型的思考过程 (reasoning_content) 无法正常输出：

1. **Gemini 3 Pro (high/low)** - 非流式响应中思考内容丢失
2. **Claude \*-thinking 系列** - 没有注入 thinkingConfig，导致无思考输出

## 修复

### 1. collector.rs - 收集 reasoning_content

在流式响应收集器中添加 `reasoning_content` 的累积逻辑：

- 新增 `reasoning_content` 变量用于累积思考内容
- 从每个流式 chunk 的 `delta.reasoning_content` 中提取并拼接
- 最终将累积的思考内容写入 `OpenAIMessage.reasoning_content` 字段

### 2. request.rs - 支持 Claude *-thinking 模型

扩展 `is_thinking_model` 检测逻辑：

- 原有逻辑：仅检测 `gemini-3` + `-high/-low/-pro` 后缀
- 新增逻辑：检测模型名以 `-thinking` 结尾（匹配 `claude-*-thinking` 系列）
- 对所有 thinking 模型注入 `thinkingConfig`，确保上游返回思考内容


## 结果

- gemini-3-pro-low/high 模型非流式请求正确返回 reasoning_content
- claude-opus/sonnet-4-5-thinking 模型正确返回思考内容
- 流式请求行为不受影响

## 注意

仅修改了 OpenAI 协议。Anthropic 协议有独立的 thinking 处理逻辑，且思维签章对于Gemini3 for Anthropic有问题（注释里写的）。Gemini 协议为原生透传，未改动。

## 改前

<img width="1109" height="645" alt="before" src="https://github.com/user-attachments/assets/7cdd14b5-9b46-405a-b8fe-579ef7f584b2" />

## 改后

<img width="1099" height="835" alt="after" src="https://github.com/user-attachments/assets/6ae87d13-ae1b-4b40-8d3f-83d2c2c79a93" />
