### PR TITLE
fix(proxy): persist fixed account mode setting to prevent auto-reset

### DIFF
--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -123,7 +123,13 @@ pub async fn internal_start_proxy_service(
     let token_manager = Arc::new(TokenManager::new(accounts_dir));
     token_manager.start_auto_cleanup();
     token_manager.update_sticky_config(config.scheduling.clone()).await;
-    
+
+    // 🆕 [FIX #820] 恢复固定账号模式设置
+    if let Some(ref account_id) = config.preferred_account_id {
+        token_manager.set_preferred_account(Some(account_id.clone())).await;
+        tracing::info!("🔒 [FIX #820] Fixed account mode restored: {}", account_id);
+    }
+
     // 檢查並啟動管理服務器（如果尚未運行）
     ensure_admin_server(config.clone(), state, integration.clone(), cloudflared_state.clone()).await?;
 
@@ -651,7 +657,23 @@ pub async fn set_preferred_account(
     if let Some(instance) = instance_lock.as_ref() {
         // 过滤空字符串为 None
         let cleaned_id = account_id.filter(|s| !s.trim().is_empty());
-        instance.token_manager.set_preferred_account(cleaned_id).await;
+
+        // 1. 更新内存状态
+        instance.token_manager.set_preferred_account(cleaned_id.clone()).await;
+
+        // 2. 持久化到配置文件 (修复 Issue #820 自动关闭问题)
+        let mut app_config = crate::modules::config::load_app_config()
+            .map_err(|e| format!("加载配置失败: {}", e))?;
+        app_config.proxy.preferred_account_id = cleaned_id.clone();
+        crate::modules::config::save_app_config(&app_config)
+            .map_err(|e| format!("保存配置失败: {}", e))?;
+
+        if let Some(ref id) = cleaned_id {
+            tracing::info!("🔒 [FIX #820] Fixed account mode enabled and persisted: {}", id);
+        } else {
+            tracing::info!("🔄 [FIX #820] Round-robin mode enabled and persisted");
+        }
+
         Ok(())
     } else {
         Err("服务未运行".to_string())

--- a/src-tauri/src/proxy/config.rs
+++ b/src-tauri/src/proxy/config.rs
@@ -235,6 +235,12 @@ pub struct ProxyConfig {
     /// 实验性功能配置
     #[serde(default)]
     pub experimental: ExperimentalConfig,
+
+    /// 固定账号模式的账号ID (Fixed Account Mode)
+    /// - None: 使用轮询模式
+    /// - Some(account_id): 固定使用指定账号
+    #[serde(default)]
+    pub preferred_account_id: Option<String>,
 }
 
 /// 上游代理配置
@@ -263,6 +269,7 @@ impl Default for ProxyConfig {
             zai: ZaiConfig::default(),
             scheduling: crate::proxy::sticky_config::StickySessionConfig::default(),
             experimental: ExperimentalConfig::default(),
+            preferred_account_id: None, // 默认使用轮询模式
         }
     }
 }


### PR DESCRIPTION
修复固定账号模式设置自动重置的问题。

问题根因:
- preferred_account_id 仅保存在内存中,未持久化到配置文件
- 任何触发配置重新加载的操作(切换设置/重启服务)都会导致设置丢失

修复内容:
1. 在 ProxyConfig 中添加 preferred_account_id 字段
2. set_preferred_account 命令现在会立即保存配置到磁盘
3. 服务启动时从配置文件恢复固定账号设置

修复效果:
- ✅ 用户设置固定账号后立即持久化
- ✅ 切换其他配置时设置保持
- ✅ 重启服务后自动恢复
- ✅ 应用重启后设置持久化