### PR TITLE
fix(openai): align retry and rate limit logic with claude handler

### DIFF
--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -1,6 +1,8 @@
 // OpenAI Handler
-use axum::{extract::Json, extract::State, http::StatusCode, response::IntoResponse, response::Response};
-use base64::Engine as _; 
+use axum::{
+    extract::Json, extract::State, http::StatusCode, response::IntoResponse, response::Response,
+};
+use base64::Engine as _;
 use bytes::Bytes;
 use serde_json::{json, Value};
 use tracing::{debug, error, info}; // Import Engine trait for encode method
@@ -12,9 +14,11 @@ use crate::proxy::mappers::openai::{
 use crate::proxy::server::AppState;
 
 const MAX_RETRY_ATTEMPTS: usize = 3;
+use super::common::{
+    apply_retry_strategy, determine_retry_strategy, should_rotate_account, RetryStrategy,
+};
 use crate::proxy::session_manager::SessionManager;
 use tokio::time::Duration;
-use super::common::{determine_retry_strategy, apply_retry_strategy, should_rotate_account, RetryStrategy};
 
 pub async fn handle_chat_completions(
     State(state): State<AppState>,
@@ -22,12 +26,12 @@ pub async fn handle_chat_completions(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     // [NEW] 自动检测并转换 Responses 格式
     // 如果请求包含 instructions 或 input 但没有 messages，则认为是 Responses 格式
-    let is_responses_format = !body.get("messages").is_some() 
+    let is_responses_format = !body.get("messages").is_some()
         && (body.get("instructions").is_some() || body.get("input").is_some());
-    
+
     if is_responses_format {
         debug!("Detected Responses API format, converting to Chat Completions format");
-        
+
         // 转换 instructions 为 system message
         if let Some(instructions) = body.get("instructions").and_then(|v| v.as_str()) {
             if !instructions.is_empty() {
@@ -35,19 +39,19 @@ pub async fn handle_chat_completions(
                     "role": "system",
                     "content": instructions
                 });
-                
+
                 // 初始化 messages 数组
                 if !body.get("messages").is_some() {
                     body["messages"] = json!([]);
                 }
-                
+
                 // 将 system message 插入到开头
                 if let Some(messages) = body.get_mut("messages").and_then(|v| v.as_array_mut()) {
                     messages.insert(0, system_msg);
                 }
             }
         }
-        
+
         // 转换 input 为 user message（如果存在）
         if let Some(input) = body.get("input") {
             let user_msg = if input.is_string() {
@@ -62,7 +66,7 @@ pub async fn handle_chat_completions(
                     "content": input.to_string()
                 })
             };
-            
+
             if let Some(messages) = body.get_mut("messages").and_then(|v| v.as_array_mut()) {
                 messages.push(user_msg);
             }
@@ -118,8 +122,8 @@ pub async fn handle_chat_completions(
             &openai_req.model,
             &mapped_model,
             &tools_val,
-            None,  // size (not used in handler, transform_openai_request handles it)
-            None   // quality
+            None, // size (not used in handler, transform_openai_request handles it)
+            None, // quality
         );
 
         // 3. 提取 SessionId (粘性指纹)
@@ -128,20 +132,24 @@ pub async fn handle_chat_completions(
         // 4. 获取 Token (使用准确的 request_type)
         // 关键：在重试尝试 (attempt > 0) 时强制轮换账号
         let (access_token, project_id, email) = match token_manager
-            .get_token(&config.request_type, attempt > 0, Some(&session_id), &mapped_model)
+            .get_token(
+                &config.request_type,
+                attempt > 0,
+                Some(&session_id),
+                &mapped_model,
+            )
             .await
         {
             Ok(t) => t,
             Err(e) => {
                 // [FIX] Attach headers to error response for logging visibility
-                let headers = [
-                    ("X-Mapped-Model", mapped_model.as_str()),
-                ];
+                let headers = [("X-Mapped-Model", mapped_model.as_str())];
                 return Ok((
                     StatusCode::SERVICE_UNAVAILABLE,
                     headers,
                     format!("Token error: {}", e),
-                ).into_response());
+                )
+                    .into_response());
             }
         };
 
@@ -162,9 +170,12 @@ pub async fn handle_chat_completions(
         let actual_stream = client_wants_stream || force_stream_internally;
 
         if force_stream_internally {
-            debug!("[{}] 🔄 Auto-converting non-stream request to stream for better quota", trace_id);
+            debug!(
+                "[{}] 🔄 Auto-converting non-stream request to stream for better quota",
+                trace_id
+            );
         }
-        
+
         let method = if actual_stream {
             "streamGenerateContent"
         } else {
@@ -199,30 +210,35 @@ pub async fn handle_chat_completions(
                 use futures::StreamExt;
 
                 let gemini_stream = response.bytes_stream();
-                
+
                 // [P1 FIX] Enhanced Peek logic to handle heartbeats and slow start
                 // Pre-read until we find meaningful content, skip heartbeats
                 let mut openai_stream =
                     create_openai_sse_stream(Box::pin(gemini_stream), openai_req.model.clone());
-                
+
                 let mut first_data_chunk = None;
                 let mut retry_this_account = false;
-                
+
                 // Loop to skip heartbeats during peek
                 loop {
-                    match tokio::time::timeout(std::time::Duration::from_secs(60), openai_stream.next()).await {
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(60),
+                        openai_stream.next(),
+                    )
+                    .await
+                    {
                         Ok(Some(Ok(bytes))) => {
                             if bytes.is_empty() {
                                 continue;
                             }
-                            
+
                             let text = String::from_utf8_lossy(&bytes);
                             // Skip SSE comments/pings (heartbeats)
                             if text.trim().starts_with(":") || text.trim().starts_with("data: :") {
                                 tracing::debug!("[OpenAI] Skipping peek heartbeat");
                                 continue;
                             }
-                            
+
                             // Check for error events
                             if text.contains("\"error\"") {
                                 tracing::warn!("[OpenAI] Error detected during peek, retrying...");
@@ -230,7 +246,7 @@ pub async fn handle_chat_completions(
                                 retry_this_account = true;
                                 break;
                             }
-                            
+
                             // We found real data!
                             first_data_chunk = Some(bytes);
                             break;
@@ -242,30 +258,35 @@ pub async fn handle_chat_completions(
                             break;
                         }
                         Ok(None) => {
-                            tracing::warn!("[OpenAI] Stream ended during peek (Empty Response), retrying...");
+                            tracing::warn!(
+                                "[OpenAI] Stream ended during peek (Empty Response), retrying..."
+                            );
                             last_error = "Empty response stream during peek".to_string();
                             retry_this_account = true;
                             break;
                         }
                         Err(_) => {
-                            tracing::warn!("[OpenAI] Timeout waiting for first data (60s), retrying...");
+                            tracing::warn!(
+                                "[OpenAI] Timeout waiting for first data (60s), retrying..."
+                            );
                             last_error = "Timeout waiting for first data".to_string();
                             retry_this_account = true;
                             break;
                         }
                     }
                 }
-                
+
                 if retry_this_account {
                     continue; // Rotate to next account
                 }
-                
+
                 // Combine first chunk with remaining stream
-                let combined_stream = futures::stream::once(async move { 
-                    Ok::<Bytes, String>(first_data_chunk.unwrap()) 
-                })
-                .chain(openai_stream);
-                
+                let combined_stream =
+                    futures::stream::once(
+                        async move { Ok::<Bytes, String>(first_data_chunk.unwrap()) },
+                    )
+                    .chain(openai_stream);
+
                 if client_wants_stream {
                     // 客户端请求流式，返回 SSE
                     let body = Body::from_stream(combined_stream);
@@ -283,19 +304,27 @@ pub async fn handle_chat_completions(
                     // 客户端请求非流式，但内部强制转为流式
                     // 收集流数据并聚合为 JSON
                     use crate::proxy::mappers::openai::collector::collect_stream_to_json;
-                    
+
                     match collect_stream_to_json(Box::pin(combined_stream)).await {
                         Ok(full_response) => {
                             info!("[{}] ✓ Stream collected and converted to JSON", trace_id);
                             return Ok((
-                                StatusCode::OK, 
-                                [("X-Account-Email", email.as_str()), ("X-Mapped-Model", mapped_model.as_str())], 
-                                Json(full_response)
-                            ).into_response());
-                        },
+                                StatusCode::OK,
+                                [
+                                    ("X-Account-Email", email.as_str()),
+                                    ("X-Mapped-Model", mapped_model.as_str()),
+                                ],
+                                Json(full_response),
+                            )
+                                .into_response());
+                        }
                         Err(e) => {
                             error!("[{}] Stream collection error: {}", trace_id, e);
-                            return Ok((StatusCode::INTERNAL_SERVER_ERROR, format!("Stream collection error: {}", e)).into_response());
+                            return Ok((
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                format!("Stream collection error: {}", e),
+                            )
+                                .into_response());
                         }
                     }
                 }
@@ -307,13 +336,28 @@ pub async fn handle_chat_completions(
                 .map_err(|e| (StatusCode::BAD_GATEWAY, format!("Parse error: {}", e)))?;
 
             let openai_response = transform_openai_response(&gemini_resp);
-            return Ok((StatusCode::OK, [("X-Account-Email", email.as_str()), ("X-Mapped-Model", mapped_model.as_str())], Json(openai_response)).into_response());
+            return Ok((
+                StatusCode::OK,
+                [
+                    ("X-Account-Email", email.as_str()),
+                    ("X-Mapped-Model", mapped_model.as_str()),
+                ],
+                Json(openai_response),
+            )
+                .into_response());
         }
 
         // 处理特定错误并重试
         let status_code = status.as_u16();
-        let _retry_after = response.headers().get("Retry-After").and_then(|h| h.to_str().ok()).map(|s| s.to_string());
-        let error_text = response.text().await.unwrap_or_else(|_| format!("HTTP {}", status_code));
+        let _retry_after = response
+            .headers()
+            .get("Retry-After")
+            .and_then(|h| h.to_str().ok())
+            .map(|s| s.to_string());
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| format!("HTTP {}", status_code));
         last_error = format!("HTTP {}: {}", status_code, error_text);
 
         // [New] 打印错误报文日志
@@ -326,17 +370,57 @@ pub async fn handle_chat_completions(
         // 确定重试策略
         let strategy = determine_retry_strategy(status_code, &error_text, false);
 
+        // 3. 标记限流状态(用于 UI 显示)
+        if status_code == 429 || status_code == 529 || status_code == 503 || status_code == 500 {
+            // [FIX] Use async version with model parameter for fine-grained rate limiting
+            token_manager
+                .mark_rate_limited_async(
+                    &email,
+                    status_code,
+                    _retry_after.as_deref(),
+                    &error_text,
+                    Some(&mapped_model),
+                )
+                .await;
+        }
+
         // 执行退避
         if apply_retry_strategy(strategy, attempt, max_attempts, status_code, &trace_id).await {
             // 判断是否需要轮换账号
             if !should_rotate_account(status_code) {
-                debug!("[{}] Keeping same account for status {} (server-side issue)", trace_id, status_code);
+                debug!(
+                    "[{}] Keeping same account for status {} (server-side issue)",
+                    trace_id, status_code
+                );
             }
+
+            // 2. [REMOVED] 不再特殊处理 QUOTA_EXHAUSTED，允许账号轮换
+            // if error_text.contains("QUOTA_EXHAUSTED") { ... }
+            /*
+            if error_text.contains("QUOTA_EXHAUSTED") {
+                error!(
+                    "OpenAI Quota exhausted (429) on account {} attempt {}/{}, stopping to protect pool.",
+                    email,
+                    attempt + 1,
+                    max_attempts
+                );
+                return Ok((status, [("X-Account-Email", email.as_str()), ("X-Mapped-Model", mapped_model.as_str())], error_text).into_response());
+            }
+            */
+
+            // 3. 其他限流或服务器过载情况，轮换账号
+            tracing::warn!(
+                "OpenAI Upstream {} on {} attempt {}/{}, rotating account",
+                status_code,
+                email,
+                attempt + 1,
+                max_attempts
+            );
             continue;
         }
 
         // [NEW] 处理 400 错误 (Thinking 签名失效)
-        if status_code == 400 
+        if status_code == 400
             && (error_text.contains("Invalid `signature`")
                 || error_text.contains("thinking.signature")
                 || error_text.contains("Invalid signature")
@@ -346,12 +430,12 @@ pub async fn handle_chat_completions(
                 "[OpenAI] Signature error detected on account {}, retrying without thinking",
                 email
             );
-            
+
             // 追加修复提示词到最后一条用户消息
             if let Some(last_msg) = openai_req.messages.last_mut() {
                 if last_msg.role == "user" {
                     let repair_prompt = "\n\n[System Recovery] Your previous output contained an invalid signature. Please regenerate the response without the corrupted signature block.";
-                    
+
                     if let Some(content) = &mut last_msg.content {
                         use crate::proxy::mappers::openai::{OpenAIContent, OpenAIContentBlock};
                         match content {
@@ -360,7 +444,7 @@ pub async fn handle_chat_completions(
                             }
                             OpenAIContent::Array(arr) => {
                                 arr.push(OpenAIContentBlock::Text {
-                                    text: repair_prompt.to_string()
+                                    text: repair_prompt.to_string(),
                                 });
                             }
                         }
@@ -368,7 +452,7 @@ pub async fn handle_chat_completions(
                     }
                 }
             }
-            
+
             continue; // 重试
         }
 
@@ -379,8 +463,10 @@ pub async fn handle_chat_completions(
                 attempt,
                 max_attempts,
                 status_code,
-                &trace_id
-            ).await {
+                &trace_id,
+            )
+            .await
+            {
                 continue;
             }
         }
@@ -390,7 +476,15 @@ pub async fn handle_chat_completions(
             "OpenAI Upstream non-retryable error {} on account {}: {}",
             status_code, email, error_text
         );
-        return Ok((status, [("X-Account-Email", email.as_str()), ("X-Mapped-Model", mapped_model.as_str())], error_text).into_response());
+        return Ok((
+            status,
+            [
+                ("X-Account-Email", email.as_str()),
+                ("X-Mapped-Model", mapped_model.as_str()),
+            ],
+            error_text,
+        )
+            .into_response());
     }
 
     // 所有尝试均失败
@@ -399,13 +493,15 @@ pub async fn handle_chat_completions(
             StatusCode::TOO_MANY_REQUESTS,
             [("X-Account-Email", email), ("X-Mapped-Model", mapped_model)],
             format!("All accounts exhausted. Last error: {}", last_error),
-        ).into_response())
+        )
+            .into_response())
     } else {
         Ok((
             StatusCode::TOO_MANY_REQUESTS,
             [("X-Mapped-Model", mapped_model)],
             format!("All accounts exhausted. Last error: {}", last_error),
-        ).into_response())
+        )
+            .into_response())
     }
 }
 
