### PR TITLE
feat: 在模型行显示配额保护状态

### DIFF
--- a/src/components/accounts/AccountTable.tsx
+++ b/src/components/accounts/AccountTable.tsx
@@ -131,6 +131,21 @@ function getTimeColorClass(resetTime: string | undefined): string {
     }
 }
 
+function isModelProtected(protectedModels: string[] | undefined, modelName: string): boolean {
+    if (!protectedModels || protectedModels.length === 0) return false;
+    const lower = modelName.toLowerCase();
+    if (lower.includes('flash') && lower.includes('gemini')) {
+        return protectedModels.includes('gemini-3-flash');
+    }
+    if (lower.includes('gemini') && lower.includes('pro')) {
+        return protectedModels.includes('gemini-3-pro-preview');
+    }
+    if (lower.includes('claude') && lower.includes('sonnet')) {
+        return protectedModels.includes('claude-sonnet-4-5');
+    }
+    return false;
+}
+
 // ============================================================================
 // 子组件
 // ============================================================================
@@ -353,10 +368,13 @@ function AccountRowContent({
                                         <span className="text-gray-300 dark:text-gray-600 italic scale-90">N/A</span>
                                     )}
                                 </div>
-                                <span className={cn("w-[36px] text-right font-bold transition-colors",
+                                <span className={cn("w-[36px] text-right font-bold transition-colors flex items-center justify-end gap-0.5",
                                     getQuotaColor(geminiProModel?.percentage || 0) === 'success' ? 'text-emerald-600 dark:text-emerald-400' :
                                         getQuotaColor(geminiProModel?.percentage || 0) === 'warning' ? 'text-amber-600 dark:text-amber-400' : 'text-rose-600 dark:text-rose-400'
                                 )}>
+                                    {isModelProtected(account.protected_models, 'gemini-pro') && (
+                                        <span title={t('accounts.quota_protected')}><Lock className="w-2.5 h-2.5 text-amber-500" /></span>
+                                    )}
                                     {geminiProModel ? `${geminiProModel.percentage}%` : '-'}
                                 </span>
                             </div>
@@ -382,10 +400,13 @@ function AccountRowContent({
                                         <span className="text-gray-300 dark:text-gray-600 italic scale-90">N/A</span>
                                     )}
                                 </div>
-                                <span className={cn("w-[36px] text-right font-bold transition-colors",
+                                <span className={cn("w-[36px] text-right font-bold transition-colors flex items-center justify-end gap-0.5",
                                     getQuotaColor(geminiFlashModel?.percentage || 0) === 'success' ? 'text-emerald-600 dark:text-emerald-400' :
                                         getQuotaColor(geminiFlashModel?.percentage || 0) === 'warning' ? 'text-amber-600 dark:text-amber-400' : 'text-rose-600 dark:text-rose-400'
                                 )}>
+                                    {isModelProtected(account.protected_models, 'gemini-flash') && (
+                                        <span title={t('accounts.quota_protected')}><Lock className="w-2.5 h-2.5 text-amber-500" /></span>
+                                    )}
                                     {geminiFlashModel ? `${geminiFlashModel.percentage}%` : '-'}
                                 </span>
                             </div>
@@ -411,10 +432,13 @@ function AccountRowContent({
                                         <span className="text-gray-300 dark:text-gray-600 italic scale-90">N/A</span>
                                     )}
                                 </div>
-                                <span className={cn("w-[36px] text-right font-bold transition-colors",
+                                <span className={cn("w-[36px] text-right font-bold transition-colors flex items-center justify-end gap-0.5",
                                     getQuotaColor(geminiImageModel?.percentage || 0) === 'success' ? 'text-emerald-600 dark:text-emerald-400' :
                                         getQuotaColor(geminiImageModel?.percentage || 0) === 'warning' ? 'text-amber-600 dark:text-amber-400' : 'text-rose-600 dark:text-rose-400'
                                 )}>
+                                    {isModelProtected(account.protected_models, 'gemini-pro-image') && (
+                                        <span title={t('accounts.quota_protected')}><Lock className="w-2.5 h-2.5 text-amber-500" /></span>
+                                    )}
                                     {geminiImageModel ? `${geminiImageModel.percentage}%` : '-'}
                                 </span>
                             </div>
@@ -440,10 +464,13 @@ function AccountRowContent({
                                         <span className="text-gray-300 dark:text-gray-600 italic scale-90">N/A</span>
                                     )}
                                 </div>
-                                <span className={cn("w-[36px] text-right font-bold transition-colors",
+                                <span className={cn("w-[36px] text-right font-bold transition-colors flex items-center justify-end gap-0.5",
                                     getQuotaColor(claudeModel?.percentage || 0) === 'success' ? 'text-emerald-600 dark:text-emerald-400' :
                                         getQuotaColor(claudeModel?.percentage || 0) === 'warning' ? 'text-amber-600 dark:text-amber-400' : 'text-rose-600 dark:text-rose-400'
                                 )}>
+                                    {isModelProtected(account.protected_models, 'claude-sonnet') && (
+                                        <span title={t('accounts.quota_protected')}><Lock className="w-2.5 h-2.5 text-amber-500" /></span>
+                                    )}
                                     {claudeModel ? `${claudeModel.percentage}%` : '-'}
                                 </span>
                             </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -135,6 +135,7 @@
         "warmup_this": "Warmup this account",
         "warmup_now": "Warmup Now",
         "warmup_batch_triggered": "Warmup tasks triggered for {{count}} accounts",
+        "quota_protected": "Protected",
         "details": {
             "title": "Quota Details"
         },

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -121,6 +121,7 @@
         "reset_time": "リセット時間",
         "switch_to": "このアカウントに切り替え",
         "actions": "操作",
+        "quota_protected": "保護中",
         "details": {
             "title": "クォータ詳細"
         },

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -130,6 +130,7 @@
         "warmup_this": "Aquecer esta conta",
         "warmup_now": "Aquecer Agora",
         "warmup_batch_triggered": "Tarefas de aquecimento acionadas para {{count}} contas",
+        "quota_protected": "Protegido",
         "details": {
             "title": "Detalhes da Cota"
         },

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -130,6 +130,7 @@
         "warmup_this": "Разогреть этот аккаунт",
         "warmup_now": "Разогреть сейчас",
         "warmup_batch_triggered": "Задачи разогрева запущены для {{count}} аккаунтов",
+        "quota_protected": "Защищено",
         "details": {
             "title": "Детали квоты"
         },

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -121,6 +121,7 @@
         "reset_time": "Sıfırlama Zamanı",
         "switch_to": "Bu hesaba geç",
         "actions": "İşlemler",
+        "quota_protected": "Korumalı",
         "details": {
             "title": "Kota Detayları"
         },

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -128,6 +128,7 @@
         "warmup_this": "Làm nóng tài khoản này",
         "warmup_now": "Làm nóng Ngay",
         "warmup_batch_triggered": "Đã kích hoạt làm nóng cho {{count}} tài khoản",
+        "quota_protected": "Được bảo vệ",
         "details": {
             "title": "Chi tiết Hạn mức"
         },

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -130,6 +130,7 @@
         "warmup_this": "預熱該帳號",
         "warmup_now": "立即預熱",
         "warmup_batch_triggered": "已成功為 {{count}} 個帳號觸發預熱任務",
+        "quota_protected": "受保護",
         "details": {
             "title": "配額詳情"
         },

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -135,6 +135,7 @@
         "warmup_this": "预热该账号",
         "warmup_now": "立即预热",
         "warmup_batch_triggered": "已成功为 {{count}} 个账号触发预热任务",
+        "quota_protected": "受保护",
         "details": {
             "title": "配额详情"
         },

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -12,6 +12,7 @@ export interface Account {
     proxy_disabled?: boolean;
     proxy_disabled_reason?: string;
     proxy_disabled_at?: number;
+    protected_models?: string[];
     created_at: number;
     last_used: number;
 }


### PR DESCRIPTION
## 摘要
当模型因配额保护被限制时，在账号表格的对应模型百分比旁边显示🔒

## 修改
- Account 类型添加 `protected_models` 字段
- 为受保护模型显示锁图标 (G3 Pro, G3 Flash, G3 Image, Claude 4.5)
- i18n

## 备注
- 所有 Claude 模型共享同一配额 (`claude-sonnet-4-5`)，保护一个即保护全部(按分组)
- Gemini Pro 和 Image 共享 `gemini-3-pro-preview` 保护组，这个后续可能应该拆开

## 效果
<img width="438" height="335" alt="image" src="https://github.com/user-attachments/assets/56982bbe-ca19-467b-be60-d8343f410a60" />
