### PR TITLE
feat: add account filter and fix UI truncation

### DIFF
--- a/src-tauri/src/modules/proxy_db.rs
+++ b/src-tauri/src/modules/proxy_db.rs
@@ -257,8 +257,8 @@ pub fn get_logs_count_filtered(filter: &str, errors_only: bool) -> Result<u64, S
     } else if filter.is_empty() {
         "SELECT COUNT(*) FROM request_logs"
     } else {
-        "SELECT COUNT(*) FROM request_logs WHERE 
-            (url LIKE ?1 OR method LIKE ?1 OR model LIKE ?1 OR CAST(status AS TEXT) LIKE ?1)"
+        "SELECT COUNT(*) FROM request_logs WHERE
+            (url LIKE ?1 OR method LIKE ?1 OR model LIKE ?1 OR CAST(status AS TEXT) LIKE ?1 OR account_email LIKE ?1)"
     };
     
     let count: u64 = if filter.is_empty() && !errors_only {
@@ -300,7 +300,7 @@ pub fn get_logs_filtered(filter: &str, errors_only: bool, limit: usize, offset: 
                 NULL as request_body, NULL as response_body,
                 input_tokens, output_tokens, account_email, mapped_model, protocol
          FROM request_logs 
-         WHERE (url LIKE ?3 OR method LIKE ?3 OR model LIKE ?3 OR CAST(status AS TEXT) LIKE ?3)
+         WHERE (url LIKE ?3 OR method LIKE ?3 OR model LIKE ?3 OR CAST(status AS TEXT) LIKE ?3 OR account_email LIKE ?3)
          ORDER BY timestamp DESC 
          LIMIT ?1 OFFSET ?2"
     };

--- a/src/components/accounts/AccountTable.tsx
+++ b/src/components/accounts/AccountTable.tsx
@@ -411,7 +411,7 @@ function AccountRowContent({
                                         />
                                     )}
                                     <div className="relative z-10 w-full flex items-center text-[10px] font-mono leading-none">
-                                        <span className="w-[54px] text-gray-500 dark:text-gray-400 font-bold truncate pr-1" title={modelId}>
+                                        <span className="min-w-[54px] max-w-[72px] text-gray-500 dark:text-gray-400 font-bold truncate pr-1" title={modelId}>
                                             {modelConfig.label}
                                         </span>
                                         <div className="flex-1 flex justify-center">

--- a/src/components/proxy/ProxyMonitor.tsx
+++ b/src/components/proxy/ProxyMonitor.tsx
@@ -1,12 +1,13 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useMemo } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import ModalDialog from '../common/ModalDialog';
 import { useTranslation } from 'react-i18next';
 import { request as invoke } from '../../utils/request';
