### PR TITLE
fix: add session_id to warmup requests to resolve 429

### DIFF
--- a/src-tauri/src/proxy/handlers/warmup.rs
+++ b/src-tauri/src/proxy/handlers/warmup.rs
@@ -79,6 +79,10 @@ pub async fn handle_warmup(
 
     let body: Value = if is_claude {
         // Claude 模型：使用 transform_claude_request_in 转换
+        let session_id = format!("warmup_{}_{}", 
+            chrono::Utc::now().timestamp_millis(),
+            &uuid::Uuid::new_v4().to_string()[..8]
+        );
         let claude_request = crate::proxy::mappers::claude::models::ClaudeRequest {
             model: req.model.clone(),
             messages: vec![crate::proxy::mappers::claude::models::Message {
@@ -94,7 +98,9 @@ pub async fn handle_warmup(
             top_p: None,
             top_k: None,
             tools: None,
-            metadata: None,
+            metadata: Some(crate::proxy::mappers::claude::models::Metadata {
+                user_id: Some(session_id),
+            }),
             thinking: None,
             output_config: None,
         };


### PR DESCRIPTION
## 摘要

增强预热功能，期望解决部分账号429问题，并新增自定义预热对话框。

## 修改

- 预热请求添加唯一 `session_id`
- 限制输出 token 为 8
- 设置 `temperature: 0`
- 新增自定义预热对话框，支持选择特定账号和模型
- 可能无法彻底解决部分账号的429，因为不清楚实际原因。但也可单纯作为自定义预热的选项的扩展


<img width="785" height="760" alt="1ed79bed-03ef-4839-aad4-3872c110bc92" src="https://github.com/user-attachments/assets/970c5378-9dad-4f92-856e-5584b4aa9af5" />
