### PR TITLE
fix(proxy): prevent invalid signature errors

### DIFF
--- a/src-tauri/src/proxy/mappers/claude/streaming.rs
+++ b/src-tauri/src/proxy/mappers/claude/streaming.rs
@@ -229,6 +229,8 @@ pub struct StreamingState {
     // [FIX #859] Post-thinking interruption tracking
     pub has_thinking: bool,
     pub has_content: bool,
+    // [NEW] Message count for Rewind detection in SignatureCache
+    pub message_count: usize,
 }
 
 impl StreamingState {
@@ -255,6 +257,7 @@ impl StreamingState {
             estimated_prompt_tokens: None,
             has_thinking: false,
             has_content: false,
+            message_count: 0,
         }
     }
 
@@ -772,7 +775,7 @@ impl<'a> PartProcessor<'a> {
 
             // 2. [NEW v3.3.17] Cache to session-based storage for tool loop recovery
             if let Some(session_id) = &self.state.session_id {
-                SignatureCache::global().cache_session_signature(session_id, sig.clone());
+                SignatureCache::global().cache_session_signature(session_id, sig.clone(), self.state.message_count);
                 tracing::debug!(
                     "[Claude-SSE] Cached signature to session {} (length: {})",
                     session_id,
@@ -971,7 +974,7 @@ impl<'a> PartProcessor<'a> {
 
             // 3. [NEW v3.3.17] Cache to session-based storage
             if let Some(session_id) = &self.state.session_id {
-                SignatureCache::global().cache_session_signature(session_id, sig.clone());
+                SignatureCache::global().cache_session_signature(session_id, sig.clone(), self.state.message_count);
             }
 
             tracing::debug!(

--- a/src-tauri/src/proxy/mappers/gemini/wrapper.rs
+++ b/src-tauri/src/proxy/mappers/gemini/wrapper.rs
@@ -169,7 +169,7 @@ mod test_fixes {
     fn test_wrap_request_with_signature() {
         let session_id = "test-session-sig";
         let signature = "test-signature-must-be-longer-than-fifty-characters-to-be-cached-by-signature-cache-12345"; // > 50 chars
-        crate::proxy::SignatureCache::global().cache_session_signature(session_id, signature.to_string());
+        crate::proxy::SignatureCache::global().cache_session_signature(session_id, signature.to_string(), 1);
 
         let body = json!({
             "model": "gemini-pro",


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
- Add Rewind detection to SignatureCache by tracking message count                                                                                                                                                 
- Implement fail-safe filtering for unverified signatures after server restart                                                                                                                                     
- Prevent 400 "Invalid signature" errors and unnecessary API retries
  
## Problem                                                                                                                                                                                                         
The `SignatureCache` is an in-memory cache that can become stale or invalid in several scenarios:                             
                                                                                                                                                                                                                     
1. **Server Restart**: Cache is cleared, but clients (like Claude Code) persist conversation history with old signatures                                                                                        
2. **User Rewind/Undo**: User deletes messages or rewinds conversation, causing signature mismatch                                                                                                              
3. **Long Context Sessions**: Extended conversations may have signature drift or expiration issues                                                                                                                                                                                            
                                                                                                                                                                                                                
In all cases, stale signatures cause upstream API to return:                                                                                                                                                    
"Invalid signature in thinking block"                                                                                                                                                                           
                                                                                                                                                                                                                
The current code handles this reactively - catching 400 errors and retrying with thinking blocks removed. This wastes one API round-trip per affected request.                                                                                                                                                                                                          

## Solution                                                                                                                                                                                                     
1. **Rewind Detection**: Track `message_count` alongside signatures in cache. When message count decreases (user rewinds/undoes), detect this and invalidate the cached signature.                              
                                                                                                                                                                                                                
2. **Fail-safe Filtering**: In `filter_invalid_thinking_blocks_with_family()`, when a signature is not found in cache (cache miss), proactively strip it instead of passing through to upstream.                
                                                                                                                                                                                                                
## Changes                                                                                                                                                                                                      
- `signature_cache.rs`: Add `SessionSignatureEntry` struct with `message_count`, implement Rewind detection logic                                                                                               
- `thinking_utils.rs`: Add cache-miss filtering branch for fail-safe behavior                                                                                                                                   
- `streaming.rs`: Add `message_count` field to `StreamingState`                                                                                                                                                 
- `response.rs`: Pass `message_count` to cache operations                                                                                                                                                       
- `mod.rs`: Thread `message_count` through stream creation                                                                                                                                                      
- `handlers/claude.rs`: Extract and pass `request.messages.len()`                                                                                                                                               
- `handlers/gemini.rs`: Compute message count from Gemini native request body (contents.len()) and pass it through for signature caching / Rewind detection               
- `Fail-safe Filtering`: In filter_invalid_thinking_blocks_with_family(), when doing family validation (target_family is set), drop thinking blocks whose signature is missing from the cache (cache miss) to avoid sending unverified signatures                                                                                                     
                                                                                                                                                                                                                
## Test Plan                                                                                                                                                                                                    
- [ ] Start dev server, have a thinking-mode conversation, verify normal operation                                                                                                                              
- [ ] **Server Restart**: Ctrl+C and restart server, continue same conversation                                                                                                                                       
  - Verify NO 400 "Invalid signature" error occurs                                                                                                                                                              
  - Verify conversation continues normally (model regenerates thinking)                                                                                                                                         
- [ ] **Rewind Detection**: In Claude Code, double press ESC to rewind conversation                                                                                                                   
  - Verify conversation continues without signature errors                                                                                                                                                      
- [ ] **Long Context**: Have extended multi-turn conversation with thinking mode                                                                                                                                
  - Verify signatures are properly tracked and updated                                                                                                                                                          
- [ ] Run `cargo test` - all tests pass