### PR TITLE
feat: 记忆窗口大小和位置

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -4847,6 +4848,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.10.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -67,6 +67,7 @@ tauri-plugin-process = "2"
 sha2 = "0.10"
 toml = "0.8"
 toml_edit = "0.22"
+tauri-plugin-window-state = "2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -18,6 +18,7 @@
     "core:event:default",
     "autostart:allow-enable",
     "autostart:allow-disable",
-    "autostart:allow-is-enabled"
+    "autostart:allow-is-enabled",
+    "window-state:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -154,6 +154,7 @@ pub fn run() {
         ))
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             let _ = app.get_webview_window("main")
                 .map(|window| {


### PR DESCRIPTION
## Summary
每次打开软件后自动恢复上次关闭时的窗口大小和位置

## Implement
使用官方插件 `tauri-plugin-window-state`

## 注意
- 正常使用：调整窗口后通过托盘退出，下次启动自动恢复窗口大小和位置
- 恢复默认：删除 `%APPDATA%\com.lbjlaq.antigravity-tools\.window-state` 文件。其余平台类似