### PR TITLE
- 新增 HTTP API 服务器模块，提供账号列表查询、配额刷新、当前账号同步及切换等接口

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -753,3 +753,21 @@ pub async fn warm_up_all_accounts() -> Result<String, String> {
 pub async fn warm_up_account(account_id: String) -> Result<String, String> {
     modules::quota::warm_up_account(&account_id).await
 }
+
+// ============================================================================
+// HTTP API 设置命令
+// ============================================================================
+
+/// 获取 HTTP API 设置
+#[tauri::command]
+pub async fn get_http_api_settings() -> Result<crate::modules::http_api::HttpApiSettings, String> {
+    crate::modules::http_api::load_settings()
+}
+
+/// 保存 HTTP API 设置
+#[tauri::command]
+pub async fn save_http_api_settings(
+    settings: crate::modules::http_api::HttpApiSettings,
+) -> Result<(), String> {
+    crate::modules::http_api::save_settings(&settings)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,23 @@ pub fn run() {
             // 启动智能调度器
             modules::scheduler::start_scheduler(app.handle().clone());
             
+            // 启动 HTTP API 服务器（供外部程序调用，如 VS Code 插件）
+            match modules::http_api::load_settings() {
+                Ok(settings) if settings.enabled => {
+                    modules::http_api::spawn_server(settings.port);
+                    info!("HTTP API server started on port {}", settings.port);
+                }
+                Ok(_) => {
+                    info!("HTTP API server is disabled in settings");
+                }
+                Err(e) => {
+                    // 加载失败时使用默认端口
+                    error!("Failed to load HTTP API settings: {}, using default port", e);
+                    modules::http_api::spawn_server(modules::http_api::DEFAULT_PORT);
+                    info!("HTTP API server started on port {}", modules::http_api::DEFAULT_PORT);
+                }
+            }
+            
             Ok(())
         })
         .on_window_event(|window, event| {
@@ -152,6 +169,9 @@ pub fn run() {
             // 预热命令
             commands::warm_up_all_accounts,
             commands::warm_up_account,
+            // HTTP API 设置命令
+            commands::get_http_api_settings,
+            commands::save_http_api_settings,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/modules/http_api.rs
+++ b/src-tauri/src/modules/http_api.rs
@@ -1,0 +1,459 @@
+//! HTTP API 模块
+//! 提供本地 HTTP 接口供外部程序（如 VS Code 插件）调用
+//! 
+//! 端点：
+//! - GET  /health                    健康检查
+//! - GET  /accounts                  获取所有账号及配额
+//! - GET  /accounts/current          获取当前账号
+//! - POST /accounts/switch           切换账号（异步执行）
+//! - POST /accounts/refresh          刷新所有配额
+//! - POST /accounts/:id/bind-device  绑定设备指纹
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tower_http::cors::{Any, CorsLayer};
+
+use crate::modules::{account, logger};
+
+/// HTTP API 服务器默认端口
+pub const DEFAULT_PORT: u16 = 19527;
+
+// ============================================================================
+// Settings
+// ============================================================================
+
+/// HTTP API 设置
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HttpApiSettings {
+    /// 是否启用 HTTP API 服务
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    /// 监听端口
+    #[serde(default = "default_port")]
+    pub port: u16,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+fn default_port() -> u16 {
+    DEFAULT_PORT
+}
+
+impl Default for HttpApiSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            port: DEFAULT_PORT,
+        }
+    }
+}
+
+/// 加载 HTTP API 设置
+pub fn load_settings() -> Result<HttpApiSettings, String> {
+    let data_dir = crate::modules::account::get_data_dir()
+        .map_err(|e| format!("Failed to get data dir: {}", e))?;
+    let settings_path = data_dir.join("http_api_settings.json");
+
+    if !settings_path.exists() {
+        return Ok(HttpApiSettings::default());
+    }
+
+    let content = std::fs::read_to_string(&settings_path)
+        .map_err(|e| format!("Failed to read settings file: {}", e))?;
+
+    serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse settings: {}", e))
+}
+
+/// 保存 HTTP API 设置
+pub fn save_settings(settings: &HttpApiSettings) -> Result<(), String> {
+    let data_dir = crate::modules::account::get_data_dir()
+        .map_err(|e| format!("Failed to get data dir: {}", e))?;
+    let settings_path = data_dir.join("http_api_settings.json");
+
+    let content = serde_json::to_string_pretty(settings)
+        .map_err(|e| format!("Failed to serialize settings: {}", e))?;
+
+    std::fs::write(&settings_path, content)
+        .map_err(|e| format!("Failed to write settings file: {}", e))
+}
+
+/// 服务器状态
+#[derive(Clone)]
+pub struct ApiState {
+    /// 当前是否有切换操作正在进行
+    switching: Arc<RwLock<bool>>,
+}
+
+impl ApiState {
+    pub fn new() -> Self {
+        Self {
+            switching: Arc::new(RwLock::new(false)),
+        }
+    }
+}
+
+// ============================================================================
+// Response Types
+// ============================================================================
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: String,
+    version: String,
+}
+
+#[derive(Serialize)]
+struct AccountResponse {
+    id: String,
+    email: String,
+    name: Option<String>,
+    is_current: bool,
+    disabled: bool,
+    quota: Option<QuotaResponse>,
+    device_bound: bool,
+    last_used: i64,
+}
+
+#[derive(Serialize)]
+struct QuotaResponse {
+    models: Vec<ModelQuota>,
+    updated_at: Option<i64>,
+    subscription_tier: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ModelQuota {
+    name: String,
+    percentage: i32,
+    reset_time: String,
+}
+
+#[derive(Serialize)]
+struct AccountListResponse {
+    accounts: Vec<AccountResponse>,
+    current_account_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CurrentAccountResponse {
+    account: Option<AccountResponse>,
+}
+
+#[derive(Serialize)]
+struct SwitchResponse {
+    success: bool,
+    message: String,
+}
+
+#[derive(Serialize)]
+struct RefreshResponse {
+    success: bool,
+    message: String,
+    refreshed_count: usize,
+}
+
+#[derive(Serialize)]
+struct BindDeviceResponse {
+    success: bool,
+    message: String,
+    device_profile: Option<DeviceProfileResponse>,
+}
+
+#[derive(Serialize)]
+struct DeviceProfileResponse {
+    machine_id: String,
+    mac_machine_id: String,
+    dev_device_id: String,
+    sqm_id: String,
+    service_machine_id: String,
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+// ============================================================================
+// Request Types
+// ============================================================================
+
+#[derive(Deserialize)]
+struct SwitchRequest {
+    account_id: String,
+}
+
+#[derive(Deserialize)]
+struct BindDeviceRequest {
+    #[serde(default = "default_bind_mode")]
+    mode: String,
+}
+
+fn default_bind_mode() -> String {
+    "generate".to_string()
+}
+
+// ============================================================================
+// Handlers
+// ============================================================================
+
+/// GET /health - 健康检查
+async fn health() -> impl IntoResponse {
+    Json(HealthResponse {
+        status: "ok".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    })
+}
+
+/// GET /accounts - 获取所有账号
+async fn list_accounts() -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    let accounts = account::list_accounts().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse { error: e }),
+        )
+    })?;
+
+    let current_id = account::get_current_account_id()
+        .ok()
+        .flatten();
+
+    let account_responses: Vec<AccountResponse> = accounts
+        .into_iter()
+        .map(|acc| {
+            let is_current = current_id.as_ref().map(|id| id == &acc.id).unwrap_or(false);
+            let quota = acc.quota.map(|q| QuotaResponse {
+                models: q.models.into_iter().map(|m| ModelQuota {
+                    name: m.name,
+                    percentage: m.percentage,
+                    reset_time: m.reset_time,
+                }).collect(),
+                updated_at: Some(q.last_updated),
+                subscription_tier: q.subscription_tier,
+            });
+            
+            AccountResponse {
+                id: acc.id,
+                email: acc.email,
+                name: acc.name,
+                is_current,
+                disabled: acc.disabled,
+                quota,
+                device_bound: acc.device_profile.is_some(),
+                last_used: acc.last_used,
+            }
+        })
+        .collect();
+
+    Ok(Json(AccountListResponse {
+        current_account_id: current_id,
+        accounts: account_responses,
+    }))
+}
+
+/// GET /accounts/current - 获取当前账号
+async fn get_current_account() -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    let current = account::get_current_account().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse { error: e }),
+        )
+    })?;
+
+    let response = current.map(|acc| {
+        let quota = acc.quota.map(|q| QuotaResponse {
+            models: q.models.into_iter().map(|m| ModelQuota {
+                name: m.name,
+                percentage: m.percentage,
+                reset_time: m.reset_time,
+            }).collect(),
+            updated_at: Some(q.last_updated),
+            subscription_tier: q.subscription_tier,
+        });
+
+        AccountResponse {
+            id: acc.id,
+            email: acc.email,
+            name: acc.name,
+            is_current: true,
+            disabled: acc.disabled,
+            quota,
+            device_bound: acc.device_profile.is_some(),
+            last_used: acc.last_used,
+        }
+    });
+
+    Ok(Json(CurrentAccountResponse { account: response }))
+}
+
+/// POST /accounts/switch - 切换账号
+async fn switch_account(
+    State(state): State<ApiState>,
+    Json(payload): Json<SwitchRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    // 检查是否已有切换操作在进行
+    {
+        let switching = state.switching.read().await;
+        if *switching {
+            return Err((
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    error: "另一个切换操作正在进行中".to_string(),
+                }),
+            ));
+        }
+    }
+
+    // 标记切换开始
+    {
+        let mut switching = state.switching.write().await;
+        *switching = true;
+    }
+
+    let account_id = payload.account_id.clone();
+    let state_clone = state.clone();
+
+    // 异步执行切换（不阻塞响应）
+    tokio::spawn(async move {
+        logger::log_info(&format!("[HTTP API] 开始切换账号: {}", account_id));
+        
+        match account::switch_account(&account_id).await {
+            Ok(()) => {
+                logger::log_info(&format!("[HTTP API] 账号切换成功: {}", account_id));
+            }
+            Err(e) => {
+                logger::log_error(&format!("[HTTP API] 账号切换失败: {}", e));
+            }
+        }
+
+        // 标记切换结束
+        let mut switching = state_clone.switching.write().await;
+        *switching = false;
+    });
+
+    // 立即返回 202 Accepted
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(SwitchResponse {
+            success: true,
+            message: format!("账号切换任务已启动: {}", payload.account_id),
+        }),
+    ))
+}
+
+/// POST /accounts/refresh - 刷新所有配额
+async fn refresh_all_quotas() -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    logger::log_info("[HTTP API] 开始刷新所有账号配额");
+
+    // 异步执行刷新
+    tokio::spawn(async {
+        match account::refresh_all_quotas_logic().await {
+            Ok(stats) => {
+                logger::log_info(&format!(
+                    "[HTTP API] 配额刷新完成，成功 {}/{} 个账号",
+                    stats.success, stats.total
+                ));
+            }
+            Err(e) => {
+                logger::log_error(&format!("[HTTP API] 配额刷新失败: {}", e));
+            }
+        }
+    });
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(RefreshResponse {
+            success: true,
+            message: "配额刷新任务已启动".to_string(),
+            refreshed_count: 0,
+        }),
+    ))
+}
+
+/// POST /accounts/:id/bind-device - 绑定设备指纹
+async fn bind_device(
+    Path(account_id): Path<String>,
+    Json(payload): Json<BindDeviceRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    logger::log_info(&format!(
+        "[HTTP API] 绑定设备指纹: account={}, mode={}",
+        account_id, payload.mode
+    ));
+
+    let result = account::bind_device_profile(&account_id, &payload.mode).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse { error: e }),
+        )
+    })?;
+
+    Ok(Json(BindDeviceResponse {
+        success: true,
+        message: "设备指纹绑定成功".to_string(),
+        device_profile: Some(DeviceProfileResponse {
+            machine_id: result.machine_id,
+            mac_machine_id: result.mac_machine_id,
+            dev_device_id: result.dev_device_id,
+            sqm_id: result.sqm_id,
+            service_machine_id: result.service_machine_id,
+        }),
+    }))
+}
+
+// ============================================================================
+// Server
+// ============================================================================
+
+/// 启动 HTTP API 服务器
+pub async fn start_server(port: u16) -> Result<(), String> {
+    let state = ApiState::new();
+
+    // CORS 配置 - 允许本地调用
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/accounts", get(list_accounts))
+        .route("/accounts/current", get(get_current_account))
+        .route("/accounts/switch", post(switch_account))
+        .route("/accounts/refresh", post(refresh_all_quotas))
+        .route("/accounts/{id}/bind-device", post(bind_device))
+        .layer(cors)
+        .with_state(state);
+
+    let addr = format!("127.0.0.1:{}", port);
+    logger::log_info(&format!("[HTTP API] 启动服务器: http://{}", addr));
+
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .map_err(|e| format!("绑定端口失败: {}", e))?;
+
+    axum::serve(listener, app)
+        .await
+        .map_err(|e| format!("服务器运行失败: {}", e))?;
+
+    Ok(())
+}
+
+/// 在后台启动 HTTP API 服务器（非阻塞）
+pub fn spawn_server(port: u16) {
+    // 使用 tauri::async_runtime::spawn 以确保在 Tauri 的 runtime 中运行
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = start_server(port).await {
+            logger::log_error(&format!("[HTTP API] 服务器启动失败: {}", e));
+        }
+    });
+}

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -13,6 +13,7 @@ pub mod proxy_db;
 pub mod device;
 pub mod update_checker;
 pub mod scheduler;
