### PR TITLE
fix: 修复 macOS 12.2 (M1芯片) 下添加账号弹窗无法显示的问题 (Fixes #468)

### DIFF
--- a/src/components/accounts/AddAccountDialog.tsx
+++ b/src/components/accounts/AddAccountDialog.tsx
@@ -346,19 +346,28 @@ function AddAccountDialog({ onAdd }: AddAccountDialogProps) {
     return (
         <>
             <button
-                className="px-4 py-2 bg-white dark:bg-base-100 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-base-200 transition-colors flex items-center gap-2 shadow-sm border border-gray-200/50 dark:border-base-300"
-                onClick={() => setIsOpen(true)}
+                className="px-4 py-2 bg-white dark:bg-base-100 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-base-200 transition-colors flex items-center gap-2 shadow-sm border border-gray-200/50 dark:border-base-300 relative z-[100]"
+                onClick={() => {
+                    console.log('AddAccountDialog button clicked');
+                    setIsOpen(true);
+                }}
             >
                 <Plus className="w-4 h-4" />
                 {t('accounts.add_account')}
             </button>
 
             {isOpen && createPortal(
-                <div className="modal modal-open z-[100]">
+                <div 
+                    className="fixed inset-0 z-[99999] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+                    style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 }}
+                >
                     {/* Draggable Top Region */}
-                    <div data-tauri-drag-region className="fixed top-0 left-0 right-0 h-8 z-[110]" />
+                    <div data-tauri-drag-region className="fixed top-0 left-0 right-0 h-8 z-[1]" />
 
-                    <div className="modal-box bg-white dark:bg-base-100 text-gray-900 dark:text-base-content">
+                    {/* Click outside to close */}
+                    <div className="absolute inset-0 z-[0]" onClick={() => setIsOpen(false)} />
+
+                    <div className="bg-white dark:bg-base-100 text-gray-900 dark:text-base-content rounded-2xl shadow-2xl w-full max-w-lg p-6 relative z-[10] m-4 max-h-[90vh] overflow-y-auto">
                         <h3 className="font-bold text-lg mb-4">{t('accounts.add.title')}</h3>
 
                         {/* Tab 导航 - 胶囊风格 */}
@@ -556,7 +565,6 @@ function AddAccountDialog({ onAdd }: AddAccountDialogProps) {
                             )}
                         </div>
                     </div>
-                    <div className="modal-backdrop bg-black/40 backdrop-blur-sm fixed inset-0 z-[-1]" onClick={() => setIsOpen(false)}></div>
                 </div>,
                 document.body
             )}


### PR DESCRIPTION
解决在 macOS 12.2 (M1芯片) 环境下，因层级渲染问题导致点击无反应的情况。
改动内容：
1. 移除 DaisyUI modal 类依赖，改用原生 fixed 定位。
2. 强制提升 z-index 至 99999，确保弹窗覆盖所有层级。
3. 显式添加背景遮罩和点击关闭功能。

Fixes #468