### PR TITLE
Add support for x-goog-api-key in auth middleware

### DIFF
--- a/src-tauri/src/proxy/middleware/auth.rs
+++ b/src-tauri/src/proxy/middleware/auth.rs
@@ -54,6 +54,12 @@ pub async fn auth_middleware(
                 .headers()
                 .get("x-api-key")
                 .and_then(|h| h.to_str().ok())
+        })
+        .or_else(|| {
+            request
+                .headers()
+                .get("x-goog-api-key")
+                .and_then(|h| h.to_str().ok())
         });
 
     if security.api_key.is_empty() {


### PR DESCRIPTION
Add Support for Google API Authentication via x-api-key Header

  Summary

  This PR adds support for Google API authentication using the x-api-key header, enabling seamless integration with Google's Gemini API endpoints.

  Changes

  - Added support for the x-api-key header in API requests
  - Implemented authentication flow compatible with Google's Gemini API specification
  - Updated request handling to accept and process API keys from the x-api-key header

  Usage Example

```
  curl --location 'http://127.0.0.1:8045/v1beta/models/gemini-3-pro-image:generateContent' \
  --header 'Content-Type: application/json' \
  --header 'x-api-key: sk-xxxx' \
  --data '{
      "contents": [
          {
              "parts": [
                  {
                      "text": "draw a cat"
                  }
              ]
          }
      ]
  }'
```
