### PR TITLE
fix: 添加限流记录自动清理机制，防止过期锁定状态残留

### DIFF
--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -74,6 +74,7 @@ pub async fn start_proxy_service(
     let accounts_dir = app_data_dir.clone();
     
     let token_manager = Arc::new(TokenManager::new(accounts_dir));
+    token_manager.start_auto_cleanup(); // 启动限流记录自动清理后台任务
     // 同步 UI 传递的调度配置
     token_manager.update_sticky_config(config.scheduling.clone()).await;
     

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -47,6 +47,22 @@ impl TokenManager {
             session_accounts: Arc::new(DashMap::new()),
         }
     }
+
+    /// 启动限流记录自动清理后台任务（每60秒检查并清除过期记录）
+    pub fn start_auto_cleanup(&self) {
+        let tracker = self.rate_limit_tracker.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            loop {
+                interval.tick().await;
+                let cleaned = tracker.cleanup_expired();
+                if cleaned > 0 {
+                    tracing::info!("🧹 Auto-cleanup: Removed {} expired rate limit record(s)", cleaned);
+                }
+            }
+        });
+        tracing::info!("✅ Rate limit auto-cleanup task started (interval: 60s)");
+    }
     
     /// 从主应用账号目录加载所有账号
     pub async fn load_accounts(&self) -> Result<usize, String> {


### PR DESCRIPTION
- 新增 FAILURE_COUNT_EXPIRY_SECONDS 常量（1小时）
- 失败计数超过1小时后自动过期重置
- 添加 start_auto_cleanup() 方法，每60秒清理过期限流记录
- 在代理服务启动时调用自动清理任务

修复限流记录在内存中永久残留导致的 'All accounts are currently limited' 错误