### PR TITLE
fix(gemini): resolve "Response stopped due to malformed function call." error for Gemini CLI

### DIFF
--- a/src-tauri/src/proxy/common/json_schema.rs
+++ b/src-tauri/src/proxy/common/json_schema.rs
@@ -383,17 +383,13 @@ fn clean_json_schema_recursive(value: &mut Value, is_schema_node: bool) -> bool 
                 }
 
                 // 6. [SAFETY] 处理空 Object
+                // [FIX] 移除 reason 字段注入逻辑
+                // 之前的实现会为空 Object 注入 reason 字段，导致 Gemini CLI 等工具报 "malformed function call"
+                // 因为模型会生成包含 reason 参数的调用，但工具定义中并没有这个参数
+                // 现在改为：空 Object 保持空的 properties，让 Gemini 模型自行决定是否需要参数
                 if map.get("type").and_then(|t| t.as_str()) == Some("object") {
-                    let has_props = map
-                        .get("properties")
-                        .and_then(|p| p.as_object())
-                        .map(|o| !o.is_empty())
-                        .unwrap_or(false);
-                    if !has_props {
-                        map.insert("properties".to_string(), serde_json::json!({
-                            "reason": { "type": "string", "description": "Reason for calling this tool" }
-                        }));
-                        map.insert("required".to_string(), serde_json::json!(["reason"]));
+                    if !map.contains_key("properties") {
+                        map.insert("properties".to_string(), serde_json::json!({}));
                     }
                 }
 


### PR DESCRIPTION
## Summary
  - Fix "Response stopped due to malformed function call" error when using Gemini CLI
  - Rename `parametersJsonSchema` to `parameters` in tool declarations for API compatibility
  - Remove unwanted `reason` field injection for empty object schemas

  ## Problem
  Users reported tool calls failing with "malformed function call" errors when using Gemini CLI through the proxy.

  ## Root Cause
  1. **Field name mismatch**: Gemini CLI uses `parametersJsonSchema`, but Gemini API expects `parameters`
  2. **Unwanted field injection**: Empty schemas were getting a `reason` field injected, causing unexpected parameters

  ## Test plan
  - [x] Verified Gemini CLI can now execute tool calls (e.g., "新建一个txt，内容123")
  - [x] Confirmed normal conversation still works

  🤖 Generated with [Claude Code](https://claude.com/claude-code)