### PR TITLE
feat: add hot reload support for experimental configuration

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -334,6 +334,8 @@ pub async fn save_config(
         instance.axum_server.update_security(&config.proxy).await;
         // 更新 z.ai 配置
         instance.axum_server.update_zai(&config.proxy).await;
+        // 更新实验性配置
+        instance.axum_server.update_experimental(&config.proxy).await;
         tracing::debug!("已同步热更新反代服务配置");
     }
 

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -39,6 +39,7 @@ pub struct AxumServer {
     proxy_state: Arc<tokio::sync::RwLock<crate::proxy::config::UpstreamProxyConfig>>,
     security_state: Arc<RwLock<crate::proxy::ProxySecurityConfig>>,
     zai_state: Arc<RwLock<crate::proxy::ZaiConfig>>,
+    experimental: Arc<RwLock<crate::proxy::config::ExperimentalConfig>>,
 }
 
 impl AxumServer {
@@ -67,6 +68,12 @@ impl AxumServer {
         let mut zai = self.zai_state.write().await;
         *zai = config.zai.clone();
         tracing::info!("z.ai 配置已热更新");
+    }
+
+    pub async fn update_experimental(&self, config: &crate::proxy::config::ProxyConfig) {
+        let mut exp = self.experimental.write().await;
+        *exp = config.experimental.clone();
+        tracing::info!("实验性配置已热更新");
     }
     /// 启动 Axum 服务器
     pub async fn start(
@@ -106,7 +113,7 @@ impl AxumServer {
             provider_rr: provider_rr.clone(),
             zai_vision_mcp: zai_vision_mcp_state,
             monitor: monitor.clone(),
-            experimental: experimental_state,
+            experimental: experimental_state.clone(),
         };
 
 
@@ -203,6 +210,7 @@ impl AxumServer {
             proxy_state,
             security_state,
             zai_state,
+            experimental: experimental_state.clone(),
         };
 
         // 在新任务中启动服务器


### PR DESCRIPTION
## 添加 experimental 配置热更新

为 `ExperimentalConfig` 添加热更新支持：

- 在 `AxumServer` 中添加 `experimental` 字段存储配置
- 在 `AppState` 中添加 `experimental` 字段供 handlers 使用
- 实现 `update_experimental()` 方法用于热更新
- 在 `save_config` 中调用热更新方法

与其他配置项（mapping、proxy、security、zai、scheduling）保持一致的热更新实施。