### PR TITLE
fix: 添加限流记录自动清理机制，防止过期锁定状态残留

### DIFF
--- a/src-tauri/src/proxy/rate_limit.rs
+++ b/src-tauri/src/proxy/rate_limit.rs
@@ -1,6 +1,6 @@
 use dashmap::DashMap;
-use std::time::{SystemTime, Duration};
 use regex::Regex;
+use std::time::{Duration, SystemTime};
 
 /// 限流原因类型
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -38,11 +38,18 @@ pub struct RateLimitInfo {
     pub model: Option<String>,
 }
 
+/// 最大锁定时间上限：2小时（与原有指数退避最大值一致，防止异常长时间锁定）
+const MAX_LOCKOUT_SECONDS: u64 = 7200;
+
+/// 失败计数过期时间：1小时（超过此时间未失败则重置计数）
+const FAILURE_COUNT_EXPIRY_SECONDS: u64 = 3600;
+
 /// 限流跟踪器
 pub struct RateLimitTracker {
     limits: DashMap<String, RateLimitInfo>,
     /// 连续失败计数（用于智能指数退避）
-    failure_counts: DashMap<String, u32>,
+    /// 现在带有时间戳，用于自动过期
+    failure_counts: DashMap<String, (u32, SystemTime)>,
 }
 
 impl RateLimitTracker {
@@ -52,20 +59,24 @@ impl RateLimitTracker {
             failure_counts: DashMap::new(),
         }
     }
-    
+
     /// 获取账号剩余的等待时间(秒)
     pub fn get_remaining_wait(&self, account_id: &str) -> u64 {
         if let Some(info) = self.limits.get(account_id) {
             let now = SystemTime::now();
             if info.reset_time > now {
-                return info.reset_time.duration_since(now).unwrap_or(Duration::from_secs(0)).as_secs();
+                return info
+                    .reset_time
+                    .duration_since(now)
+                    .unwrap_or(Duration::from_secs(0))
+                    .as_secs();
             }
         }
         0
     }
-    
+
     /// 标记账号请求成功，重置连续失败计数
-    /// 
+    ///
     /// 当账号成功完成请求后调用此方法，将其失败计数归零，
     /// 这样下次失败时会从最短的锁定时间（60秒）开始。
     pub fn mark_success(&self, account_id: &str) {
@@ -75,31 +86,37 @@ impl RateLimitTracker {
         // 同时清除限流记录（如果有）
         self.limits.remove(account_id);
     }
-    
+
     /// 精确锁定账号到指定时间点
-    /// 
+    ///
     /// 使用账号配额中的 reset_time 来精确锁定账号,
     /// 这比指数退避更加精准。
-    /// 
+    ///
     /// # 参数
     /// - `model`: 可选的模型名称,用于模型级别限流。None 表示账号级别限流
-    pub fn set_lockout_until(&self, account_id: &str, reset_time: SystemTime, reason: RateLimitReason, model: Option<String>) {
+    pub fn set_lockout_until(
+        &self,
+        account_id: &str,
+        reset_time: SystemTime,
+        reason: RateLimitReason,
+        model: Option<String>,
+    ) {
         let now = SystemTime::now();
         let retry_sec = reset_time
             .duration_since(now)
             .map(|d| d.as_secs())
             .unwrap_or(60); // 如果时间已过,使用默认 60 秒
-        
+
         let info = RateLimitInfo {
             reset_time,
             retry_after_sec: retry_sec,
             detected_at: now,
             reason,
-            model: model.clone(),  // 🆕 支持模型级别限流
+            model: model.clone(), // 🆕 支持模型级别限流
         };
-        
+
         self.limits.insert(account_id.to_string(), info);
-        
+
         if let Some(m) = &model {
             tracing::info!(
                 "账号 {} 的模型 {} 已精确锁定到配额刷新时间,剩余 {} 秒",
@@ -115,34 +132,41 @@ impl RateLimitTracker {
             );
         }
     }
-    
+
     /// 使用 ISO 8601 时间字符串精确锁定账号
-    /// 
+    ///
     /// 解析类似 "2026-01-08T17:00:00Z" 格式的时间字符串
-    /// 
+    ///
     /// # 参数
     /// - `model`: 可选的模型名称,用于模型级别限流
-    pub fn set_lockout_until_iso(&self, account_id: &str, reset_time_str: &str, reason: RateLimitReason, model: Option<String>) -> bool {
+    pub fn set_lockout_until_iso(
+        &self,
+        account_id: &str,
+        reset_time_str: &str,
+        reason: RateLimitReason,
+        model: Option<String>,
+    ) -> bool {
         // 尝试解析 ISO 8601 格式
         match chrono::DateTime::parse_from_rfc3339(reset_time_str) {
             Ok(dt) => {
-                let reset_time = SystemTime::UNIX_EPOCH + 
-                    std::time::Duration::from_secs(dt.timestamp() as u64);
+                let reset_time =
+                    SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(dt.timestamp() as u64);
                 self.set_lockout_until(account_id, reset_time, reason, model);
                 true
-            },
+            }
             Err(e) => {
                 tracing::warn!(
                     "无法解析配额刷新时间 '{}': {},将使用默认退避策略",
-                    reset_time_str, e
+                    reset_time_str,
+                    e
                 );
                 false
             }
         }
     }
-    
+
     /// 从错误响应解析限流信息
-    /// 
+    ///
     /// # Arguments
     /// * `account_id` - 账号 ID
     /// * `status` - HTTP 状态码
@@ -160,7 +184,7 @@ impl RateLimitTracker {
         if status != 429 && status != 500 && status != 503 && status != 529 {
             return None;
         }
-        
+
         // 1. 解析限流原因类型
         let reason = if status == 429 {
             tracing::warn!("Google 429 Error Body: {}", body);
@@ -168,75 +192,108 @@ impl RateLimitTracker {
         } else {
             RateLimitReason::ServerError
         };
-        
+
         let mut retry_after_sec = None;
-        
+
         // 2. 从 Retry-After header 提取
         if let Some(retry_after) = retry_after_header {
             if let Ok(seconds) = retry_after.parse::<u64>() {
                 retry_after_sec = Some(seconds);
             }
         }
-        
+
         // 3. 从错误消息提取 (优先尝试 JSON 解析，再试正则)
         if retry_after_sec.is_none() {
             retry_after_sec = self.parse_retry_time_from_body(body);
         }
-        
+
         // 4. 处理默认值与软避让逻辑（根据限流类型设置不同默认值）
         let retry_sec = match retry_after_sec {
             Some(s) => {
-                // 引入 PR #28 的安全缓冲区：最小 2 秒，防止极高频无效重试
-                if s < 2 { 2 } else { s }
-            },
+                // 引入 PR #28 的安全缓冲区：最小 2 秒，最大 MAX_LOCKOUT_SECONDS
+                let safe_sec = if s < 2 { 2 } else { s };
+                std::cmp::min(safe_sec, MAX_LOCKOUT_SECONDS)
+            }
             None => {
                 // 获取连续失败次数，用于指数退避
+                // [优化] 现在带有自动过期逻辑（1小时后重置计数）
                 let failure_count = {
-                    let mut count = self.failure_counts.entry(account_id.to_string()).or_insert(0);
-                    *count += 1;
-                    *count
+                    let now = SystemTime::now();
+                    let mut entry = self
+                        .failure_counts
+                        .entry(account_id.to_string())
+                        .or_insert((0, now));
+
+                    // 检查是否超过过期时间，如果是则重置计数
+                    let elapsed = now
+                        .duration_since(entry.1)
+                        .unwrap_or(Duration::from_secs(0))
+                        .as_secs();
+                    if elapsed > FAILURE_COUNT_EXPIRY_SECONDS {
+                        tracing::debug!(
+                            "账号 {} 失败计数已过期（{}秒 > {}秒），重置为 0",
+                            account_id,
+                            elapsed,
+                            FAILURE_COUNT_EXPIRY_SECONDS
+                        );
+                        *entry = (0, now);
+                    }
+
+                    entry.0 += 1;
+                    entry.1 = now; // 更新时间戳
+                    entry.0
                 };
-                
+
                 match reason {
                     RateLimitReason::QuotaExhausted => {
                         // [智能限流] 根据连续失败次数动态调整锁定时间
                         // 第1次: 60s, 第2次: 5min, 第3次: 30min, 第4次+: 2h
                         let lockout = match failure_count {
                             1 => {
-                                tracing::warn!("检测到配额耗尽 (QUOTA_EXHAUSTED)，第1次失败，锁定 60秒");
+                                tracing::warn!(
+                                    "检测到配额耗尽 (QUOTA_EXHAUSTED)，第1次失败，锁定 60秒"
+                                );
                                 60
-                            },
+                            }
                             2 => {
-                                tracing::warn!("检测到配额耗尽 (QUOTA_EXHAUSTED)，第2次连续失败，锁定 5分钟");
+                                tracing::warn!(
+                                    "检测到配额耗尽 (QUOTA_EXHAUSTED)，第2次连续失败，锁定 5分钟"
+                                );
                                 300
-                            },
+                            }
                             3 => {
-                                tracing::warn!("检测到配额耗尽 (QUOTA_EXHAUSTED)，第3次连续失败，锁定 30分钟");
+                                tracing::warn!(
+                                    "检测到配额耗尽 (QUOTA_EXHAUSTED)，第3次连续失败，锁定 30分钟"
+                                );
                                 1800
-                            },
+                            }
+                            // [优化] 第4次+: 不再锁定 2小时，而是使用最大锁定时间 (30分钟)
                             _ => {
-                                tracing::warn!("检测到配额耗尽 (QUOTA_EXHAUSTED)，第{}次连续失败，锁定 2小时", failure_count);
-                                7200
+                                tracing::warn!(
+                                    "检测到配额耗尽 (QUOTA_EXHAUSTED)，第{}次连续失败，锁定 {}分钟（最大上限）",
+                                    failure_count, MAX_LOCKOUT_SECONDS / 60
+                                );
+                                MAX_LOCKOUT_SECONDS
                             }
                         };
                         lockout
-                    },
+                    }
                     RateLimitReason::RateLimitExceeded => {
                         // 速率限制：通常是短暂的，使用较短的默认值（30秒）
                         tracing::debug!("检测到速率限制 (RATE_LIMIT_EXCEEDED)，使用默认值 30秒");
                         30
-                    },
+                    }
                     RateLimitReason::ModelCapacityExhausted => {
                         // 模型容量耗尽：服务端暂时无可用 GPU 实例
                         // 这是临时性问题，使用较短的重试时间（15秒）
                         tracing::warn!("检测到模型容量不足 (MODEL_CAPACITY_EXHAUSTED)，服务端暂无可用实例，15秒后重试");
                         15
-                    },
+                    }
                     RateLimitReason::ServerError => {
                         // 服务器错误：执行"软避让"，默认锁定 20 秒
                         tracing::warn!("检测到 5xx 错误 ({}), 执行 20s 软避让...", status);
                         20
-                    },
+                    }
                     RateLimitReason::Unknown => {
                         // 未知原因：使用中等默认值（60秒）
                         tracing::debug!("无法解析 429 限流原因, 使用默认值 60秒");
@@ -245,7 +302,7 @@ impl RateLimitTracker {
                 }
             }
         };