@@ -672,30 +768,31 @@ pub async fn handle_completions(
     // [Fix Phase 2] Backport normalization logic from handle_chat_completions
     // Handle "instructions" + "input" (Codex style) -> system + user messages
     // This is critical because `transform_openai_request` expects `messages` to be populated.
-    
+
     // [FIX] 检查是否已经有 messages (被第一次标准化处理过)
     let has_codex_fields = body.get("instructions").is_some() || body.get("input").is_some();
-    let already_normalized = body.get("messages")
+    let already_normalized = body
+        .get("messages")
         .and_then(|m| m.as_array())
         .map(|arr| !arr.is_empty())
         .unwrap_or(false);
-    
+
     // 只有在未标准化时才进行简单转换
     if has_codex_fields && !already_normalized {
         tracing::debug!("[Codex] Performing simple normalization (messages not yet populated)");
-        
+
         let mut messages = Vec::new();
-        
+
         // instructions -> system message
         if let Some(inst) = body.get("instructions").and_then(|v| v.as_str()) {
             if !inst.is_empty() {
                 messages.push(json!({
                     "role": "system",
-                    "content": inst 
+                    "content": inst
                 }));
             }
         }
-        
+
         // input -> user message (支持对象数组形式的对话历史)
         if let Some(input) = body.get("input") {
             if let Some(s) = input.as_str() {
@@ -705,8 +802,12 @@ pub async fn handle_completions(
                 }));
             } else if let Some(arr) = input.as_array() {
                 // 判断是消息对象数组还是简单的内容块/字符串数组
-                let is_message_array = arr.first().and_then(|v| v.as_object()).map(|obj| obj.contains_key("role")).unwrap_or(false);
-                
+                let is_message_array = arr
+                    .first()
+                    .and_then(|v| v.as_object())
+                    .map(|obj| obj.contains_key("role"))
+                    .unwrap_or(false);
+
                 if is_message_array {
                     // 深度识别：像处理 messages 一样处理 input 数组
                     for item in arr {
@@ -714,12 +815,20 @@ pub async fn handle_completions(
                     }
                 } else {
                     // 降级处理：传统的字符串或混合内容拼接
-                    let content = arr.iter().map(|v| {
-                        if let Some(s) = v.as_str() { s.to_string() }
-                        else if v.is_object() { v.to_string() }
-                        else { "".to_string() }
-                    }).collect::<Vec<_>>().join("\n");
-                    
+                    let content = arr
+                        .iter()
+                        .map(|v| {
+                            if let Some(s) = v.as_str() {
+                                s.to_string()
+                            } else if v.is_object() {
+                                v.to_string()
+                            } else {
+                                "".to_string()
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+
                     if !content.is_empty() {
                         messages.push(json!({
                             "role": "user",
@@ -737,22 +846,24 @@ pub async fn handle_completions(
                 }
             };
         }
-        
+
         if let Some(obj) = body.as_object_mut() {
-            tracing::debug!("[Codex] Injecting normalized messages: {} messages", messages.len());
+            tracing::debug!(
+                "[Codex] Injecting normalized messages: {} messages",
+                messages.len()
+            );
             obj.insert("messages".to_string(), json!(messages));
         }
     } else if already_normalized {
-        tracing::debug!("[Codex] Skipping normalization (messages already populated by first pass)");
+        tracing::debug!(
+            "[Codex] Skipping normalization (messages already populated by first pass)"
+        );
     }
 
     let mut openai_req: OpenAIRequest = match serde_json::from_value(body.clone()) {
         Ok(req) => req,
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                format!("Invalid request: {}", e),
-            ).into_response();
+            return (StatusCode::BAD_REQUEST, format!("Invalid request: {}", e)).into_response();
         }
     };
 
@@ -799,30 +910,38 @@ pub async fn handle_completions(
             &openai_req.model,
             &mapped_model,
             &tools_val,
-            None,  // size
-            None   // quality
+            None, // size
+            None, // quality
         );
 
         // 3. 提取 SessionId (复用)
         // [New] 使用 TokenManager 内部逻辑提取 session_id，支持粘性调度
         let session_id_str = SessionManager::extract_openai_session_id(&openai_req);
         let session_id = Some(session_id_str.as_str());
-        
+
         // 重试时强制轮换，除非只是简单的网络抖动但 Claude 逻辑里 attempt > 0 总是 force_rotate
         let force_rotate = attempt > 0;
 
-        let (access_token, project_id, email) =
-            match token_manager.get_token(&config.request_type, force_rotate, session_id, &mapped_model).await {
-                Ok(t) => t,
-                Err(e) => {
-                    return (
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        [("X-Mapped-Model", mapped_model)],
-                        format!("Token error: {}", e),
-                    ).into_response()
-                }
-            };
-        
+        let (access_token, project_id, email) = match token_manager
+            .get_token(
+                &config.request_type,
+                force_rotate,
+                session_id,
+                &mapped_model,
+            )
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    [("X-Mapped-Model", mapped_model)],
+                    format!("Token error: {}", e),
+                )
+                    .into_response()
+            }
+        };
+
         last_email = Some(email.clone());
 
         info!("✓ Using account: {} (type: {})", email, config.request_type);
@@ -830,8 +949,14 @@ pub async fn handle_completions(
         let gemini_body = transform_openai_request(&openai_req, &project_id, &mapped_model);
 
         // [New] 打印转换后的报文 (Gemini Body) 供调试 (Codex 路径) ———— 缩减为 simple debug
-        debug!("[Codex-Request] Transformed Gemini Body ({} parts)", 
-           gemini_body.get("contents").and_then(|c| c.as_array()).map(|a| a.len()).unwrap_or(0));
+        debug!(
+            "[Codex-Request] Transformed Gemini Body ({} parts)",
+            gemini_body
+                .get("contents")
+                .and_then(|c| c.as_array())
+                .map(|a| a.len())
+                .unwrap_or(0)
+        );
 
         // [AUTO-CONVERSION] For Legacy/Codex as well
         let client_wants_stream = openai_req.stream;
@@ -851,7 +976,12 @@ pub async fn handle_completions(
             Ok(r) => r,
             Err(e) => {
                 last_error = e.clone();
-                debug!("Codex Request failed on attempt {}/{}: {}", attempt + 1, max_attempts, e);
+                debug!(
+                    "Codex Request failed on attempt {}/{}: {}",
+                    attempt + 1,
+                    max_attempts,
+                    e
+                );
                 continue;
             }
         };
@@ -867,12 +997,12 @@ pub async fn handle_completions(
                 use futures::StreamExt;
 
                 let gemini_stream = response.bytes_stream();
-                
+
                 // DECISION: Which stream to create?
                 // If client wants stream: give them what they asked (Legacy/Codex SSE).
                 // If forced stream: use Chat SSE + Collector, because our collector works on Chat format
                 // and we already have logic to convert Chat JSON -> Legacy JSON.
-                
+
                 if client_wants_stream {
                     let mut openai_stream = if is_codex_style {
                         use crate::proxy::mappers::openai::streaming::create_codex_sse_stream;
@@ -885,13 +1015,22 @@ pub async fn handle_completions(
                     // [P1 FIX] Enhanced Peek logic (Reused from above/standard)
                     let mut first_data_chunk = None;
                     let mut retry_this_account = false;
-                    
+
                     loop {
-                        match tokio::time::timeout(std::time::Duration::from_secs(60), openai_stream.next()).await {
+                        match tokio::time::timeout(
+                            std::time::Duration::from_secs(60),
+                            openai_stream.next(),
+                        )
+                        .await
+                        {
                             Ok(Some(Ok(bytes))) => {
-                                if bytes.is_empty() { continue; }
+                                if bytes.is_empty() {
+                                    continue;
+                                }
                                 let text = String::from_utf8_lossy(&bytes);
-                                if text.trim().starts_with(":") || text.trim().starts_with("data: :") {
+                                if text.trim().starts_with(":")
+                                    || text.trim().starts_with("data: :")
+                                {
                                     continue;
                                 }
                                 if text.contains("\"error\"") {
@@ -919,13 +1058,13 @@ pub async fn handle_completions(
                             }
                         }
                     }
-                    
+
                     if retry_this_account {
-                        continue; 
+                        continue;
                     }
-                    
-                    let combined_stream = futures::stream::once(async move { 
-                        Ok::<Bytes, String>(first_data_chunk.unwrap()) 
+
+                    let combined_stream = futures::stream::once(async move {
+                        Ok::<Bytes, String>(first_data_chunk.unwrap())
                     })
                     .chain(openai_stream);
 
@@ -942,23 +1081,35 @@ pub async fn handle_completions(
                     // Forced Stream Internal -> Convert to Legacy JSON
                     // Use CHAT SSE Stream (so Collector can parse it)
                     use crate::proxy::mappers::openai::streaming::create_openai_sse_stream;
-                    // Note: We use create_openai_sse_stream regardless of is_codex_style here, 
+                    // Note: We use create_openai_sse_stream regardless of is_codex_style here,
                     // because we just want the content aggregation which chat stream does well.
-                    let mut openai_stream = create_openai_sse_stream(Box::pin(gemini_stream), openai_req.model.clone());
+                    let mut openai_stream =
+                        create_openai_sse_stream(Box::pin(gemini_stream), openai_req.model.clone());
 
                     // Peek Logic (Repeated for safety/correctness on this stream type)
                     let mut first_data_chunk = None;
                     let mut retry_this_account = false;
                     loop {
-                        match tokio::time::timeout(std::time::Duration::from_secs(60), openai_stream.next()).await {
+                        match tokio::time::timeout(
+                            std::time::Duration::from_secs(60),
+                            openai_stream.next(),
+                        )
+                        .await
+                        {
                             Ok(Some(Ok(bytes))) => {
-                                if bytes.is_empty() { continue; }
+                                if bytes.is_empty() {
+                                    continue;
+                                }
                                 let text = String::from_utf8_lossy(&bytes);
-                                if text.trim().starts_with(":") || text.trim().starts_with("data: :") { continue; }
+                                if text.trim().starts_with(":")
+                                    || text.trim().starts_with("data: :")
+                                {
+                                    continue;
+                                }
                                 if text.contains("\"error\"") {
                                     last_error = "Error event in internal stream".to_string();
                                     retry_this_account = true;
-                                    break; 
+                                    break;
                                 }
                                 first_data_chunk = Some(bytes);
                                 break;
@@ -980,18 +1131,21 @@ pub async fn handle_completions(
                             }
                         }
                     }
-                    if retry_this_account { continue; }
+                    if retry_this_account {
+                        continue;
+                    }
 
-                    let combined_stream = futures::stream::once(async move { 
-                        Ok::<Bytes, String>(first_data_chunk.unwrap()) 
-                    }).chain(openai_stream);
+                    let combined_stream = futures::stream::once(async move {
+                        Ok::<Bytes, String>(first_data_chunk.unwrap())
+                    })
+                    .chain(openai_stream);
 
                     // Collect
                     use crate::proxy::mappers::openai::collector::collect_stream_to_json;
                     match collect_stream_to_json(Box::pin(combined_stream)).await {
-                         Ok(chat_resp) => {
-                             // NOW: Convert Chat Response -> Legacy Response (Same logic as below)
-                             let choices = chat_resp.choices.iter().map(|c| {
+                        Ok(chat_resp) => {
+                            // NOW: Convert Chat Response -> Legacy Response (Same logic as below)
+                            let choices = chat_resp.choices.iter().map(|c| {
                                 json!({
                                     "text": match &c.message.content {
                                         Some(crate::proxy::mappers::openai::OpenAIContent::String(s)) => s.clone(),
@@ -1012,11 +1166,23 @@ pub async fn handle_completions(
                                 "usage": chat_resp.usage
                             });
 
-                            return (StatusCode::OK, [("X-Account-Email", email.as_str()), ("X-Mapped-Model", mapped_model.as_str())], Json(legacy_resp)).into_response();
-                         },
-                         Err(e) => {
-                             return (StatusCode::INTERNAL_SERVER_ERROR, format!("Stream collection error: {}", e)).into_response();
-                         }
+                            return (
+                                StatusCode::OK,
+                                [
+                                    ("X-Account-Email", email.as_str()),
+                                    ("X-Mapped-Model", mapped_model.as_str()),
+                                ],
+                                Json(legacy_resp),
+                            )
+                                .into_response();
+                        }
+                        Err(e) => {
+                            return (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                format!("Stream collection error: {}", e),
+                            )
+                                .into_response();
+                        }
                     }
                 }
             }
@@ -1028,7 +1194,8 @@ pub async fn handle_completions(
                         StatusCode::BAD_GATEWAY,
                         [("X-Mapped-Model", mapped_model.as_str())],
                         format!("Parse error: {}", e),
-                    ).into_response();
+                    )
+                        .into_response();
                 }
             };
 
@@ -1056,13 +1223,28 @@ pub async fn handle_completions(
                 "usage": chat_resp.usage
             });
 
-            return (StatusCode::OK, [("X-Account-Email", email.as_str()), ("X-Mapped-Model", mapped_model.as_str())], Json(legacy_resp)).into_response();
+            return (
+                StatusCode::OK,
+                [
+                    ("X-Account-Email", email.as_str()),
+                    ("X-Mapped-Model", mapped_model.as_str()),
+                ],
+                Json(legacy_resp),
+            )
+                .into_response();
         }
 
         // Handle errors and retry
         let status_code = status.as_u16();
-        let retry_after = response.headers().get("Retry-After").and_then(|h| h.to_str().ok()).map(|s| s.to_string());
-        let error_text = response.text().await.unwrap_or_else(|_| format!("HTTP {}", status_code));
+        let retry_after = response
+            .headers()
+            .get("Retry-After")
+            .and_then(|h| h.to_str().ok())
+            .map(|s| s.to_string());
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| format!("HTTP {}", status_code));
         last_error = format!("HTTP {}: {}", status_code, error_text);
 
         tracing::error!(
@@ -1073,18 +1255,34 @@ pub async fn handle_completions(
 
         // 3. 标记限流状态(用于 UI 显示)
         if status_code == 429 || status_code == 529 || status_code == 503 || status_code == 500 {
-            token_manager.mark_rate_limited_async(&email, status_code, retry_after.as_deref(), &error_text, Some(&mapped_model)).await;
+            token_manager
+                .mark_rate_limited_async(
+                    &email,
+                    status_code,
+                    retry_after.as_deref(),
+                    &error_text,
+                    Some(&mapped_model),
+                )
+                .await;
         }
 
         // 确定重试策略
         let strategy = determine_retry_strategy(status_code, &error_text, false);
-        
+
         if apply_retry_strategy(strategy, attempt, max_attempts, status_code, &trace_id).await {
             // 继续重试 (loop 会增加 attempt, 导致 force_rotate=true)
             continue;
         } else {
             // 不可重试
-            return (status, [("X-Account-Email", email.as_str()), ("X-Mapped-Model", mapped_model.as_str())], error_text).into_response();
+            return (
+                status,
+                [
+                    ("X-Account-Email", email.as_str()),
+                    ("X-Mapped-Model", mapped_model.as_str()),
+                ],
+                error_text,
+            )
+                .into_response();
         }
     }
 
@@ -1094,31 +1292,34 @@ pub async fn handle_completions(
             StatusCode::TOO_MANY_REQUESTS,
             [("X-Account-Email", email), ("X-Mapped-Model", mapped_model)],
             format!("All accounts exhausted. Last error: {}", last_error),
-        ).into_response()
+        )
+            .into_response()
     } else {
         (
             StatusCode::TOO_MANY_REQUESTS,
             [("X-Mapped-Model", mapped_model)],
             format!("All accounts exhausted. Last error: {}", last_error),
-        ).into_response()
+        )
+            .into_response()
     }
 }
 
 pub async fn handle_list_models(State(state): State<AppState>) -> impl IntoResponse {
     use crate::proxy::common::model_mapping::get_all_dynamic_models;
 
-    let model_ids = get_all_dynamic_models(
-        &state.custom_mapping,
-    ).await;
+    let model_ids = get_all_dynamic_models(&state.custom_mapping).await;
 
-    let data: Vec<_> = model_ids.into_iter().map(|id| {
-        json!({
-            "id": id,
-            "object": "model",
-            "created": 1706745600,
-            "owned_by": "antigravity"
+    let data: Vec<_> = model_ids
+        .into_iter()
+        .map(|id| {
+            json!({
+                "id": id,
+                "object": "model",
+                "created": 1706745600,
+                "owned_by": "antigravity"
+            })
         })
-    }).collect();
+        .collect();
 
     Json(json!({
         "object": "list",
@@ -1178,7 +1379,7 @@ pub async fn handle_images_generations(
     let (image_config, _) = crate::proxy::mappers::common_utils::parse_image_config_with_params(
         model,
         Some(size),
-        Some(quality)
+        Some(quality),
     );
 
     // 3. Prompt Enhancement（保留原有逻辑）
@@ -1196,7 +1397,9 @@ pub async fn handle_images_generations(
     let upstream = state.upstream.clone();
     let token_manager = state.token_manager;
 
-    let (access_token, project_id, email) = match token_manager.get_token("image_gen", false, None, "dall-e-3").await
+    let (access_token, project_id, email) = match token_manager
+        .get_token("image_gen", false, None, "dall-e-3")
+        .await
     {
         Ok(t) => t,
         Err(e) => {
@@ -1353,8 +1556,9 @@ pub async fn handle_images_generations(
     Ok((
         StatusCode::OK,
         [("X-Account-Email", email.as_str())],
-        Json(openai_response)
-    ).into_response())
+        Json(openai_response),
+    )
+        .into_response())
 }
 
 pub async fn handle_images_edits(
@@ -1370,6 +1574,10 @@ pub async fn handle_images_edits(
     let mut size = "1024x1024".to_string();
     let mut response_format = "b64_json".to_string(); // Default to b64_json for better compatibility with tools handling edits
     let mut model = "gemini-3-pro-image".to_string();
+    let mut reference_images: Vec<String> = Vec::new();
+    let mut aspect_ratio: Option<String> = None;
+    let mut image_size_param: Option<String> = None;
+    let mut style: Option<String> = None;
 
     while let Some(field) = multipart
         .next_field()
@@ -1390,6 +1598,15 @@ pub async fn handle_images_edits(
                 .await
                 .map_err(|e| (StatusCode::BAD_REQUEST, format!("Mask read error: {}", e)))?;
             mask_data = Some(base64::engine::general_purpose::STANDARD.encode(data));
+        } else if name.starts_with("image") && name != "image_size" {
+            // Support image1, image2, etc.
+            let data = field.bytes().await.map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Reference image read error: {}", e),
+                )
+            })?;
+            reference_images.push(base64::engine::general_purpose::STANDARD.encode(data));
         } else if name == "prompt" {
             prompt = field
                 .text()
@@ -1402,6 +1619,18 @@ pub async fn handle_images_edits(
         } else if name == "size" {
             if let Ok(val) = field.text().await {
                 size = val;
+            }
+        } else if name == "image_size" {
+            if let Ok(val) = field.text().await {
+                image_size_param = Some(val);
+            }
+        } else if name == "aspect_ratio" {
+            if let Ok(val) = field.text().await {
+                aspect_ratio = Some(val);
+            }
+        } else if name == "style" {
+            if let Ok(val) = field.text().await {
+                style = Some(val);
             }
         } else if name == "response_format" {
             if let Ok(val) = field.text().await {
@@ -1447,8 +1676,9 @@ pub async fn handle_images_edits(
     // 1. 获取 Upstream
     let upstream = state.upstream.clone();
     let token_manager = state.token_manager;
-    // Fix: Proper get_token call with correct signature and unwrap (using image_gen quota)
-    let (access_token, project_id, email) = match token_manager.get_token("image_gen", false, None, "dall-e-3").await
+    let (access_token, project_id, email) = match token_manager
+        .get_token("image_gen", false, None, "dall-e-3")
+        .await
     {
         Ok(t) => t,
         Err(e) => {
@@ -1459,7 +1689,28 @@ pub async fn handle_images_edits(
         }
     };
 
-    // 2. 映射配置
+    // 2. Prepare Config (Aspect Ratio / Size)
+    // Priority: aspect_ratio param > size param
+    // Priority: image_size param > quality param (derived from model suffix or default)
+
+    // We reuse parse_image_config_with_params but need to adapt the inputs
+    let size_input = aspect_ratio.as_deref().or(Some(&size)); // If aspect_ratio is "16:9", it works. If it's just "1:1", it also works.
+
+    // Map 'image_size' (2K) to 'quality' semantics if needed, or pass directly if logic supports
+    // common_utils logic: 'hd' -> 4K, 'medium' -> 2K.
+    let quality_input = match image_size_param.as_deref() {
+        Some("4K") => Some("hd"),
+        Some("2K") => Some("medium"),
+        _ => None, // Fallback to standard
+    };
+
+    let (mut image_config, _) = crate::proxy::mappers::common_utils::parse_image_config_with_params(
+        &model,
+        size_input,
+        quality_input,
+    );
+
+    // 3. Construct Contents
     let mut contents_parts = Vec::new();
 
     contents_parts.push(json!({
@@ -1629,6 +1880,7 @@ pub async fn handle_images_edits(
     Ok((
         StatusCode::OK,
         [("X-Account-Email", email.as_str())],
-        Json(openai_response)
-    ).into_response())
+        Json(openai_response),
+    )
+        .into_response())
 }


### PR DESCRIPTION
- Ensure minimum 2 retry attempts even for single accounts to handle transient errors
- Use model-aware rate limiting (mark_rate_limited_async) to prevent account-wide lockouts
- Use mapped physical model name for accurate quota protection checks
- Allow account rotation on QUOTA_EXHAUSTED errors instead of hard stopping