### PR TITLE
fix(linux): prevent crash when switching theme on Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -365,6 +366,7 @@
       "resolved": "https://registry.npmmirror.com/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1705,6 +1707,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1881,6 +1884,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2477,6 +2481,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -2585,6 +2590,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2818,6 +2824,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2865,6 +2872,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3034,6 +3042,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3043,6 +3052,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3089,6 +3099,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3225,7 +3236,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -3534,6 +3546,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3617,6 +3630,7 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "dirs 5.0.1",
  "eventsource-stream",
  "futures",
+ "gtk",
  "hyper",
  "hyper-util",
  "image",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,3 +62,6 @@ tracing-appender = "0.2.4"
 tracing-log = "0.2.0"
 tauri-plugin-autostart = "2.5.1"
 sha2 = "0.10"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18"

--- a/src/components/common/ThemeManager.tsx
+++ b/src/components/common/ThemeManager.tsx
@@ -3,6 +3,9 @@ import { useEffect } from 'react';
 import { useConfigStore } from '../../stores/useConfigStore';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 
+// Detect if running on Linux platform
+const isLinux = navigator.userAgent.toLowerCase().includes('linux');
+
 export default function ThemeManager() {
     const { config, loadConfig } = useConfigStore();
 
@@ -27,9 +30,12 @@ export default function ThemeManager() {
             const isDark = theme === 'dark';
 
             // Set Tauri window background color
+            // Skip on Linux due to crash with transparent windows + softbuffer
             try {
-                const bgColor = isDark ? '#1d232a' : '#FAFBFC';
-                await getCurrentWindow().setBackgroundColor(bgColor);
+                if (!isLinux) {
+                    const bgColor = isDark ? '#1d232a' : '#FAFBFC';
+                    await getCurrentWindow().setBackgroundColor(bgColor);
+                }
             } catch (e) {
                 console.error('Failed to set window background color:', e);
             }

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,6 +3,9 @@ import { Sun, Moon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useConfigStore } from '../../stores/useConfigStore';
 
+// Detect if running on Linux platform
+const isLinux = navigator.userAgent.toLowerCase().includes('linux');
+
 function Navbar() {
     const location = useLocation();
     const { t, i18n } = useTranslation();
@@ -27,8 +30,8 @@ function Navbar() {
 
         const newTheme = config.theme === 'light' ? 'dark' : 'light';
 
-        // 如果浏览器支持 View Transition API
-        if ('startViewTransition' in document) {
+        // Use View Transition API if supported, but skip on Linux (may cause crash)
+        if ('startViewTransition' in document && !isLinux) {
             const x = event.clientX;
             const y = event.clientY;
             const endRadius = Math.hypot(
@@ -64,7 +67,7 @@ function Navbar() {
                 );
             });
         } else {
-            // 降级方案：直接切换
+            // Fallback: direct switch (Linux or browsers without View Transition)
             await saveConfig({
                 ...config,
                 theme: newTheme,


### PR DESCRIPTION
      - Skip setBackgroundColor API call on Linux (causes softbuffer crash with transparent windows)
      - Disable View Transition API on Linux (incompatible with WebKitGTK transparent windows)
      - Add GTK workaround to disable window transparency alpha channel at startup
      - Add gtk dependency for Linux platform only

      Fixes theme switch causing app freeze/crash on Linux systems.