### PR TITLE
fix(i18n/tr): correct turkish language

### DIFF
--- a/src-tauri/src/modules/i18n.rs
+++ b/src-tauri/src/modules/i18n.rs
@@ -19,6 +19,7 @@ pub struct TrayTexts {
 fn load_translations(lang: &str) -> HashMap<String, String> {
     let json_content = match lang {
         "en" | "en-US" => include_str!("../../../src/locales/en.json"),
+        "tr" | "tr-TR" => include_str!("../../../src/locales/tr.json"),
         _ => include_str!("../../../src/locales/zh.json"),
     };
     


### PR DESCRIPTION
This pull request adds support for Turkish language translations to the application. The main update is to the translation loading logic, allowing the app to load Turkish translations when the language is set to "tr" or "tr-TR".

Localization improvements:

* Updated the `load_translations` function in `src-tauri/src/modules/i18n.rs` to include support for Turkish (`tr` and `tr-TR`) by loading the `tr.json` translation file.