### PR TITLE
fix&perf: Optimize Smart Warmup Strategy

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -180,14 +180,6 @@ pub async fn fetch_account_quota(
         let _ = instance.token_manager.reload_account(&account_id).await;
     }
 
-    // 6. 联动预热 (根据配置)
-    if let Ok(config) = crate::modules::config::load_app_config() {
-        if config.scheduled_warmup.enabled {
-            let account = crate::modules::load_account(&account_id).unwrap_or(account);
-            crate::modules::scheduler::trigger_warmup_for_account(&account).await;
-        }
-    }
-
     Ok(quota)
 }
 
@@ -204,17 +196,6 @@ pub async fn refresh_all_quotas(
     let instance_lock = proxy_state.instance.read().await;
     if let Some(instance) = instance_lock.as_ref() {
         let _ = instance.token_manager.reload_all_accounts().await;
-    }
-
-    // 联动预热 (根据配置)
-    if let Ok(config) = crate::modules::config::load_app_config() {
-        if config.scheduled_warmup.enabled {
-            if let Ok(accounts) = crate::modules::list_accounts() {
-                for acc in accounts {
-                    crate::modules::scheduler::trigger_warmup_for_account(&acc).await;
-                }
-            }
-        }
     }
 
     Ok(stats)


### PR DESCRIPTION
## 总要

优化智能预热（Smart Warmup）功能，解决重复预热、性能低下、状态丢失、没日志等问题。

## 问题

### 1. 刷新触发预热
刷新配额时会自动触发预热检查，导致用户刷新配额查看状态时意外消耗预热额度。

### 2. 冷却期过短
原30分钟冷却期不足。由于现在配额每20%粒度更新，100%-80%期间显示始终为100%，可能在同一周期内触发多次预热。未被标记的Pro账号配额5小时重置，需要更长冷却期。

### 3. 预热速度慢
原实现为串行执行，每个账号/模型依次处理，10个账号筛选需要15-20秒，40个任务预热需要80秒以上。

### 4. 重启后状态丢失
预热历史记录存储在内存中，程序重启后冷却期失效，导致重复预热。

### 5. 手动预热无限制
用户可反复点击预热按钮，浪费配额。

### 6. 历史记录臃肿
记录了所有100%额度的模型，包括不在预热白名单中的模型。

## 更改

### 分离刷新和预热
- 移除 `fetch_account_quota` 中的预热触发
- 移除 `refresh_all_quotas` 中的预热触发
- 预热仅通过定时调度器或手动按钮触发

### 延长冷却期
- 30分钟 → 4小时（14400秒）
- 匹配 Pro 账号5小时重置周期，留1小时余量

### 持久化历史记录
- 保存至 `~/.antigravity_tools/warmup_history.json`
- 程序启动时自动加载
- 每次预热成功后保存
- 使用 JSON pretty 格式便于调试

### 并发执行
- 筛选阶段：每批5个账号并发获取配额
- 预热阶段：每批3个任务并发执行，批次间隔2秒

### 白名单过滤
- 只记录和预热4个模型组：
  - `gemini-3-flash`
  - `claude-sonnet-4-5`
  - `gemini-3-pro-high`
  - `gemini-3-pro-image`
- 统一模型名映射：`gemini-2.5-flash` → `gemini-3-flash`

### 成功后记录
- 预热失败不记录历史
- 失败的模型可在下次触发时重试

### 手动预热遵守冷却期
- 手动预热前检查冷却期
- 过滤4小时内已预热的模型
- 前端显示跳过数量

### 日志完善
- 调度器扫描结果
- 预热任务启动/完成
- 冷却期跳过统计
- 前端 Toast 提示

## Performance (我的测试，仅参考)

| 操作 | 优化前 | 优化后 |
|------|--------|--------|
| 筛选10账号 | ~15秒 | ~3秒 |
| 预热40任务 | ~80秒 | ~28秒 |

同时，这种级别的并发速率理论不会触发任何RateLimit或Google的检测。

## Files Changed

- `src-tauri/src/commands/mod.rs` - 移除刷新时的预热触发
- `src-tauri/src/modules/scheduler.rs` - 冷却期、持久化、并发、白名单
- `src-tauri/src/modules/quota.rs` - 手动预热冷却期检查、并发筛选

## Data File

**路径**: `~/.antigravity_tools/warmup_history.json`

**格式**:
```json
{
  "email@gmail.com:gemini-3-flash:100": 1736820400,
  "email@gmail.com:claude-sonnet-4-5:100": 1736820450
}
```

## Testing

1. 删除 `warmup_history.json`
2. 启动程序，观察调度器扫描日志
3. 点击手动预热，确认前端 Toast 显示
4. 立即再次预热，应提示冷却期跳过
5. 检查 JSON 文件格式正确
6. 重启程序，再次预热，应仍受冷却期限制