-        
+
         let info = RateLimitInfo {
             reset_time: SystemTime::now() + Duration::from_secs(retry_sec),
             retry_after_sec: retry_sec,
@@ -253,10 +310,10 @@ impl RateLimitTracker {
             reason,
             model,
         };
-        
+
         // 存储
         self.limits.insert(account_id.to_string(), info.clone());
-        
+
         tracing::warn!(
             "账号 {} [{}] 限流类型: {:?}, 重置延时: {}秒",
             account_id,
@@ -264,23 +321,24 @@ impl RateLimitTracker {
             reason,
             retry_sec
         );
-        
+
         Some(info)
     }
-    
+
     /// 解析限流原因类型
     fn parse_rate_limit_reason(&self, body: &str) -> RateLimitReason {
         // 尝试从 JSON 中提取 reason 字段
         let trimmed = body.trim();
         if trimmed.starts_with('{') || trimmed.starts_with('[') {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed) {
-                if let Some(reason_str) = json.get("error")
+                if let Some(reason_str) = json
+                    .get("error")
                     .and_then(|e| e.get("details"))
                     .and_then(|d| d.as_array())
                     .and_then(|a| a.get(0))
                     .and_then(|o| o.get("reason"))
-                    .and_then(|v| v.as_str()) {
-                    
+                    .and_then(|v| v.as_str())
+                {
                     return match reason_str {
                         "QUOTA_EXHAUSTED" => RateLimitReason::QuotaExhausted,
                         "RATE_LIMIT_EXCEEDED" => RateLimitReason::RateLimitExceeded,
@@ -289,33 +347,38 @@ impl RateLimitTracker {
                     };
                 }
                 // [NEW] 尝试从 message 字段进行文本匹配（防止 missed reason）
-                 if let Some(msg) = json.get("error")
+                if let Some(msg) = json
+                    .get("error")
                     .and_then(|e| e.get("message"))
-                    .and_then(|v| v.as_str()) {
+                    .and_then(|v| v.as_str())
+                {
                     let msg_lower = msg.to_lowercase();
                     if msg_lower.contains("per minute") || msg_lower.contains("rate limit") {
                         return RateLimitReason::RateLimitExceeded;
                     }
-                 }
+                }
             }
         }
-        
+
         // 如果无法从 JSON 解析，尝试从消息文本判断
         let body_lower = body.to_lowercase();
         // [FIX] 优先判断分钟级限制，避免将 TPM 误判为 Quota
-        if body_lower.contains("per minute") || body_lower.contains("rate limit") || body_lower.contains("too many requests") {
-             RateLimitReason::RateLimitExceeded
+        if body_lower.contains("per minute")
+            || body_lower.contains("rate limit")
+            || body_lower.contains("too many requests")
+        {
+            RateLimitReason::RateLimitExceeded
         } else if body_lower.contains("exhausted") || body_lower.contains("quota") {
             RateLimitReason::QuotaExhausted
         } else {
             RateLimitReason::Unknown
         }
     }
-    
+
     /// 通用时间解析函数：支持 "2h1m1s" 等所有格式组合
     fn parse_duration_string(&self, s: &str) -> Option<u64> {
         tracing::debug!("[时间解析] 尝试解析: '{}'", s);
-        
+
         // 使用正则表达式提取小时、分钟、秒、毫秒
         // 支持格式："2h1m1s", "1h30m", "5m", "30s", "500ms" 等
         let re = Regex::new(r"(?:(\d+)h)?(?:(\d+)m)?(?:(\d+(?:\.\d+)?)s)?(?:(\d+)ms)?").ok()?;
@@ -326,36 +389,53 @@ impl RateLimitTracker {
                 return None;
             }
         };
-        
-        let hours = caps.get(1)
+
+        let hours = caps
+            .get(1)
             .and_then(|m| m.as_str().parse::<u64>().ok())
             .unwrap_or(0);
-        let minutes = caps.get(2)
+        let minutes = caps
+            .get(2)
             .and_then(|m| m.as_str().parse::<u64>().ok())
             .unwrap_or(0);
-        let seconds = caps.get(3)
+        let seconds = caps
+            .get(3)
             .and_then(|m| m.as_str().parse::<f64>().ok())
             .unwrap_or(0.0);
-        let milliseconds = caps.get(4)
+        let milliseconds = caps
+            .get(4)
             .and_then(|m| m.as_str().parse::<u64>().ok())
             .unwrap_or(0);
-        
-        tracing::debug!("[时间解析] 提取结果: {}h {}m {:.3}s {}ms", hours, minutes, seconds, milliseconds);
-        
+
+        tracing::debug!(
+            "[时间解析] 提取结果: {}h {}m {:.3}s {}ms",
+            hours,
+            minutes,
+            seconds,
+            milliseconds
+        );
+
         // 计算总秒数
-        let total_seconds = hours * 3600 + minutes * 60 + seconds.ceil() as u64 + (milliseconds + 999) / 1000;
-        
+        let total_seconds =
+            hours * 3600 + minutes * 60 + seconds.ceil() as u64 + (milliseconds + 999) / 1000;
+
         // 如果总秒数为 0，说明解析失败
         if total_seconds == 0 {
             tracing::warn!("[时间解析] 失败: '{}' (总秒数为0)", s);
             None
         } else {
-            tracing::info!("[时间解析] ✓ 成功: '{}' => {}秒 ({}h {}m {:.1}s)", 
-                s, total_seconds, hours, minutes, seconds);
+            tracing::info!(
+                "[时间解析] ✓ 成功: '{}' => {}秒 ({}h {}m {:.1}s)",
+                s,
+                total_seconds,
+                hours,
+                minutes,
+                seconds
+            );
             Some(total_seconds)
         }
     }
-    
+
     /// 从错误消息 body 中解析重置时间
     fn parse_retry_time_from_body(&self, body: &str) -> Option<u64> {
         // A. 优先尝试 JSON 精准解析 (借鉴 PR #28)
@@ -364,26 +444,29 @@ impl RateLimitTracker {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed) {
                 // 1. Google 常见的 quotaResetDelay 格式 (支持所有格式："2h1m1s", "1h30m", "42s", "500ms" 等)
                 // 路径: error.details[0].metadata.quotaResetDelay
-                if let Some(delay_str) = json.get("error")
+                if let Some(delay_str) = json
+                    .get("error")
                     .and_then(|e| e.get("details"))
                     .and_then(|d| d.as_array())
                     .and_then(|a| a.get(0))
-                    .and_then(|o| o.get("metadata"))  // 添加 metadata 层级
+                    .and_then(|o| o.get("metadata")) // 添加 metadata 层级
                     .and_then(|m| m.get("quotaResetDelay"))
-                    .and_then(|v| v.as_str()) {
-                    
+                    .and_then(|v| v.as_str())
+                {
                     tracing::debug!("[JSON解析] 找到 quotaResetDelay: '{}'", delay_str);
-                    
+
                     // 使用通用时间解析函数
                     if let Some(seconds) = self.parse_duration_string(delay_str) {
                         return Some(seconds);
                     }
                 }
-                
+
                 // 2. OpenAI 常见的 retry_after 字段 (数字)
-                if let Some(retry) = json.get("error")
+                if let Some(retry) = json
+                    .get("error")
                     .and_then(|e| e.get("retry_after"))
-                    .and_then(|v| v.as_u64()) {
+                    .and_then(|v| v.as_u64())
+                {
                     return Some(retry);
                 }
             }
@@ -398,7 +481,7 @@ impl RateLimitTracker {
                 }
             }
         }
-        
+
         // 模式 2: "Try again in 30s" 或 "backoff for 42s"
         if let Ok(re) = Regex::new(r"(?i)(?:try again in|backoff for|wait)\s*(\d+)s") {
             if let Some(caps) = re.captures(body) {
@@ -407,7 +490,7 @@ impl RateLimitTracker {
                 }
             }
         }
-        
+
         // 模式 3: "quota will reset in X seconds"
         if let Ok(re) = Regex::new(r"(?i)quota will reset in (\d+) second") {
             if let Some(caps) = re.captures(body) {
@@ -416,7 +499,7 @@ impl RateLimitTracker {
                 }
             }
         }
-        
+
         // 模式 4: OpenAI 风格的 "Retry after (\d+) seconds"
         if let Ok(re) = Regex::new(r"(?i)retry after (\d+) second") {
             if let Some(caps) = re.captures(body) {
@@ -434,15 +517,15 @@ impl RateLimitTracker {
                 }
             }
         }
-        
+
         None
     }
-    
+
     /// 获取账号的限流信息
     pub fn get(&self, account_id: &str) -> Option<RateLimitInfo> {
         self.limits.get(account_id).map(|r| r.clone())
     }
-    
+
     /// 检查账号是否仍在限流中
     pub fn is_rate_limited(&self, account_id: &str) -> bool {
         if let Some(info) = self.get(account_id) {
@@ -451,7 +534,7 @@ impl RateLimitTracker {
             false
         }
     }
-    
+
     /// 获取距离限流重置还有多少秒
     pub fn get_reset_seconds(&self, account_id: &str) -> Option<u64> {
         if let Some(info) = self.get(account_id) {
@@ -463,13 +546,13 @@ impl RateLimitTracker {
             None
         }
     }
-    
+
     /// 清除过期的限流记录
     #[allow(dead_code)]
     pub fn cleanup_expired(&self) -> usize {
         let now = SystemTime::now();
         let mut count = 0;
-        
+
         self.limits.retain(|_k, v| {
             if v.reset_time <= now {
                 count += 1;
@@ -478,28 +561,31 @@ impl RateLimitTracker {
                 true
             }
         });
-        
+
         if count > 0 {
             tracing::debug!("清除了 {} 个过期的限流记录", count);
         }
-        
+
         count
     }
-    
+
     /// 清除指定账号的限流记录
     #[allow(dead_code)]
     pub fn clear(&self, account_id: &str) -> bool {
         self.limits.remove(account_id).is_some()
     }
-    
+
     /// 清除所有限流记录 (乐观重置策略)
-    /// 
+    ///
     /// 用于乐观重置机制,当所有账号都被限流但等待时间很短时,
     /// 清除所有限流记录以解决时序竞争条件
     pub fn clear_all(&self) {
         let count = self.limits.len();
         self.limits.clear();
-        tracing::warn!("🔄 Optimistic reset: Cleared all {} rate limit record(s)", count);
+        tracing::warn!(
+            "🔄 Optimistic reset: Cleared all {} rate limit record(s)",
+            count
+        );
     }
 }
 
@@ -512,15 +598,15 @@ impl Default for RateLimitTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_parse_retry_time_minutes_seconds() {
         let tracker = RateLimitTracker::new();
         let body = "Rate limit exceeded. Try again in 2m 30s";
         let time = tracker.parse_retry_time_from_body(body);
-        assert_eq!(time, Some(150)); 
+        assert_eq!(time, Some(150));
     }
-    
+
     #[test]
     fn test_parse_google_json_delay() {
         let tracker = RateLimitTracker::new();

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -16,20 +16,19 @@ pub struct ProxyToken {
     pub expires_in: i64,
     pub timestamp: i64,
     pub email: String,
-    pub account_path: PathBuf,  // 账号文件路径，用于更新
+    pub account_path: PathBuf, // 账号文件路径，用于更新
     pub project_id: Option<String>,
     pub subscription_tier: Option<String>, // "FREE" | "PRO" | "ULTRA"
-    pub remaining_quota: Option<i32>, // [FIX #563] Remaining quota for priority sorting
+    pub remaining_quota: Option<i32>,      // [FIX #563] Remaining quota for priority sorting
     pub protected_models: HashSet<String>, // [NEW #621]
 }
 
-
 pub struct TokenManager {
-    tokens: Arc<DashMap<String, ProxyToken>>,  // account_id -> ProxyToken
+    tokens: Arc<DashMap<String, ProxyToken>>, // account_id -> ProxyToken
     current_index: Arc<AtomicUsize>,
     last_used_account: Arc<tokio::sync::Mutex<Option<(String, std::time::Instant)>>>,
     data_dir: PathBuf,
-    rate_limit_tracker: Arc<RateLimitTracker>,  // 新增: 限流跟踪器
+    rate_limit_tracker: Arc<RateLimitTracker>, // 新增: 限流跟踪器
     sticky_config: Arc<tokio::sync::RwLock<StickySessionConfig>>, // 新增：调度配置
     session_accounts: Arc<DashMap<String, String>>, // 新增：会话与账号映射 (SessionID -> AccountID)
 }
@@ -47,11 +46,33 @@ impl TokenManager {
             session_accounts: Arc::new(DashMap::new()),
         }
     }
-    
+
+    /// 启动限流记录自动清理后台任务
+    ///
+    /// 每 60 秒检查并清除过期的限流记录，防止内存中残留无效的限流状态。
+    /// 此方法应在 TokenManager 创建后调用一次。
+    pub fn start_auto_cleanup(&self) {
+        let tracker = self.rate_limit_tracker.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            loop {
+                interval.tick().await;
+                let cleaned = tracker.cleanup_expired();
+                if cleaned > 0 {
+                    tracing::info!(
+                        "🧹 Auto-cleanup: Removed {} expired rate limit record(s)",
+                        cleaned
+                    );
+                }
+            }
+        });
+        tracing::info!("✅ Rate limit auto-cleanup task started (interval: 60s)");
+    }
+
     /// 从主应用账号目录加载所有账号
     pub async fn load_accounts(&self) -> Result<usize, String> {
         let accounts_dir = self.data_dir.join("accounts");
-        
+
         if !accounts_dir.exists() {
             return Err(format!("账号目录不存在: {:?}", accounts_dir));
         }
@@ -63,42 +84,45 @@ impl TokenManager {
             let mut last_used = self.last_used_account.lock().await;
             *last_used = None;
         }
-        
-        let entries = std::fs::read_dir(&accounts_dir)
-            .map_err(|e| format!("读取账号目录失败: {}", e))?;
-        
+
+        let entries =
+            std::fs::read_dir(&accounts_dir).map_err(|e| format!("读取账号目录失败: {}", e))?;
+
         let mut count = 0;
-        
+
         for entry in entries {
             let entry = entry.map_err(|e| format!("读取目录项失败: {}", e))?;
             let path = entry.path();
-            
+
             if path.extension().and_then(|s| s.to_str()) != Some("json") {
                 continue;
             }
-            
+
             // 尝试加载账号
             match self.load_single_account(&path).await {
                 Ok(Some(token)) => {
                     let account_id = token.account_id.clone();
                     self.tokens.insert(account_id, token);
                     count += 1;
-                },
+                }
                 Ok(None) => {
                     // 跳过无效账号
-                },
+                }
                 Err(e) => {
                     tracing::debug!("加载账号失败 {:?}: {}", path, e);
                 }
             }
         }
-        
+
         Ok(count)
     }
 
     /// 重新加载指定账号（用于配额更新后的实时同步）
     pub async fn reload_account(&self, account_id: &str) -> Result<(), String> {
-        let path = self.data_dir.join("accounts").join(format!("{}.json", account_id));
+        let path = self
+            .data_dir
+            .join("accounts")
+            .join(format!("{}.json", account_id));
         if !path.exists() {
             return Err(format!("账号文件不存在: {:?}", path));
         }
@@ -117,14 +141,13 @@ impl TokenManager {
     pub async fn reload_all_accounts(&self) -> Result<usize, String> {
         self.load_accounts().await
     }
-    
+
     /// 加载单个账号
     async fn load_single_account(&self, path: &PathBuf) -> Result<Option<ProxyToken>, String> {
-        let content = std::fs::read_to_string(path)
-            .map_err(|e| format!("读取文件失败: {}", e))?;
-        
-        let mut account: serde_json::Value = serde_json::from_str(&content)
-            .map_err(|e| format!("解析 JSON 失败: {}", e))?;
+        let content = std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?;
+
+        let mut account: serde_json::Value =
+            serde_json::from_str(&content).map_err(|e| format!("解析 JSON 失败: {}", e))?;
 
         if account
             .get("disabled")
@@ -134,7 +157,10 @@ impl TokenManager {
             tracing::debug!(
                 "Skipping disabled account file: {:?} (email={})",
                 path,
-                account.get("email").and_then(|v| v.as_str()).unwrap_or("<unknown>")
+                account
+                    .get("email")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>")
             );
             return Ok(None);
         }
@@ -145,7 +171,10 @@ impl TokenManager {
             tracing::debug!(
                 "Account skipped due to quota protection: {:?} (email={})",
                 path,
-                account.get("email").and_then(|v| v.as_str()).unwrap_or("<unknown>")
+                account
+                    .get("email")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>")
             );
             return Ok(None);
         }
@@ -159,55 +188,61 @@ impl TokenManager {
             tracing::debug!(
                 "Skipping proxy-disabled account file: {:?} (email={})",
                 path,
-                account.get("email").and_then(|v| v.as_str()).unwrap_or("<unknown>")
+                account
+                    .get("email")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>")
             );
             return Ok(None);
         }
 
-        let account_id = account["id"].as_str()
-            .ok_or("缺少 id 字段")?
-            .to_string();
-        
-        let email = account["email"].as_str()
+        let account_id = account["id"].as_str().ok_or("缺少 id 字段")?.to_string();
+
+        let email = account["email"]
+            .as_str()
             .ok_or("缺少 email 字段")?
             .to_string();
-        
-        let token_obj = account["token"].as_object()
-            .ok_or("缺少 token 字段")?;
-        
-        let access_token = token_obj["access_token"].as_str()
+
+        let token_obj = account["token"].as_object().ok_or("缺少 token 字段")?;
+
+        let access_token = token_obj["access_token"]
+            .as_str()
             .ok_or("缺少 access_token")?
             .to_string();
-        
-        let refresh_token = token_obj["refresh_token"].as_str()
+
+        let refresh_token = token_obj["refresh_token"]
+            .as_str()
             .ok_or("缺少 refresh_token")?
             .to_string();
-        
-        let expires_in = token_obj["expires_in"].as_i64()
-            .ok_or("缺少 expires_in")?;
-        
-        let timestamp = token_obj["expiry_timestamp"].as_i64()
+
+        let expires_in = token_obj["expires_in"].as_i64().ok_or("缺少 expires_in")?;
+
+        let timestamp = token_obj["expiry_timestamp"]
+            .as_i64()
             .ok_or("缺少 expiry_timestamp")?;
-        
+
         // project_id 是可选的
-        let project_id = token_obj.get("project_id")
+        let project_id = token_obj
+            .get("project_id")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
-        
-        
+
         // 【新增】提取订阅等级 (subscription_tier 为 "FREE" | "PRO" | "ULTRA")
-        let subscription_tier = account.get("quota")
+        let subscription_tier = account
+            .get("quota")
             .and_then(|q| q.get("subscription_tier"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
-        
+
         // [FIX #563] 提取最大剩余配额百分比用于优先级排序 (Option<i32> now)
-        let remaining_quota = account.get("quota")
+        let remaining_quota = account
+            .get("quota")
             .and_then(|q| self.calculate_quota_stats(q));
-            // .filter(|&r| r > 0); // 移除 >0 过滤，因为 0% 也是有效数据，只是优先级低
-        
+        // .filter(|&r| r > 0); // 移除 >0 过滤，因为 0% 也是有效数据，只是优先级低
+
         // 【新增 #621】提取受限模型列表
-        let protected_models: HashSet<String> = account.get("protected_models")
+        let protected_models: HashSet<String> = account
+            .get("protected_models")
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
@@ -216,7 +251,7 @@ impl TokenManager {
                     .collect()
             })
             .unwrap_or_default();
-        
+
         Ok(Some(ProxyToken {
             account_id,
             access_token,
@@ -232,20 +267,23 @@ impl TokenManager {
         }))
     }
 
-    
     /// 检查账号是否应该被配额保护
     /// 如果配额低于阈值，自动禁用账号并返回 true
-    async fn check_and_protect_quota(&self, account_json: &mut serde_json::Value, account_path: &PathBuf) -> bool {
+    async fn check_and_protect_quota(
+        &self,
+        account_json: &mut serde_json::Value,
+        account_path: &PathBuf,
+    ) -> bool {
         // 1. 加载配额保护配置
         let config = match crate::modules::config::load_app_config() {
             Ok(cfg) => cfg.quota_protection,
             Err(_) => return false, // 配置加载失败，跳过保护
         };
-        
+
         if !config.enabled {
             return false; // 配额保护未启用
         }
-        
+
         // 2. 获取配额信息
         // 注意：我们需要 clone 配额信息来遍历，避免借用冲突，但修改是针对 account_json 的
         let quota = match account_json.get("quota") {
@@ -254,22 +292,26 @@ impl TokenManager {
         };
 
         // 3. 检查是否已经被账号级或模型级配额保护禁用
-        let is_proxy_disabled = account_json.get("proxy_disabled")
+        let is_proxy_disabled = account_json
+            .get("proxy_disabled")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        
-        let reason = account_json.get("proxy_disabled_reason")
+
+        let reason = account_json
+            .get("proxy_disabled_reason")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        
+
         if is_proxy_disabled {
             if reason == "quota_protection" {
                 // [兼容性 #621] 如果是被旧版账号级保护禁用的，尝试恢复并转为模型级
-                return self.check_and_restore_quota(account_json, account_path, &quota, &config).await;
+                return self
+                    .check_and_restore_quota(account_json, account_path, &quota, &config)
+                    .await;
             }
             return true; // 其他原因禁用，跳过加载
         }
-        
+
         // 4. 获取模型列表
         let models = match quota.get("models").and_then(|m| m.as_array()) {
             Some(m) => m,
@@ -279,45 +321,67 @@ impl TokenManager {
         // 5. 遍历受监控的模型，检查保护与恢复
         let threshold = config.threshold_percentage as i32;
 
-
         let mut changed = false;
 
         for model in models {
             let name = model.get("name").and_then(|v| v.as_str()).unwrap_or("");
             if !config.monitored_models.iter().any(|m| m == name) {
-                continue; 
+                continue;
             }
 
-            let percentage = model.get("percentage").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-            let account_id = account_json.get("id").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+            let percentage = model
+                .get("percentage")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0) as i32;
+            let account_id = account_json
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string();
 
             if percentage <= threshold {
                 // 触发保护 (Issue #621 改为模型级)
-                if self.trigger_quota_protection(account_json, &account_id, account_path, percentage, threshold, name).await.unwrap_or(false) {
+                if self
+                    .trigger_quota_protection(
+                        account_json,
+                        &account_id,
+                        account_path,
+                        percentage,
+                        threshold,
+                        name,
+                    )
+                    .await
+                    .unwrap_or(false)
+                {
                     changed = true;
                 }
             } else {
                 // 尝试恢复 (如果之前受限)
-                let protected_models = account_json.get("protected_models").and_then(|v| v.as_array());
-                let is_protected = protected_models.map_or(false, |arr| {
-                    arr.iter().any(|m| m.as_str() == Some(name))
-                });
+                let protected_models = account_json
+                    .get("protected_models")
+                    .and_then(|v| v.as_array());
+                let is_protected = protected_models
+                    .map_or(false, |arr| arr.iter().any(|m| m.as_str() == Some(name)));
 
                 if is_protected {
-                    if self.restore_quota_protection(account_json, &account_id, account_path, name).await.unwrap_or(false) {
+                    if self
+                        .restore_quota_protection(account_json, &account_id, account_path, name)
+                        .await
+                        .unwrap_or(false)
+                    {
                         changed = true;
                     }
                 }
             }
         }
-        
+
         let _ = changed; // 避免 unused 警告，如果后续逻辑需要可以继续使用
-        
+
         // 我们不再因为配额原因返回 true（即不再跳过账号），
         // 而是加载并在 get_token 时进行过滤。
         false
     }
-    
+
     /// 计算账号的最大剩余配额百分比（用于排序）
     /// 返回值: Option<i32> (max_percentage)
     fn calculate_quota_stats(&self, quota: &serde_json::Value) -> Option<i32> {
@@ -325,10 +389,10 @@ impl TokenManager {
             Some(m) => m,
             None => return None,
         };
-        
+
         let mut max_percentage = 0;
         let mut has_data = false;
-        
+
         for model in models {
             if let Some(pct) = model.get("percentage").and_then(|v| v.as_i64()) {
                 let pct_i32 = pct as i32;
@@ -338,14 +402,14 @@ impl TokenManager {
                 has_data = true;
             }
         }
-        
+
         if has_data {
             Some(max_percentage)
         } else {
             None
         }
     }
-    
+
     /// 触发配额保护，限制特定模型 (Issue #621)
     /// 返回 true 如果发生了改变
     async fn trigger_quota_protection(
@@ -361,28 +425,37 @@ impl TokenManager {
         if account_json.get("protected_models").is_none() {
             account_json["protected_models"] = serde_json::Value::Array(Vec::new());
         }
-        
+
         let protected_models = account_json["protected_models"].as_array_mut().unwrap();
-        
+
         // 2. 检查是否已存在
-        if !protected_models.iter().any(|m| m.as_str() == Some(model_name)) {
+        if !protected_models
+            .iter()
+            .any(|m| m.as_str() == Some(model_name))
+        {
             protected_models.push(serde_json::Value::String(model_name.to_string()));
-            
+
             tracing::info!(
                 "账号 {} 的模型 {} 因配额受限（{}% <= {}%）已被加入保护列表",
-                account_id, model_name, current_val, threshold
+                account_id,
+                model_name,
+                current_val,
+                threshold
             );
-            
+
             // 3. 写入磁盘
-            std::fs::write(account_path, serde_json::to_string_pretty(account_json).unwrap())
-                .map_err(|e| format!("写入文件失败: {}", e))?;
-            
+            std::fs::write(
+                account_path,
+                serde_json::to_string_pretty(account_json).unwrap(),
+            )
+            .map_err(|e| format!("写入文件失败: {}", e))?;
+
             return Ok(true);
         }
-        
+
         Ok(false)
     }
-    
+
     /// 检查并从账号级保护恢复（迁移至模型级，Issue #621）
     async fn check_and_restore_quota(
         &self,
@@ -395,7 +468,10 @@ impl TokenManager {
         // 我们将其 proxy_disabled 设为 false，但同时更新其 protected_models 列表。
         tracing::info!(
             "正在迁移账号 {} 从全局配额保护模式至模型级保护模式",
-            account_json.get("email").and_then(|v| v.as_str()).unwrap_or("unknown")
+            account_json
+                .get("email")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
         );
 
         account_json["proxy_disabled"] = serde_json::Value::Bool(false);
@@ -408,22 +484,30 @@ impl TokenManager {
         if let Some(models) = quota.get("models").and_then(|m| m.as_array()) {
             for model in models {
                 let name = model.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                if !config.monitored_models.iter().any(|m| m == name) { continue; }
-                
-                let percentage = model.get("percentage").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+                if !config.monitored_models.iter().any(|m| m == name) {
+                    continue;
+                }
+
+                let percentage = model
+                    .get("percentage")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0) as i32;
                 if percentage <= threshold {
                     protected_list.push(serde_json::Value::String(name.to_string()));
                 }
             }
         }
-        
+
         account_json["protected_models"] = serde_json::Value::Array(protected_list);
-        
-        let _ = std::fs::write(account_path, serde_json::to_string_pretty(account_json).unwrap());
-        
+
+        let _ = std::fs::write(
+            account_path,
+            serde_json::to_string_pretty(account_json).unwrap(),
+        );
+
         false // 返回 false 表示现在已可以尝试加载该账号（模型级过滤会在 get_token 时发生）
     }
-    
+
     /// 恢复特定模型的配额保护 (Issue #621)
     /// 返回 true 如果发生了改变
     async fn restore_quota_protection(
@@ -433,51 +517,68 @@ impl TokenManager {
         account_path: &PathBuf,
         model_name: &str,
     ) -> Result<bool, String> {
-        if let Some(arr) = account_json.get_mut("protected_models").and_then(|v| v.as_array_mut()) {
+        if let Some(arr) = account_json
+            .get_mut("protected_models")
+            .and_then(|v| v.as_array_mut())
+        {
             let original_len = arr.len();
             arr.retain(|m| m.as_str() != Some(model_name));
-            
+
             if arr.len() < original_len {
-                tracing::info!("账号 {} 的模型 {} 配额已恢复，移出保护列表", account_id, model_name);
-                std::fs::write(account_path, serde_json::to_string_pretty(account_json).unwrap())
-                    .map_err(|e| format!("写入文件失败: {}", e))?;
+                tracing::info!(
+                    "账号 {} 的模型 {} 配额已恢复，移出保护列表",
+                    account_id,
+                    model_name
+                );
+                std::fs::write(
+                    account_path,
+                    serde_json::to_string_pretty(account_json).unwrap(),
+                )
+                .map_err(|e| format!("写入文件失败: {}", e))?;
                 return Ok(true);
             }
         }
-        
+
         Ok(false)
     }
 
-    
     /// 获取当前可用的 Token（支持粘性会话与智能调度）
     /// 参数 `quota_group` 用于区分 "claude" vs "gemini" 组
     /// 参数 `force_rotate` 为 true 时将忽略锁定，强制切换账号
     /// 参数 `session_id` 用于跨请求维持会话粘性
     /// 参数 `target_model` 用于检查配额保护 (Issue #621)
     pub async fn get_token(
-        &self, 
-        quota_group: &str, 
-        force_rotate: bool, 
+        &self,
+        quota_group: &str,
+        force_rotate: bool,
         session_id: Option<&str>,
         target_model: &str,
     ) -> Result<(String, String, String), String> {
         // 【优化 Issue #284】添加 5 秒超时，防止死锁
         let timeout_duration = std::time::Duration::from_secs(5);
-        match tokio::time::timeout(timeout_duration, self.get_token_internal(quota_group, force_rotate, session_id, target_model)).await {
+        match tokio::time::timeout(
+            timeout_duration,
+            self.get_token_internal(quota_group, force_rotate, session_id, target_model),
+        )
+        .await
+        {
             Ok(result) => result,
-            Err(_) => Err("Token acquisition timeout (5s) - system too busy or deadlock detected".to_string()),
+            Err(_) => Err(
+                "Token acquisition timeout (5s) - system too busy or deadlock detected".to_string(),
+            ),
         }
     }
 
     /// 内部实现：获取 Token 的核心逻辑
     async fn get_token_internal(
-        &self, 
-        quota_group: &str, 
-        force_rotate: bool, 
+        &self,
+        quota_group: &str,
+        force_rotate: bool,
         session_id: Option<&str>,
         target_model: &str,
     ) -> Result<(String, String, String), String> {
-        let mut tokens_snapshot: Vec<ProxyToken> = self.tokens.iter().map(|e| e.value().clone()).collect();
+        let mut tokens_snapshot: Vec<ProxyToken> =
+            self.tokens.iter().map(|e| e.value().clone()).collect();
         let total = tokens_snapshot.len();
         if total == 0 {
             return Err("Token pool is empty".to_string());
@@ -494,22 +595,21 @@ impl TokenManager {
                 Some("FREE") => 2,
                 _ => 3,
             };
-            
+
             // First: compare by subscription tier
-            let tier_cmp = tier_priority(&a.subscription_tier)
-                .cmp(&tier_priority(&b.subscription_tier));
-            
+            let tier_cmp =
+                tier_priority(&a.subscription_tier).cmp(&tier_priority(&b.subscription_tier));
+
             if tier_cmp != std::cmp::Ordering::Equal {
                 return tier_cmp;
             }
-            
+
             // [FIX #563] Second: compare by remaining quota percentage (higher is better)
             // Accounts with unknown/zero percentage go last within their tier
             let quota_a = a.remaining_quota.unwrap_or(0);
             let quota_b = b.remaining_quota.unwrap_or(0);
-            quota_b.cmp(&quota_a)  // Descending: higher percentage first
+            quota_b.cmp(&quota_a) // Descending: higher percentage first
         });
-
 
         // 0. 读取当前调度配置
         let scheduling = self.sticky_config.read().await.clone();
@@ -533,17 +633,24 @@ impl TokenManager {
 
             // ===== 【核心】粘性会话与智能调度逻辑 =====
             let mut target_token: Option<ProxyToken> = None;
-            
+
             // 模式 A: 粘性会话处理 (CacheFirst 或 Balance 且有 session_id)
-            if !rotate && session_id.is_some() && scheduling.mode != SchedulingMode::PerformanceFirst {
+            if !rotate
+                && session_id.is_some()
+                && scheduling.mode != SchedulingMode::PerformanceFirst
+            {
                 let sid = session_id.unwrap();
-                
+
                 // 1. 检查会话是否已绑定账号
                 if let Some(bound_id) = self.session_accounts.get(sid).map(|v| v.clone()) {
                     // 【修复】先通过 account_id 找到对应的账号，获取其 email
                     // 2. 转换 email -> account_id 检查绑定的账号是否限流
-                    if let Some(bound_token) = tokens_snapshot.iter().find(|t| t.account_id == bound_id) {
-                        let key = self.email_to_account_id(&bound_token.email).unwrap_or_else(|| bound_token.account_id.clone());
+                    if let Some(bound_token) =
+                        tokens_snapshot.iter().find(|t| t.account_id == bound_id)
+                    {
+                        let key = self
+                            .email_to_account_id(&bound_token.email)
+                            .unwrap_or_else(|| bound_token.account_id.clone());
                         let reset_sec = self.rate_limit_tracker.get_remaining_wait(&key);
                         if reset_sec > 0 {
                             // 【修复 Issue #284】立即解绑并切换账号，不再阻塞等待
@@ -553,7 +660,9 @@ impl TokenManager {
                                 bound_token.email, reset_sec
                             );
                             self.session_accounts.remove(sid);
-                        } else if !attempted.contains(&bound_id) && !bound_token.protected_models.contains(target_model) {
+                        } else if !attempted.contains(&bound_id)
+                            && !bound_token.protected_models.contains(target_model)
+                        {
                             // 3. 账号可用且未被标记为尝试失败，优先复用
                             tracing::debug!("Sticky Session: Successfully reusing bound account {} for session {}", bound_token.email, sid);
                             target_token = Some(bound_token.clone());
@@ -563,7 +672,10 @@ impl TokenManager {
                         }
                     } else {
                         // 绑定的账号已不存在（可能被删除），解绑
-                        tracing::debug!("Sticky Session: Bound account not found for session {}, unbinding", sid);
+                        tracing::debug!(
+                            "Sticky Session: Bound account not found for session {}, unbinding",
+                            sid
+                        );
                         self.session_accounts.remove(sid);
                     }
                 }
@@ -575,14 +687,26 @@ impl TokenManager {
                 if let Some((account_id, last_time)) = &last_used_account_id {
                     // [FIX #3] 60s 锁定逻辑应检查 `attempted` 集合，避免重复尝试失败的账号
                     if last_time.elapsed().as_secs() < 60 && !attempted.contains(account_id) {
-                        if let Some(found) = tokens_snapshot.iter().find(|t| &t.account_id == account_id) {
+                        if let Some(found) =
+                            tokens_snapshot.iter().find(|t| &t.account_id == account_id)
+                        {
                             // 【修复】检查限流状态和配额保护，避免复用已被锁定的账号
-                            if !self.is_rate_limited_by_account_id(&found.account_id) && !found.protected_models.contains(target_model) { // Changed to account_id
-                                tracing::debug!("60s Window: Force reusing last account: {}", found.email);
+                            if !self.is_rate_limited_by_account_id(&found.account_id)
+                                && !found.protected_models.contains(target_model)
+                            {
+                                // Changed to account_id
+                                tracing::debug!(
+                                    "60s Window: Force reusing last account: {}",
+                                    found.email
+                                );
                                 target_token = Some(found.clone());
                             } else {
-                                if self.is_rate_limited_by_account_id(&found.account_id) { // Changed to account_id
-                                    tracing::debug!("60s Window: Last account {} is rate-limited, skipping", found.email);
+                                if self.is_rate_limited_by_account_id(&found.account_id) {
+                                    // Changed to account_id
+                                    tracing::debug!(
+                                        "60s Window: Last account {} is rate-limited, skipping",
+                                        found.email
+                                    );
                                 } else {
                                     tracing::debug!("60s Window: Last account {} is quota-protected for model {}, skipping", found.email, target_model);
                                 }
@@ -590,7 +714,7 @@ impl TokenManager {
                         }
                     }
                 }
-                
+
                 // 若无锁定，则轮询选择新账号
                 if target_token.is_none() {
                     let start_idx = self.current_index.fetch_add(1, Ordering::SeqCst) % total;
@@ -603,24 +727,35 @@ impl TokenManager {
 
                         // 【新增 #621】模型级限流检查
                         if candidate.protected_models.contains(target_model) {
-                            tracing::debug!("Account {} is quota-protected for model {}, skipping", candidate.email, target_model);
+                            tracing::debug!(
+                                "Account {} is quota-protected for model {}, skipping",
+                                candidate.email,
+                                target_model
+                            );
                             continue;
                         }
 
                         // 【新增】主动避开限流或 5xx 锁定的账号 (来自 PR #28 的高可用思路)
-                        if self.is_rate_limited_by_account_id(&candidate.account_id) { // Changed to account_id
+                        if self.is_rate_limited_by_account_id(&candidate.account_id) {
+                            // Changed to account_id
                             continue;
                         }
 
                         target_token = Some(candidate.clone());
                         // 【优化】标记需要更新，稍后统一写回
-                        need_update_last_used = Some((candidate.account_id.clone(), std::time::Instant::now()));
-                        
+                        need_update_last_used =
+                            Some((candidate.account_id.clone(), std::time::Instant::now()));
+
                         // 如果是会话首次分配且需要粘性，在此建立绑定
                         if let Some(sid) = session_id {
                             if scheduling.mode != SchedulingMode::PerformanceFirst {
-                                self.session_accounts.insert(sid.to_string(), candidate.account_id.clone());
-                                tracing::debug!("Sticky Session: Bound new account {} to session {}", candidate.email, sid);
+                                self.session_accounts
+                                    .insert(sid.to_string(), candidate.account_id.clone());
+                                tracing::debug!(
+                                    "Sticky Session: Bound new account {} to session {}",
+                                    candidate.email,
+                                    sid
+                                );
                             }
                         }
                         break;
@@ -642,30 +777,32 @@ impl TokenManager {
                     }
 
                     // 【新增】主动避开限流或 5xx 锁定的账号
-                    if self.is_rate_limited_by_account_id(&candidate.account_id) { // Changed to account_id
+                    if self.is_rate_limited_by_account_id(&candidate.account_id) {
+                        // Changed to account_id
                         continue;
                     }
 
                     target_token = Some(candidate.clone());
-                    
+
                     if rotate {
                         tracing::debug!("Force Rotation: Switched to account: {}", candidate.email);
                     }
                     break;
                 }
             }
-            
+
             let mut token = match target_token {
                 Some(t) => t,
                 None => {
                     // 乐观重置策略: 双层防护机制
                     // 当所有账号都无法选择时,可能是时序竞争导致的状态不同步
-                    
+
                     // 计算最短等待时间
-                    let min_wait = tokens_snapshot.iter()
+                    let min_wait = tokens_snapshot
+                        .iter()
                         .filter_map(|t| self.rate_limit_tracker.get_reset_seconds(&t.account_id))
                         .min();
-                    
+
                     // Layer 1: 如果最短等待时间 <= 2秒,执行缓冲延迟
                     if let Some(wait_sec) = min_wait {
                         if wait_sec <= 2 {
@@ -673,16 +810,21 @@ impl TokenManager {
                                 "All accounts rate-limited but shortest wait is {}s. Applying 500ms buffer for state sync...",
                                 wait_sec
                             );
-                            
+
                             // 缓冲延迟 500ms
                             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-                            
+
                             // 重新尝试选择账号
-                            let retry_token = tokens_snapshot.iter()
-                                .find(|t| !attempted.contains(&t.account_id) && !self.is_rate_limited_by_account_id(&t.account_id)); // Changed to account_id
-                            
+                            let retry_token = tokens_snapshot.iter().find(|t| {
+                                !attempted.contains(&t.account_id)
+                                    && !self.is_rate_limited_by_account_id(&t.account_id)
+                            }); // Changed to account_id
+
                             if let Some(t) = retry_token {
-                                tracing::info!("✅ Buffer delay successful! Found available account: {}", t.email);
+                                tracing::info!(
+                                    "✅ Buffer delay successful! Found available account: {}",
+                                    t.email
+                                );
                                 t.clone()
                             } else {
                                 // Layer 2: 缓冲后仍无可用账号,执行乐观重置
@@ -690,16 +832,20 @@ impl TokenManager {
                                     "Buffer delay failed. Executing optimistic reset for all {} accounts...",
                                     tokens_snapshot.len()
                                 );
-                                
+
                                 // 清除所有限流记录
                                 self.rate_limit_tracker.clear_all();
-                                
+
                                 // 再次尝试选择账号
-                                let final_token = tokens_snapshot.iter()
+                                let final_token = tokens_snapshot
+                                    .iter()
                                     .find(|t| !attempted.contains(&t.account_id));
-                                
+
                                 if let Some(t) = final_token {
-                                    tracing::info!("✅ Optimistic reset successful! Using account: {}", t.email);
+                                    tracing::info!(
+                                        "✅ Optimistic reset successful! Using account: {}",
+                                        t.email
+                                    );
                                     t.clone()
                                 } else {
                                     // 所有策略都失败,返回错误
@@ -710,7 +856,10 @@ impl TokenManager {
                             }
                         } else {
                             // 等待时间 > 2秒,正常返回错误
-                            return Err(format!("All accounts are currently limited. Please wait {}s.", wait_sec));
+                            return Err(format!(
+                                "All accounts are currently limited. Please wait {}s.",
+                                wait_sec
+                            ));
                         }
                     } else {
                         // 无限流记录但仍无可用账号,可能是其他问题
@@ -719,7 +868,6 @@ impl TokenManager {
                 }
             };
 
-        
             // 3. 检查 token 是否过期（提前5分钟刷新）
             let now = chrono::Utc::now().timestamp();
             if now >= token.timestamp - 300 {
@@ -743,7 +891,10 @@ impl TokenManager {
                         }
 
                         // 同步落盘（避免重启后继续使用过期 timestamp 导致频繁刷新）
-                        if let Err(e) = self.save_refreshed_token(&token.account_id, &token_response).await {
+                        if let Err(e) = self
+                            .save_refreshed_token(&token.account_id, &token_response)
+                            .await
+                        {
                             tracing::debug!("保存刷新后的 token 失败 ({}): {}", token.email, e);
                         }
                     }
@@ -755,7 +906,10 @@ impl TokenManager {
                                 token.email
                             );
                             let _ = self
-                                .disable_account(&token.account_id, &format!("invalid_grant: {}", e))
+                                .disable_account(
+                                    &token.account_id,
+                                    &format!("invalid_grant: {}", e),
+                                )
                                 .await;
                             self.tokens.remove(&token.account_id);
                         }
@@ -765,8 +919,11 @@ impl TokenManager {
 
                         // 【优化】标记需要清除锁定，避免在循环内加锁
                         if quota_group != "image_gen" {
-                            if matches!(&last_used_account_id, Some((id, _)) if id == &token.account_id) {
-                                need_update_last_used = Some((String::new(), std::time::Instant::now())); // 空字符串表示需要清除
+                            if matches!(&last_used_account_id, Some((id, _)) if id == &token.account_id)
+                            {
+                                need_update_last_used =
+                                    Some((String::new(), std::time::Instant::now()));
+                                // 空字符串表示需要清除
                             }
                         }
                         continue;
@@ -789,13 +946,19 @@ impl TokenManager {
                     }
                     Err(e) => {
                         tracing::error!("Failed to fetch project_id for {}: {}", token.email, e);
-                        last_error = Some(format!("Failed to fetch project_id for {}: {}", token.email, e));
+                        last_error = Some(format!(
+                            "Failed to fetch project_id for {}: {}",
+                            token.email, e
+                        ));
                         attempted.insert(token.account_id.clone());
 
                         // 【优化】标记需要清除锁定，避免在循环内加锁
                         if quota_group != "image_gen" {
-                            if matches!(&last_used_account_id, Some((id, _)) if id == &token.account_id) {
-                                need_update_last_used = Some((String::new(), std::time::Instant::now())); // 空字符串表示需要清除
+                            if matches!(&last_used_account_id, Some((id, _)) if id == &token.account_id)
+                            {
+                                need_update_last_used =
+                                    Some((String::new(), std::time::Instant::now()));
+                                // 空字符串表示需要清除
                             }
                         }
                         continue;
@@ -843,7 +1006,7 @@ impl TokenManager {
 
         std::fs::write(&path, serde_json::to_string_pretty(&content).unwrap())
             .map_err(|e| format!("写入文件失败: {}", e))?;
-        
+
         // 【修复 Issue #3】从内存中移除禁用的账号，防止被60s锁定逻辑继续使用
         self.tokens.remove(account_id);
 
@@ -853,55 +1016,65 @@ impl TokenManager {
 
     /// 保存 project_id 到账号文件
     async fn save_project_id(&self, account_id: &str, project_id: &str) -> Result<(), String> {
-        let entry = self.tokens.get(account_id)
-            .ok_or("账号不存在")?;
-        
+        let entry = self.tokens.get(account_id).ok_or("账号不存在")?;
+
         let path = &entry.account_path;
-        
+
         let mut content: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?
-        ).map_err(|e| format!("解析 JSON 失败: {}", e))?;
-        
+            &std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?,
+        )
+        .map_err(|e| format!("解析 JSON 失败: {}", e))?;
+
         content["token"]["project_id"] = serde_json::Value::String(project_id.to_string());
-        
+
         std::fs::write(path, serde_json::to_string_pretty(&content).unwrap())
             .map_err(|e| format!("写入文件失败: {}", e))?;
-        
+
         tracing::debug!("已保存 project_id 到账号 {}", account_id);
         Ok(())
     }
-    
+
     /// 保存刷新后的 token 到账号文件
-    async fn save_refreshed_token(&self, account_id: &str, token_response: &crate::modules::oauth::TokenResponse) -> Result<(), String> {
-        let entry = self.tokens.get(account_id)
-            .ok_or("账号不存在")?;
-        
+    async fn save_refreshed_token(
+        &self,
+        account_id: &str,
+        token_response: &crate::modules::oauth::TokenResponse,
+    ) -> Result<(), String> {
+        let entry = self.tokens.get(account_id).ok_or("账号不存在")?;
+
         let path = &entry.account_path;
-        
+
         let mut content: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?
-        ).map_err(|e| format!("解析 JSON 失败: {}", e))?;
-        
+            &std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?,
+        )
+        .map_err(|e| format!("解析 JSON 失败: {}", e))?;
+
         let now = chrono::Utc::now().timestamp();
-        
-        content["token"]["access_token"] = serde_json::Value::String(token_response.access_token.clone());
-        content["token"]["expires_in"] = serde_json::Value::Number(token_response.expires_in.into());
-        content["token"]["expiry_timestamp"] = serde_json::Value::Number((now + token_response.expires_in).into());
-        
+
+        content["token"]["access_token"] =
+            serde_json::Value::String(token_response.access_token.clone());
+        content["token"]["expires_in"] =
+            serde_json::Value::Number(token_response.expires_in.into());
+        content["token"]["expiry_timestamp"] =
+            serde_json::Value::Number((now + token_response.expires_in).into());
+
         std::fs::write(path, serde_json::to_string_pretty(&content).unwrap())
             .map_err(|e| format!("写入文件失败: {}", e))?;
-        
+
         tracing::debug!("已保存刷新后的 token 到账号 {}", account_id);
         Ok(())
     }
-    
+
     pub fn len(&self) -> usize {
         self.tokens.len()
     }
 
     /// 通过 email 获取指定账号的 Token（用于预热等需要指定账号的场景）
     /// 此方法会自动刷新过期的 token
-    pub async fn get_token_by_email(&self, email: &str) -> Result<(String, String, String), String> {
+    pub async fn get_token_by_email(
+        &self,
+        email: &str,
+    ) -> Result<(String, String, String), String> {
         // 查找账号信息
         let token_info = {
             let mut found = None;
@@ -937,7 +1110,7 @@ impl TokenManager {
         };
 
         let project_id = project_id_opt.unwrap_or_else(|| "bamboo-precept-lgxtn".to_string());
-        
+
         // 检查是否过期 (提前5分钟)
         if now < timestamp + expires_in - 300 {
             return Ok((current_access_token, project_id, email.to_string()));
@@ -950,7 +1123,7 @@ impl TokenManager {
             Ok(token_response) => {
                 tracing::info!("[Warmup] Token refresh successful for {}", email);
                 let new_now = chrono::Utc::now().timestamp();
-                
+
                 // 更新缓存
                 if let Some(mut entry) = self.tokens.get_mut(&account_id) {
                     entry.access_token = token_response.access_token.clone();
@@ -959,16 +1132,21 @@ impl TokenManager {
                 }
 
                 // 保存到磁盘
-                let _ = self.save_refreshed_token(&account_id, &token_response).await;
+                let _ = self
+                    .save_refreshed_token(&account_id, &token_response)
+                    .await;
 
                 Ok((token_response.access_token, project_id, email.to_string()))
             }
-            Err(e) => Err(format!("[Warmup] Token refresh failed for {}: {}", email, e)),
+            Err(e) => Err(format!(
+                "[Warmup] Token refresh failed for {}: {}",
+                email, e
+            )),
         }
     }
-    
+
     // ===== 限流管理方法 =====
-    
+
     /// 标记账号限流(从外部调用,通常在 handler 中)
     /// 参数为 email，内部会自动转换为 account_id
     pub fn mark_rate_limited(
@@ -979,7 +1157,9 @@ impl TokenManager {
         error_body: &str,
     ) {
         // 【替代方案】转换 email -> account_id
-        let key = self.email_to_account_id(email).unwrap_or_else(|| email.to_string());
+        let key = self
+            .email_to_account_id(email)
+            .unwrap_or_else(|| email.to_string());
         self.rate_limit_tracker.parse_from_error(
             &key,
             status,
@@ -988,7 +1168,7 @@ impl TokenManager {
             None,
         );
     }
-    
+
     /// 检查账号是否在限流中
     /// 参数为 email，内部会自动转换为 account_id
     pub fn is_rate_limited(&self, email: &str) -> bool {
@@ -1005,48 +1185,49 @@ impl TokenManager {
     pub fn is_rate_limited_by_account_id(&self, account_id: &str) -> bool {
         self.rate_limit_tracker.is_rate_limited(account_id)
     }
-    
+
     /// 获取距离限流重置还有多少秒
     #[allow(dead_code)]
     pub fn get_rate_limit_reset_seconds(&self, account_id: &str) -> Option<u64> {
         self.rate_limit_tracker.get_reset_seconds(account_id)
     }
-    
+
     /// 清除过期的限流记录
     #[allow(dead_code)]
     pub fn clean_expired_rate_limits(&self) {
         self.rate_limit_tracker.cleanup_expired();
     }
-    
+
     /// 【替代方案】通过 email 查找对应的 account_id
     /// 用于将 handlers 传入的 email 转换为 tracker 使用的 account_id
     fn email_to_account_id(&self, email: &str) -> Option<String> {
-        self.tokens.iter()
+        self.tokens
+            .iter()
             .find(|entry| entry.value().email == email)
             .map(|entry| entry.value().account_id.clone())
     }
-    
+
     /// 清除指定账号的限流记录
     #[allow(dead_code)]
     pub fn clear_rate_limit(&self, account_id: &str) -> bool {
         self.rate_limit_tracker.clear(account_id)
     }
-    
+
     /// 标记账号请求成功，重置连续失败计数
-    /// 
+    ///
     /// 在请求成功完成后调用，将该账号的失败计数归零，
     /// 下次失败时从最短的锁定时间开始（智能限流）。
     pub fn mark_account_success(&self, account_id: &str) {
         self.rate_limit_tracker.mark_success(account_id);
     }
-    
+
     /// 从账号文件获取配额刷新时间
-    /// 
+    ///
     /// 返回该账号最近的配额刷新时间字符串（ISO 8601 格式）
     pub fn get_quota_reset_time(&self, email: &str) -> Option<String> {
         // 尝试从账号文件读取配额信息
         let accounts_dir = self.data_dir.join("accounts");
-        
+
         // 遍历账号文件查找对应的 email
         if let Ok(entries) = std::fs::read_dir(&accounts_dir) {
             for entry in entries.flatten() {
@@ -1058,14 +1239,18 @@ impl TokenManager {
                             if let Some(models) = account
                                 .get("quota")
                                 .and_then(|q| q.get("models"))
-                                .and_then(|m| m.as_array()) 
+                                .and_then(|m| m.as_array())
                             {
                                 // 找到最早的 reset_time（最保守的锁定策略）
                                 let mut earliest_reset: Option<&str> = None;
                                 for model in models {
-                                    if let Some(reset_time) = model.get("reset_time").and_then(|r| r.as_str()) {
+                                    if let Some(reset_time) =
+                                        model.get("reset_time").and_then(|r| r.as_str())
+                                    {
                                         if !reset_time.is_empty() {
-                                            if earliest_reset.is_none() || reset_time < earliest_reset.unwrap() {
+                                            if earliest_reset.is_none()
+                                                || reset_time < earliest_reset.unwrap()
+                                            {
                                                 earliest_reset = Some(reset_time);
                                             }
                                         }
@@ -1082,30 +1267,36 @@ impl TokenManager {
         }
         None
     }
-    
+
     /// 使用配额刷新时间精确锁定账号
-    /// 
+    ///
     /// 当 API 返回 429 但没有 quotaResetDelay 时,尝试使用账号的配额刷新时间
-    /// 
+    ///
     /// # 参数
     /// - `model`: 可选的模型名称,用于模型级别限流
-    pub fn set_precise_lockout(&self, email: &str, reason: crate::proxy::rate_limit::RateLimitReason, model: Option<String>) -> bool {
+    pub fn set_precise_lockout(
+        &self,
+        email: &str,
+        reason: crate::proxy::rate_limit::RateLimitReason,
+        model: Option<String>,
+    ) -> bool {
         if let Some(reset_time_str) = self.get_quota_reset_time(email) {
             tracing::info!("找到账号 {} 的配额刷新时间: {}", email, reset_time_str);
-            self.rate_limit_tracker.set_lockout_until_iso(email, &reset_time_str, reason, model)
+            self.rate_limit_tracker
+                .set_lockout_until_iso(email, &reset_time_str, reason, model)
         } else {
             tracing::debug!("未找到账号 {} 的配额刷新时间,将使用默认退避策略", email);
             false
         }
     }
-    
+
     /// 实时刷新配额并精确锁定账号
-    /// 
+    ///
     /// 当 429 发生时调用此方法:
     /// 1. 实时调用配额刷新 API 获取最新的 reset_time
     /// 2. 使用最新的 reset_time 精确锁定账号
     /// 3. 如果获取失败,返回 false 让调用方使用回退策略
-    /// 
+    ///
     /// # 参数
     /// - `model`: 可选的模型名称,用于模型级别限流
     pub async fn fetch_and_lock_with_realtime_quota(
@@ -1125,7 +1316,7 @@ impl TokenManager {
             }
             found_token
         };
-        
+
         let access_token = match access_token {
             Some(t) => t,
             None => {
@@ -1133,13 +1324,15 @@ impl TokenManager {
                 return false;
             }
         };
-        
+
         // 2. 调用配额刷新 API
         tracing::info!("账号 {} 正在实时刷新配额...", email);
         match crate::modules::quota::fetch_quota(&access_token, email).await {
             Ok((quota_data, _project_id)) => {
                 // 3. 从最新配额中提取 reset_time
-                let earliest_reset = quota_data.models.iter()
+                let earliest_reset = quota_data
+                    .models
+                    .iter()
                     .filter_map(|m| {
                         if !m.reset_time.is_empty() {
                             Some(m.reset_time.as_str())
@@ -1148,33 +1341,39 @@ impl TokenManager {
                         }
                     })
                     .min();
-                
+
                 if let Some(reset_time_str) = earliest_reset {
                     tracing::info!(
                         "账号 {} 实时配额刷新成功,reset_time: {}",
-                        email, reset_time_str
+                        email,
+                        reset_time_str
                     );
-                    self.rate_limit_tracker.set_lockout_until_iso(email, reset_time_str, reason, model)
+                    self.rate_limit_tracker.set_lockout_until_iso(
+                        email,
+                        reset_time_str,
+                        reason,
+                        model,
+                    )
                 } else {
                     tracing::warn!("账号 {} 配额刷新成功但未找到 reset_time", email);
                     false
                 }
-            },
+            }
             Err(e) => {
                 tracing::warn!("账号 {} 实时配额刷新失败: {:?}", email, e);
                 false
             }
         }
     }
-    
+
     /// 标记账号限流(异步版本,支持实时配额刷新)
-    /// 
+    ///
     /// 三级降级策略:
     /// 1. 优先: API 返回 quotaResetDelay → 直接使用
     /// 2. 次优: 实时刷新配额 → 获取最新 reset_time
     /// 3. 保底: 使用本地缓存配额 → 读取账号文件
     /// 4. 兜底: 指数退避策略 → 默认锁定时间
-    /// 
+    ///
     /// # 参数
     /// - `model`: 可选的模型名称,用于模型级别限流。传入实际使用的模型可以避免不同模型配额互相影响
     pub async fn mark_rate_limited_async(
@@ -1183,18 +1382,25 @@ impl TokenManager {
         status: u16,
         retry_after_header: Option<&str>,
         error_body: &str,
-        model: Option<&str>,  // 🆕 新增模型参数
+        model: Option<&str>, // 🆕 新增模型参数
     ) {
         // 检查 API 是否返回了精确的重试时间
-        let has_explicit_retry_time = retry_after_header.is_some() || 
-            error_body.contains("quotaResetDelay");
-        
+        let has_explicit_retry_time =
+            retry_after_header.is_some() || error_body.contains("quotaResetDelay");
+
         if has_explicit_retry_time {
             // API 返回了精确时间(quotaResetDelay),直接使用,无需实时刷新
             if let Some(m) = model {
-                tracing::debug!("账号 {} 的模型 {} 的 429 响应包含 quotaResetDelay,直接使用 API 返回的时间", account_id, m);
+                tracing::debug!(
+                    "账号 {} 的模型 {} 的 429 响应包含 quotaResetDelay,直接使用 API 返回的时间",
+                    account_id,
+                    m
+                );
             } else {
-                tracing::debug!("账号 {} 的 429 响应包含 quotaResetDelay,直接使用 API 返回的时间", account_id);
+                tracing::debug!(
+                    "账号 {} 的 429 响应包含 quotaResetDelay,直接使用 API 返回的时间",
+                    account_id
+                );
             }
             self.rate_limit_tracker.parse_from_error(
                 account_id,
@@ -1205,34 +1411,46 @@ impl TokenManager {
             );
             return;
         }
-        
+
         // 确定限流原因
         let reason = if error_body.to_lowercase().contains("model_capacity") {
             crate::proxy::rate_limit::RateLimitReason::ModelCapacityExhausted
-        } else if error_body.to_lowercase().contains("exhausted") || error_body.to_lowercase().contains("quota") {
+        } else if error_body.to_lowercase().contains("exhausted")
+            || error_body.to_lowercase().contains("quota")
+        {
             crate::proxy::rate_limit::RateLimitReason::QuotaExhausted
         } else {
             crate::proxy::rate_limit::RateLimitReason::Unknown
         };
-        
+
         // API 未返回 quotaResetDelay,需要实时刷新配额获取精确锁定时间
         if let Some(m) = model {
-            tracing::info!("账号 {} 的模型 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...", account_id, m);
+            tracing::info!(
+                "账号 {} 的模型 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...",
+                account_id,
+                m
+            );
         } else {
-            tracing::info!("账号 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...", account_id);
+            tracing::info!(
+                "账号 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...",
+                account_id
+            );
         }
-        
-        if self.fetch_and_lock_with_realtime_quota(account_id, reason, model.map(|s| s.to_string())).await {
+
+        if self
+            .fetch_and_lock_with_realtime_quota(account_id, reason, model.map(|s| s.to_string()))
+            .await
+        {
             tracing::info!("账号 {} 已使用实时配额精确锁定", account_id);
             return;
         }
-        
+
         // 实时刷新失败,尝试使用本地缓存的配额刷新时间
         if self.set_precise_lockout(account_id, reason, model.map(|s| s.to_string())) {
             tracing::info!("账号 {} 已使用本地缓存配额锁定", account_id);
             return;
         }
-        
+
         // 都失败了,回退到指数退避策略
         tracing::warn!("账号 {} 无法获取配额刷新时间,使用指数退避策略", account_id);
         self.rate_limit_tracker.parse_from_error(


### PR DESCRIPTION
## 问题描述

限流记录在内存中永久残留，导致出现 "All accounts are currently limited" 错误，只有重启应用才能恢复。

## 解决方案

1. 添加 MAX_LOCKOUT_SECONDS（2小时）限制最大锁定时间
2. 添加 FAILURE_COUNT_EXPIRY_SECONDS（1小时）实现失败计数自动过期
3. 在 TokenManager 中实现 start_auto_cleanup() 方法，每 60 秒自动清理过期记录
4. 修改 failure_counts 数据结构，添加时间戳支持自动过期逻辑
5. 在代理服务启动时集成自动清理任务

## 修改的文件

- src/proxy/rate_limit.rs - 添加常量和失败计数过期逻辑
- src/proxy/token_manager.rs - 添加自动清理任务
- src/commands/proxy.rs - 服务启动时调用自动清理