+pub mod http_api;
 
 use crate::models;
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -298,7 +298,17 @@
             "clear_logs": "Clear Logs Cache",
             "clear_logs_title": "Clear Logs Confirmation",
             "clear_logs_msg": "Are you sure you want to clear all log cache files?",
-            "logs_cleared": "Logs cache cleared"
+            "logs_cleared": "Logs cache cleared",
+            "http_api_title": "HTTP API Service",
+            "http_api_desc": "Provides local HTTP interface for external programs (e.g. VS Code plugins).",
+            "http_api_enabled": "Enable HTTP API",
+            "http_api_enabled_desc": "When enabled, external programs can manage accounts via HTTP interface",
+            "http_api_port": "Listen Port",
+            "http_api_port_desc": "Restart required after changing port. If port conflict occurs, please use another available port.",
+            "http_api_port_placeholder": "Default port 19527",
+            "http_api_port_invalid": "Invalid port number (range: 1024-65535)",
+            "http_api_settings_saved": "HTTP API settings saved, restart required to apply",
+            "http_api_restart_required": "⚠️ Restart required to apply"
         },
         "about": {
             "title": "About",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -298,7 +298,17 @@
             "clear_logs": "清理日志缓存",
             "clear_logs_title": "清理日志确认",
             "clear_logs_msg": "确定要清理所有日志缓存文件吗？",
-            "logs_cleared": "日志缓存已清理"
+            "logs_cleared": "日志缓存已清理",
+            "http_api_title": "HTTP API 服务",
+            "http_api_desc": "为外部程序（如 VS Code 插件）提供本地 HTTP 接口。",
+            "http_api_enabled": "启用 HTTP API",
+            "http_api_enabled_desc": "启用后，外部程序可通过 HTTP 接口管理账号",
+            "http_api_port": "监听端口",
+            "http_api_port_desc": "修改端口后需要重启应用才能生效。如遇端口冲突，请更换为其他未被占用的端口。",
+            "http_api_port_placeholder": "默认端口 19527",
+            "http_api_port_invalid": "端口号无效（范围：1024-65535）",
+            "http_api_settings_saved": "HTTP API 设置已保存，重启应用后生效",
+            "http_api_restart_required": "⚠️ 需要重启应用后生效"
         },
         "about": {
             "title": "关于",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -61,6 +61,14 @@ function Settings() {
         downloadUrl: string;
     } | null>(null);
 
+    // HTTP API settings state
+    const [httpApiSettings, setHttpApiSettings] = useState<{
+        enabled: boolean;
+        port: number;
+    }>({ enabled: true, port: 19527 });
+    const [httpApiPortInput, setHttpApiPortInput] = useState('19527');
+    const [httpApiSettingsChanged, setHttpApiSettingsChanged] = useState(false);
+
     useEffect(() => {
         loadConfig();
 
@@ -86,6 +94,14 @@ function Settings() {
                 setFormData(prev => ({ ...prev, auto_launch: enabled }));
             })
             .catch(err => console.error('Failed to get auto launch status:', err));
+
+        // 加载 HTTP API 设置
+        invoke<{ enabled: boolean; port: number }>('get_http_api_settings')
+            .then(settings => {
+                setHttpApiSettings(settings);
+                setHttpApiPortInput(String(settings.port));
+            })
+            .catch(err => console.error('Failed to load HTTP API settings:', err));
     }, [loadConfig]);
 
     useEffect(() => {
@@ -606,6 +622,85 @@ function Settings() {
                                 <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
                                     {t('settings.advanced.antigravity_args_desc')}
                                 </p>
+                            </div>
+
+                            {/* HTTP API 设置 */}
+                            <div className="border-t border-gray-200 dark:border-base-200 pt-4">
+                                <h3 className="font-medium text-gray-900 dark:text-base-content mb-3">{t('settings.advanced.http_api_title')}</h3>
+                                <div className="bg-gray-50 dark:bg-base-200 border border-gray-200 dark:border-base-300 rounded-lg p-4 space-y-4">
+                                    <p className="text-sm text-gray-600 dark:text-gray-400">{t('settings.advanced.http_api_desc')}</p>
+                                    
+                                    {/* 启用开关 */}
+                                    <div className="flex items-center justify-between">
+                                        <div>
+                                            <div className="font-medium text-gray-900 dark:text-base-content">{t('settings.advanced.http_api_enabled')}</div>
+                                            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">{t('settings.advanced.http_api_enabled_desc')}</p>
+                                        </div>
+                                        <label className="relative inline-flex items-center cursor-pointer">
+                                            <input
+                                                type="checkbox"
+                                                className="sr-only peer"
+                                                checked={httpApiSettings.enabled}
+                                                onChange={(e) => {
+                                                    setHttpApiSettings(prev => ({ ...prev, enabled: e.target.checked }));
+                                                    setHttpApiSettingsChanged(true);
+                                                }}
+                                            />
+                                            <div className="w-11 h-6 bg-gray-200 dark:bg-base-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-500"></div>
+                                        </label>
+                                    </div>
+
+                                    {/* 端口配置 */}
+                                    {httpApiSettings.enabled && (
+                                        <div className="mt-4">
+                                            <label className="block text-sm font-medium text-gray-900 dark:text-base-content mb-2">{t('settings.advanced.http_api_port')}</label>
+                                            <div className="flex gap-2">
+                                                <input
+                                                    type="number"
+                                                    className="w-32 px-4 py-2 border border-gray-200 dark:border-base-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900 dark:text-base-content bg-white dark:bg-base-200"
+                                                    min="1024"
+                                                    max="65535"
+                                                    value={httpApiPortInput}
+                                                    onChange={(e) => {
+                                                        setHttpApiPortInput(e.target.value);
+                                                        const port = parseInt(e.target.value);
+                                                        if (port >= 1024 && port <= 65535) {
+                                                            setHttpApiSettings(prev => ({ ...prev, port }));
+                                                            setHttpApiSettingsChanged(true);
+                                                        }
+                                                    }}
+                                                    placeholder={t('settings.advanced.http_api_port_placeholder')}
+                                                />
+                                                <button
+                                                    className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                                    disabled={!httpApiSettingsChanged}
+                                                    onClick={async () => {
+                                                        const port = parseInt(httpApiPortInput);
+                                                        if (port < 1024 || port > 65535) {
+                                                            showToast(t('settings.advanced.http_api_port_invalid'), 'error');
+                                                            return;
+                                                        }
+                                                        try {
+                                                            await invoke('save_http_api_settings', {
+                                                                settings: httpApiSettings
+                                                            });
+                                                            setHttpApiSettingsChanged(false);
+                                                            showToast(t('settings.advanced.http_api_settings_saved'), 'success');
+                                                        } catch (error) {
+                                                            showToast(`${t('common.error')}: ${error}`, 'error');
+                                                        }
+                                                    }}
+                                                >
+                                                    {t('common.save')}
+                                                </button>
+                                            </div>
+                                            <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">{t('settings.advanced.http_api_port_desc')}</p>
+                                            {httpApiSettingsChanged && (
+                                                <p className="text-sm text-orange-500 dark:text-orange-400 mt-2">{t('settings.advanced.http_api_restart_required')}</p>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
                             </div>
 
                             <div className="border-t border-gray-200 dark:border-base-200 pt-4">


### PR DESCRIPTION
## 🎯 需求描述
希望为 Antigravity-Manager 提供一个本地 HTTP API 服务，使其能够作为后台服务被第三方程序调用。通过简单的 HTTP 请求即可完成账号切换、配额查询等操作，无需手动打开客户端界面，方便集成到各类自动化工具或工作流中。同时支持用户自定义监听端口，以适应不同的本地环境。


## ✨ 本次改动

本 PR 实现了一个**本地 HTTP API 服务**，并支持**端口可配置化**，具体包括：

**后端 (Rust)**
- 新增 [http_api](cci:1://file:///private/var/www/Antigravity-Manager/src-tauri/src/commands/mod.rs:760:0-764:1) 模块，提供以下 RESTful 接口：
  - `GET /health` - 健康检查
  - `GET /accounts` - 获取所有账号及配额
  - `GET /accounts/current` - 获取当前活跃账号
  - `POST /accounts/switch` - 切换账号
  - `POST /accounts/refresh` - 刷新所有配额
  - `POST /accounts/:id/bind-device` - 绑定设备指纹
- 新增 [HttpApiSettings](cci:2://file:///private/var/www/Antigravity-Manager/src-tauri/src/modules/http_api.rs:34:0-41:1) 结构体，支持服务开关 ([enabled](cci:1://file:///private/var/www/Antigravity-Manager/src-tauri/src/modules/http_api.rs:43:0-45:1)) 和端口 ([port](cci:1://file:///private/var/www/Antigravity-Manager/src-tauri/src/modules/http_api.rs:47:0-49:1)) 的持久化配置
- 新增 Tauri 命令：[get_http_api_settings](cci:1://file:///private/var/www/Antigravity-Manager/src-tauri/src/commands/mod.rs:760:0-764:1) / [save_http_api_settings](cci:1://file:///private/var/www/Antigravity-Manager/src-tauri/src/commands/mod.rs:766:0-772:1)
- 优化应用启动流程，根据用户配置动态决定是否启动 API 服务及使用哪个端口

**前端 (React)**
- 在"设置 > 高级"中新增 **HTTP API 服务** 配置面板
- 支持启用/禁用服务开关
- 支持自定义监听端口（范围 1024-65535）
- 保存成功后显示"需要重启生效"的提示

**国际化**
- 完善中英文双语翻译

## 🚀 使用场景

为第三方程序提供标准化的本地调用入口，任何支持 HTTP 协议的外部工具均可轻松接入。

## ⚙️ 技术实现

- 基于 **Axum** 框架构建，轻量高效
- 使用 **Tokio** 异步运行时，资源占用极低，不影响主程序性能
- 支持 CORS，方便本地 Web 应用调用

## 📝 配置文件

设置保存在数据目录下的 `http_api_settings.json`，格式如下：
```json
{
  "enabled": true,
  "port": 19527
}