-import { Trash2, Search, X, Copy, CheckCircle, ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
+import { Trash2, Search, X, Copy, CheckCircle, ChevronLeft, ChevronRight, RefreshCw, User } from 'lucide-react';
 
 import { AppConfig } from '../../types/config';
 import { formatCompactNumber } from '../../utils/format';
+import { useAccountStore } from '../../stores/useAccountStore';
 
 
 interface ProxyRequestLog {
@@ -100,7 +101,7 @@ const LogTable: React.FC<LogTableProps> = ({
                                     </span>
                                 )}
                             </td>
-                            <td className="text-gray-600 dark:text-gray-400 truncate text-[10px]" style={{ width: '140px', maxWidth: '140px' }}>
+                            <td className="text-gray-600 dark:text-gray-400 truncate text-[10px]" style={{ width: '140px', maxWidth: '140px' }} title={log.account_email || ''}>
                                 {log.account_email ? log.account_email.replace(/(.{3}).*(@.*)/, '$1***$2') : '-'}
                             </td>
                             <td className="truncate" style={{ width: '180px', maxWidth: '180px' }}>{log.url}</td>
@@ -141,10 +142,13 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
     const [logs, setLogs] = useState<ProxyRequestLog[]>([]);
     const [stats, setStats] = useState<ProxyStats>({ total_requests: 0, success_count: 0, error_count: 0 });
     const [filter, setFilter] = useState('');
+    const [accountFilter, setAccountFilter] = useState('');
     const [selectedLog, setSelectedLog] = useState<ProxyRequestLog | null>(null);
     const [isLoggingEnabled, setIsLoggingEnabled] = useState(false);
     const [isClearConfirmOpen, setIsClearConfirmOpen] = useState(false);
     const [copiedRequestId, setCopiedRequestId] = useState<string | null>(null);
+
+    const { accounts, fetchAccounts } = useAccountStore();
 
     // Pagination state
     const PAGE_SIZE_OPTIONS = [50, 100, 200, 500];
@@ -154,7 +158,20 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
     const [loading, setLoading] = useState(false);
     const [loadingDetail, setLoadingDetail] = useState(false);
 
-    const loadData = async (page = 1, searchFilter = filter) => {
+    const uniqueAccounts = useMemo(() => {
+        const emailSet = new Set<string>();
+        logs.forEach(log => {
+            if (log.account_email) {
+                emailSet.add(log.account_email);
+            }
+        });
+        accounts.forEach(acc => {
+            emailSet.add(acc.email);
+        });
+        return Array.from(emailSet).sort();
+    }, [logs, accounts]);
+
+    const loadData = async (page = 1, searchFilter = filter, accountEmailFilter = accountFilter) => {
         if (loading) return;
         setLoading(true);
 
@@ -174,9 +191,11 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
                 await invoke('set_proxy_monitor_enabled', { enabled: config.proxy.enable_logging });
             }
 
-            // Determine if filtering by errors only
             const errorsOnly = searchFilter === '__ERROR__';
-            const actualFilter = errorsOnly ? '' : searchFilter;
+            const baseFilter = errorsOnly ? '' : searchFilter;
+            const actualFilter = accountEmailFilter
+                ? (baseFilter ? `${baseFilter} ${accountEmailFilter}` : accountEmailFilter)
+                : baseFilter;
 
             // Get count with filter
             const count = await Promise.race([
@@ -228,7 +247,7 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
     const goToPage = (page: number) => {
         if (page >= 1 && page <= totalPages && page !== currentPage) {
             setCurrentPage(page);
-            loadData(page, filter);
+            loadData(page, filter, accountFilter);
         }
     };
 
@@ -254,7 +273,8 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
     useEffect(() => {
         isMountedRef.current = true;
         loadData();
-        
+        fetchAccounts();
+
         let unlistenFn: (() => void) | null = null;
         let updateTimeout: number | null = null;
 
@@ -341,18 +361,21 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
     // Reload when pageSize changes
     useEffect(() => {
         setCurrentPage(1);
-        loadData(1, filter);
+        loadData(1, filter, accountFilter);
     }, [pageSize]);
 
     // Reload when filter changes (search based on all logs)
     useEffect(() => {
         setCurrentPage(1);
-        loadData(1, filter);
-    }, [filter]);
+        loadData(1, filter, accountFilter);
+    }, [filter, accountFilter]);
 
     // Logs are already filtered and sorted by backend
-    // Just use logs directly as filteredLogs for compatibility
-    const filteredLogs = logs;
+    // Apply account filter on frontend
+    const filteredLogs = useMemo(() => {
+        if (!accountFilter) return logs;
+        return logs.filter(log => log.account_email === accountFilter);
+    }, [logs, accountFilter]);
 
     const quickFilters = [
         { label: t('monitor.filters.all'), value: '' },
@@ -437,6 +460,23 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
                         />
                     </div>
 
+                    <div className="relative">
+                        <User className="absolute left-2.5 top-2 text-gray-400 z-10" size={14} />
+                        <select
+                            className="select select-sm select-bordered pl-8 text-xs min-w-[140px] max-w-[220px]"
+                            value={accountFilter}
+                            onChange={(e) => setAccountFilter(e.target.value)}
+                            title={t('monitor.filters.by_account')}
+                        >
+                            <option value="">{t('monitor.filters.all_accounts')}</option>
+                            {uniqueAccounts.map(email => (
+                                <option key={email} value={email} title={email}>
+                                    {email}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
                     <div className="hidden lg:flex gap-4 text-[10px] font-bold uppercase">
                         <span className="text-blue-500">{formatCompactNumber(stats.total_requests)} REQS</span>
                         <span className="text-green-500">{formatCompactNumber(stats.success_count)} OK</span>
@@ -458,7 +498,7 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
                             {q.label}
                         </button>
                     ))}
-                    {filter && <button onClick={() => setFilter('')} className="text-[10px] text-blue-500"> {t('monitor.filters.reset')} </button>}
+                    {(filter || accountFilter) && <button onClick={() => { setFilter(''); setAccountFilter(''); }} className="text-[10px] text-blue-500"> {t('monitor.filters.reset')} </button>}
                 </div>
             </div>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -780,7 +780,9 @@
             "gemini": "Gemini",
             "claude": "Claude",
             "images": "Images",
-            "reset": "Reset"
+            "reset": "Reset",
+            "by_account": "Filter by account",
+            "all_accounts": "All Accounts"
         },
         "table": {
             "status": "Status",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -798,7 +798,9 @@
             "gemini": "Gemini",
             "claude": "Claude",
             "images": "画像",
-            "reset": "リセット"
+            "reset": "リセット",
+            "by_account": "アカウントでフィルタ",
+            "all_accounts": "すべてのアカウント"
         },
         "table": {
             "status": "ステータス",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -776,7 +776,9 @@
             "gemini": "Gemini",
             "claude": "Claude",
             "images": "Imagens",
-            "reset": "Redefinir"
+            "reset": "Redefinir",
+            "by_account": "Filtrar por conta",
+            "all_accounts": "Todas as Contas"
         },
         "table": {
             "status": "Status",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -774,7 +774,9 @@
             "gemini": "Gemini",
             "claude": "Claude",
             "images": "Изображения",
-            "reset": "Сброс"
+            "reset": "Сброс",
+            "by_account": "Фильтр по аккаунту",
+            "all_accounts": "Все аккаунты"
         },
         "table": {
             "status": "Статус",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -751,7 +751,9 @@
             "gemini": "Gemini",
             "claude": "Claude",
             "images": "Görseller",
-            "reset": "Sıfırla"
+            "reset": "Sıfırla",
+            "by_account": "Hesaba göre filtrele",
+            "all_accounts": "Tüm Hesaplar"
         },
         "table": {
             "status": "Durum",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -781,7 +781,9 @@
             "gemini": "Gemini",
             "claude": "Claude",
             "images": "Ảnh",
-            "reset": "Đặt lại"
+            "reset": "Đặt lại",
+            "by_account": "Lọc theo tài khoản",
+            "all_accounts": "Tất cả tài khoản"
         },
         "table": {
             "status": "Trạng thái",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -782,7 +782,9 @@
             "gemini": "Gemini",
             "claude": "Claude",
             "images": "繪圖",
-            "reset": "重置"
+            "reset": "重置",
+            "by_account": "按帳號篩選",
+            "all_accounts": "全部帳號"
         },
         "table": {
             "status": "狀態",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -780,7 +780,9 @@
             "gemini": "Gemini",
             "claude": "Claude",
             "images": "绘图",
-            "reset": "重置"
+            "reset": "重置",
+            "by_account": "按账号筛选",
+            "all_accounts": "全部账号"
         },
         "table": {
             "status": "状态",


### PR DESCRIPTION
## Summary
- 流量日志页面新增“按账号筛选”下拉菜单
- 下拉框显示完整邮箱，表格账号列悬停时显示完整邮箱
- 修复账号管理页面模型标签截断问题（固定宽度改为弹性宽度）
- i18n

## Changes
- `src/components/proxy/ProxyMonitor.tsx` - 新增账号筛选功能
- `src/components/accounts/AccountTable.tsx` - 修复模型标签宽度
- `src-tauri/src/modules/proxy_db.rs` - SQL 查詢新增 account_email 栏位搜寻
- `src/locales/*.json`