### PR TITLE
fix(proxy): respect client max_tokens in Claude mapper

### DIFF
--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -1605,7 +1605,8 @@ fn build_generation_config(
     }*/
 
     // max_tokens 映射为 maxOutputTokens
-    let mut final_max_tokens = 16384;
+    // Respect client-provided max_tokens (aligns with OpenAI mapper behavior)
+    let mut final_max_tokens: i64 = claude_req.max_tokens.map(|t| t as i64).unwrap_or(16384);
     
     // [NEW] 确保 maxOutputTokens 大于 thinkingBudget (API 强约束)
     if let Some(thinking_config) = config.get("thinkingConfig") {


### PR DESCRIPTION
## Summary

The Claude mapper currently ignores the client-provided `max_tokens` parameter, hardcoding `maxOutputTokens` to `16384`. This causes streams to be cut off when models attempt to generate longer outputs (observed as `Stream error: error decoding response body`).

## Root Cause

In `build_generation_config()`:
```rust
// Before (ignores client value)
let mut final_max_tokens = 16384;
```

Meanwhile, the OpenAI mapper correctly uses the client value:
```rust
// openai/request.rs line 277
"maxOutputTokens": request.max_tokens.unwrap_or(16384),
```

## Fix

Use the same pattern as OpenAI mapper:
```rust
// After (respects client value)
let mut final_max_tokens: i64 = claude_req.max_tokens.map(|t| t as i64).unwrap_or(16384);
```

## Notes

- The existing `thinkingBudget` constraint logic is preserved - if `max_tokens` is smaller than `thinkingBudget`, it will still be bumped up to `(budget + 8192)`
- Default value remains `16384` for backward compatibility when client doesn't specify max_tokens
- This change aligns Claude and OpenAI protocol handling for consistency