### PR TITLE
fix(rate_limit): support millisecond parsing with decimal points

### DIFF
--- a/src-tauri/src/proxy/rate_limit.rs
+++ b/src-tauri/src/proxy/rate_limit.rs
@@ -233,9 +233,11 @@ impl RateLimitTracker {
                         lockout
                     },
                     RateLimitReason::RateLimitExceeded => {
-                        // 速率限制：通常是短暂的，使用较短的默认值（30秒）
-                        tracing::debug!("检测到速率限制 (RATE_LIMIT_EXCEEDED)，使用默认值 30秒");
-                        30
+                        // 🔧 [FIX] 速率限制：降低默认值从 30秒 → 5秒
+                        // 原因: 时间解析器修复后,多数情况会解析成功,不会走到这里
+                        // 即使解析失败,5秒也足够应对瞬时限流
+                        tracing::debug!("检测到速率限制 (RATE_LIMIT_EXCEEDED)，使用默认值 5秒");
+                        5
                     },
                     RateLimitReason::ModelCapacityExhausted => {
                         // 模型容量耗尽：服务端暂时无可用 GPU 实例
@@ -326,10 +328,11 @@ impl RateLimitTracker {
     /// 通用时间解析函数：支持 "2h1m1s" 等所有格式组合
     fn parse_duration_string(&self, s: &str) -> Option<u64> {
         tracing::debug!("[时间解析] 尝试解析: '{}'", s);
-        
+
         // 使用正则表达式提取小时、分钟、秒、毫秒
-        // 支持格式："2h1m1s", "1h30m", "5m", "30s", "500ms" 等
-        let re = Regex::new(r"(?:(\d+)h)?(?:(\d+)m)?(?:(\d+(?:\.\d+)?)s)?(?:(\d+)ms)?").ok()?;
+        // 支持格式："2h1m1s", "1h30m", "5m", "30s", "500ms", "510.790006ms" 等
+        // 🔧 [FIX] 修改 ms 部分支持小数: (\d+)ms -> (\d+(?:\.\d+)?)ms
+        let re = Regex::new(r"(?:(\d+)h)?(?:(\d+)m)?(?:(\d+(?:\.\d+)?)s)?(?:(\d+(?:\.\d+)?)ms)?").ok()?;
         let caps = match re.captures(s) {
             Some(c) => c,
             None => {
@@ -337,7 +340,7 @@ impl RateLimitTracker {
                 return None;
             }
         };
-        
+
         let hours = caps.get(1)
             .and_then(|m| m.as_str().parse::<u64>().ok())
             .unwrap_or(0);
@@ -347,22 +350,23 @@ impl RateLimitTracker {
         let seconds = caps.get(3)
             .and_then(|m| m.as_str().parse::<f64>().ok())
             .unwrap_or(0.0);
+        // 🔧 [FIX] 毫秒也支持小数解析
         let milliseconds = caps.get(4)
-            .and_then(|m| m.as_str().parse::<u64>().ok())
-            .unwrap_or(0);
-        
-        tracing::debug!("[时间解析] 提取结果: {}h {}m {:.3}s {}ms", hours, minutes, seconds, milliseconds);
-        
-        // 计算总秒数
-        let total_seconds = hours * 3600 + minutes * 60 + seconds.ceil() as u64 + (milliseconds + 999) / 1000;
-        
+            .and_then(|m| m.as_str().parse::<f64>().ok())
+            .unwrap_or(0.0);
+
+        tracing::debug!("[时间解析] 提取结果: {}h {}m {:.3}s {:.3}ms", hours, minutes, seconds, milliseconds);
+
+        // 🔧 [FIX] 计算总秒数，毫秒部分向上取整
+        let total_seconds = hours * 3600 + minutes * 60 + seconds.ceil() as u64 + (milliseconds / 1000.0).ceil() as u64;
+
         // 如果总秒数为 0，说明解析失败
         if total_seconds == 0 {
             tracing::warn!("[时间解析] 失败: '{}' (总秒数为0)", s);
             None
         } else {
-            tracing::info!("[时间解析] ✓ 成功: '{}' => {}秒 ({}h {}m {:.1}s)", 
-                s, total_seconds, hours, minutes, seconds);
+            tracing::info!("[时间解析] ✓ 成功: '{}' => {}秒 ({}h {}m {:.1}s {:.1}ms)",
+                s, total_seconds, hours, minutes, seconds, milliseconds);
             Some(total_seconds)
         }
     }


### PR DESCRIPTION
修复时间解析器无法处理小数毫秒格式的问题。

问题根因:
- Google API 返回 '510.790006ms' 格式的延迟时间
- 正则表达式只支持整数毫秒,解析失败
- 回退到 30 秒默认值,导致账号被错误锁定

修复内容:
1. 修改正则表达式支持小数毫秒: (\d+(?:\.\d+)?)ms
2. 毫秒计算逻辑改用 f64,向上取整
3. 降低默认回退时间: 30秒 -> 5秒

修复效果:
- ✅ '510.790006ms' -> 正确解析为 1 秒
- ✅ '304.641338ms' -> 正确解析为 1 秒
- ✅ 固定账号模式在限流时快速恢复
- ✅ 解决 "All accounts limited" 错误锁定过长问题