### PR TITLE
feat(i18n): localize remaining UI strings

### DIFF
--- a/src/components/accounts/AddAccountDialog.tsx
+++ b/src/components/accounts/AddAccountDialog.tsx
@@ -283,7 +283,7 @@ function AddAccountDialog({ onAdd }: AddAccountDialogProps) {
             const url = typeof res === 'string' ? res : res.url;
 
             if (!url) {
-                throw new Error('Could not obtain OAuth URL');
+                throw new Error(t('accounts.add.oauth.error_no_url', 'OAuth URLを取得できませんでした'));
             }
 
             setOauthUrl(url); // 确保链接在 UI 中可见，方便用户手动复制
@@ -293,7 +293,7 @@ function AddAccountDialog({ onAdd }: AddAccountDialogProps) {
 
             if (!popup) {
                 setStatus('error');
-                setMessage(t('common.error') + ': Popup blocked');
+                setMessage(t('accounts.add.oauth.popup_blocked', 'ポップアップがブロックされました'));
                 return;
             }
 
@@ -367,14 +367,14 @@ function AddAccountDialog({ onAdd }: AddAccountDialogProps) {
         if (!manualCode.trim()) return;
 
         setStatus('loading');
-        setMessage(t('accounts.add.oauth.manual_submitting', '正在提交授权码...') || 'Submitting code...');
+        setMessage(t('accounts.add.oauth.manual_submitting', '認可コードを送信中...'));
 
         try {
             await invoke('submit_oauth_code', { code: manualCode.trim(), state: null });
 
             // 提交成功反馈
             setStatus('success');
-            setMessage(t('accounts.add.oauth.manual_submitted', '授权码已提交，后台正在处理并刷新列表') || 'Code submitted! Backend is processing...');
+            setMessage(t('accounts.add.oauth.manual_submitted', '認可コードを送信しました。バックエンドで処理中です...'));
 
             setManualCode('');
 

--- a/src/components/common/NetworkMonitor.tsx
+++ b/src/components/common/NetworkMonitor.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { useNetworkMonitorStore, NetworkRequest } from '../../stores/networkMonitorStore';
 import { X, Play, Pause, Trash2, Activity, ChevronDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 const NetworkMonitor: React.FC = () => {
     const { requests, isOpen, setIsOpen, isRecording, toggleRecording, clearRequests } = useNetworkMonitorStore();
     const [selectedRequest, setSelectedRequest] = useState<NetworkRequest | null>(null);
+    const { t } = useTranslation();
 
     // If not open, show a small floating button
     if (!isOpen) {
@@ -13,7 +15,7 @@ const NetworkMonitor: React.FC = () => {
                 <button
                     onClick={() => setIsOpen(true)}
                     className="btn btn-circle btn-primary shadow-lg"
-                    title="Open Network Monitor"
+                    title={t('monitor.network.open', 'ネットワークモニターを開く')}
                 >
                     <Activity size={24} />
                     {requests.filter(r => r.status === 'pending').length > 0 && (
@@ -33,21 +35,25 @@ const NetworkMonitor: React.FC = () => {
             <div className="flex items-center justify-between p-4 border-b border-base-300 bg-base-200/50">
                 <div className="flex items-center gap-2">
                     <Activity className="text-primary" size={20} />
-                    <h2 className="font-bold text-lg">Network Monitor</h2>
-                    <span className="badge badge-sm">{requests.length} requests</span>
+                    <h2 className="font-bold text-lg">{t('monitor.network.title', 'ネットワークモニター')}</h2>
+                    <span className="badge badge-sm">
+                        {t('monitor.network.requests_count', '{{count}} 件', { count: requests.length })}
+                    </span>
                 </div>
                 <div className="flex items-center gap-2">
                     <button
                         onClick={toggleRecording}
                         className={`btn btn-sm btn-circle ${isRecording ? 'btn-error' : 'btn-success'}`}
-                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                        title={isRecording
+                            ? t('monitor.network.stop_recording', '記録を停止')
+                            : t('monitor.network.start_recording', '記録を開始')}
                     >
                         {isRecording ? <Pause size={14} /> : <Play size={14} />}
                     </button>
                     <button
                         onClick={clearRequests}
                         className="btn btn-sm btn-circle btn-ghost"
-                        title="Clear Requests"
+                        title={t('monitor.network.clear_requests', 'リクエストをクリア')}
                     >
                         <Trash2 size={16} />
                     </button>
@@ -67,10 +73,10 @@ const NetworkMonitor: React.FC = () => {
                     <table className="table table-xs table-pin-rows w-full">
                         <thead>
                             <tr className="bg-base-200">
-                                <th className="w-16">Status</th>
-                                <th>Command</th>
-                                <th className="w-20 text-right">Time</th>
-                                <th className="w-20 text-right">Duration</th>
+                                <th className="w-16">{t('monitor.network.table.status', '状態')}</th>
+                                <th>{t('monitor.network.table.command', 'コマンド')}</th>
+                                <th className="w-20 text-right">{t('monitor.network.table.time', '時刻')}</th>
+                                <th className="w-20 text-right">{t('monitor.network.table.duration', '所要時間')}</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -97,7 +103,7 @@ const NetworkMonitor: React.FC = () => {
                             {requests.length === 0 && (
                                 <tr>
                                     <td colSpan={4} className="text-center py-8 opacity-50">
-                                        No requests recorded
+                                        {t('monitor.network.empty', '記録されたリクエストはありません')}
                                     </td>
                                 </tr>
                             )}
@@ -110,30 +116,30 @@ const NetworkMonitor: React.FC = () => {
                     <div className="flex-1 md:w-1/2 overflow-y-auto bg-base-100 flex flex-col absolute inset-0 md:static z-10 w-full">
                         <div className="flex items-center justify-between p-2 border-b border-base-300 bg-base-200/30 md:hidden">
                             <button onClick={() => setSelectedRequest(null)} className="btn btn-sm btn-ghost">
-                                <ChevronDown size={16} className="rotate-90" /> Back
+                                <ChevronDown size={16} className="rotate-90" /> {t('common.back', '戻る')}
                             </button>
                             <span className="font-mono text-xs">{selectedRequest.cmd}</span>
                         </div>
 
                         <div className="p-4 space-y-4">
                             <div>
-                                <h3 className="text-xs font-bold uppercase opacity-50 mb-1">General</h3>
+                                <h3 className="text-xs font-bold uppercase opacity-50 mb-1">{t('monitor.network.sections.general', '概要')}</h3>
                                 <div className="bg-base-200 rounded p-2 text-xs space-y-1">
                                     <div className="flex justify-between">
                                         <span className="opacity-70">ID:</span>
                                         <span className="font-mono select-all">{selectedRequest.id}</span>
                                     </div>
                                     <div className="flex justify-between">
-                                        <span className="opacity-70">Status:</span>
+                                        <span className="opacity-70">{t('monitor.network.fields.status', '状態')}:</span>
                                         <BadgeStatus status={selectedRequest.status} />
                                     </div>
                                     <div className="flex justify-between">
-                                        <span className="opacity-70">Start Time:</span>
+                                        <span className="opacity-70">{t('monitor.network.fields.start_time', '開始時刻')}:</span>
                                         <span>{new Date(selectedRequest.startTime).toLocaleString()}</span>
                                     </div>
                                     {selectedRequest.duration && (
                                         <div className="flex justify-between">
-                                            <span className="opacity-70">Duration:</span>
+                                            <span className="opacity-70">{t('monitor.network.fields.duration', '所要時間')}:</span>
                                             <span>{selectedRequest.duration}ms</span>
                                         </div>
                                     )}
@@ -141,13 +147,15 @@ const NetworkMonitor: React.FC = () => {
                             </div>
 
                             <div>
-                                <h3 className="text-xs font-bold uppercase opacity-50 mb-1">Request Args</h3>
+                                <h3 className="text-xs font-bold uppercase opacity-50 mb-1">{t('monitor.network.sections.request_args', 'リクエスト引数')}</h3>
                                 <JsonView data={selectedRequest.args} />
                             </div>
 
                             <div>
                                 <h3 className="text-xs font-bold uppercase opacity-50 mb-1">
-                                    {selectedRequest.status === 'error' ? 'Error Details' : 'Response'}
+                                    {selectedRequest.status === 'error'
+                                        ? t('monitor.network.sections.error_details', 'エラー詳細')
+                                        : t('monitor.network.sections.response', 'レスポンス')}
                                 </h3>
                                 {(selectedRequest.response || selectedRequest.error) ? (
                                     <JsonView
@@ -155,7 +163,7 @@ const NetworkMonitor: React.FC = () => {
                                         isError={selectedRequest.status === 'error'}
                                     />
                                 ) : (
-                                    <div className="text-xs opacity-50 italic">Waiting for response...</div>
+                                    <div className="text-xs opacity-50 italic">{t('monitor.network.waiting', '応答待ち...')}</div>
                                 )}
                             </div>
                         </div>
@@ -167,19 +175,21 @@ const NetworkMonitor: React.FC = () => {
 };
 
 const BadgeStatus = ({ status }: { status: NetworkRequest['status'] }) => {
+    const { t } = useTranslation();
     switch (status) {
         case 'success':
             return <span className="badge badge-xs badge-success">200</span>;
         case 'error':
-            return <span className="badge badge-xs badge-error">Err</span>;
+            return <span className="badge badge-xs badge-error">{t('monitor.network.badge_error', 'エラー')}</span>;
         case 'pending':
             return <span className="loading loading-spinner loading-xs text-warning"></span>;
     }
 };
 
 const JsonView = ({ data, isError = false }: { data: any, isError?: boolean }) => {
+    const { t } = useTranslation();
     if (data === undefined || data === null) {
-        return <div className="text-xs opacity-50 italic">Empty</div>;
+        return <div className="text-xs opacity-50 italic">{t('common.empty', '空')}</div>;
     }
 
     return (

--- a/src/components/proxy/ProxyMonitor.tsx
+++ b/src/components/proxy/ProxyMonitor.tsx
@@ -123,7 +123,7 @@ const LogTable: React.FC<LogTableProps> = ({
             {loading && (
                 <div className="flex items-center justify-center p-4 bg-white dark:bg-base-100">
                     <div className="loading loading-spinner loading-md"></div>
-                    <span className="ml-3 text-sm text-gray-500">{t('common.loading') || 'Loading...'}</span>
+                    <span className="ml-3 text-sm text-gray-500">{t('common.loading')}</span>
                 </div>
             )}
 
@@ -244,6 +244,8 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
     };
 
     const totalPages = Math.ceil(totalCount / pageSize);
+    const pageStart = totalCount === 0 ? 0 : (currentPage - 1) * pageSize + 1;
+    const pageEnd = totalCount === 0 ? 0 : Math.min(currentPage * pageSize, totalCount);
 
     const goToPage = (page: number) => {
         if (page >= 1 && page <= totalPages && page !== currentPage) {
@@ -480,12 +482,12 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
                     </div>
 
                     <div className="hidden lg:flex gap-4 text-[10px] font-bold uppercase">
-                        <span className="text-blue-500">{formatCompactNumber(stats.total_requests)} REQS</span>
-                        <span className="text-green-500">{formatCompactNumber(stats.success_count)} OK</span>
-                        <span className="text-red-500">{formatCompactNumber(stats.error_count)} ERR</span>
+                        <span className="text-blue-500">{formatCompactNumber(stats.total_requests)} {t('monitor.stats.total')}</span>
+                        <span className="text-green-500">{formatCompactNumber(stats.success_count)} {t('monitor.stats.ok')}</span>
+                        <span className="text-red-500">{formatCompactNumber(stats.error_count)} {t('monitor.stats.err')}</span>
                     </div>
 
-                    <button onClick={() => loadData(currentPage, filter)} className="btn btn-sm btn-ghost text-gray-400" title={t('common.refresh') || 'Refresh'}>
+                    <button onClick={() => loadData(currentPage, filter)} className="btn btn-sm btn-ghost text-gray-400" title={t('common.refresh')}>
                         <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
                     </button>
                     <button onClick={clearLogs} className="btn btn-sm btn-ghost text-gray-400">
@@ -525,7 +527,7 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
             {/* Pagination Controls */}
             <div className="flex items-center justify-between px-4 py-3 bg-gray-50 dark:bg-base-200 border-t border-gray-200 dark:border-base-300 text-xs">
                 <div className="flex items-center gap-2 whitespace-nowrap">
-                    <span className="text-gray-500">Per page</span>
+                    <span className="text-gray-500">{t('common.per_page')}</span>
                     <select
                         value={pageSize}
                         onChange={(e) => setPageSize(Number(e.target.value))}
@@ -558,7 +560,7 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
                 </div>
 
                 <div className="text-gray-500">
-                    Total {totalCount} records
+                    {t('common.pagination_info', { start: pageStart, end: pageEnd, total: totalCount })}
                 </div>
             </div>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,7 @@
 {
     "common": {
         "loading": "Loading...",
+        "empty": "Empty",
         "load_more": "Load More",
         "add": "Add",
         "copy": "Copy",
@@ -33,7 +34,9 @@
         "disabled": "Disabled",
         "tauri_api_not_loaded": "Tauri API not loaded, please restart the app",
         "environment_error": "Environment error: {{error}}",
-        "submit": "Submit"
+        "submit": "Submit",
+        "retry": "Retry",
+        "back": "Back"
     },
     "nav": {
         "dashboard": "Dashboard",
@@ -205,7 +208,11 @@
                 "link_click_to_copy": "Click to copy",
                 "manual_hint": "Browser didn't redirect? Paste the full callback URL or raw Code here:",
                 "manual_placeholder": "Paste callback URL or code...",
-                "error_no_flow": "Please click 'Start OAuth' first"
+                "error_no_flow": "Please click 'Start OAuth' first",
+                "error_no_url": "Could not obtain OAuth URL",
+                "popup_blocked": "Popup blocked",
+                "manual_submitting": "Submitting authorization code...",
+                "manual_submitted": "Authorization code submitted. Backend is processing..."
             },
             "token": {
                 "label": "Refresh Token",
@@ -391,6 +398,10 @@
             "support_alipay": "Alipay",
             "support_wechat": "WeChat Pay",
             "support_buymeacoffee": "Buy Me a Coffee"
+        },
+        "branding": {
+            "title": "Antigravity Tools",
+            "subtitle": "Professional Account Management"
         }
     },
     "tray": {
@@ -406,6 +417,9 @@
     },
     "proxy": {
         "title": "API Proxy Service",
+        "error": {
+            "load_failed": "Failed to load configuration"
+        },
         "status": {
             "running": "Service Running",
             "stopped": "Service Stopped",
@@ -851,6 +865,34 @@
         "dialog": {
             "clear_title": "Clear Proxy Logs",
             "clear_msg": "Are you sure you want to clear all proxy logs? This action cannot be undone."
+        },
+        "network": {
+            "title": "Network Monitor",
+            "open": "Open Network Monitor",
+            "requests_count": "{{count}} requests",
+            "start_recording": "Start Recording",
+            "stop_recording": "Stop Recording",
+            "clear_requests": "Clear Requests",
+            "empty": "No requests recorded",
+            "waiting": "Waiting for response...",
+            "badge_error": "Error",
+            "table": {
+                "status": "Status",
+                "command": "Command",
+                "time": "Time",
+                "duration": "Duration"
+            },
+            "sections": {
+                "general": "General",
+                "request_args": "Request Args",
+                "error_details": "Error Details",
+                "response": "Response"
+            },
+            "fields": {
+                "status": "Status",
+                "start_time": "Start Time",
+                "duration": "Duration"
+            }
         }
     },
     "update_notification": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -34,7 +34,9 @@
         "tauri_api_not_loaded": "Tauri APIが読み込まれていません。アプリを再起動してください",
         "environment_error": "環境エラー: {{error}}",
         "load_more": "もっと読み込む",
-        "submit": "送信"
+        "submit": "送信",
+        "retry": "再試行",
+        "back": "戻る"
     },
     "nav": {
         "dashboard": "ダッシュボード",
@@ -199,7 +201,11 @@
                 "link_click_to_copy": "クリックしてコピー",
                 "manual_hint": "ブラウザがリダイレクトされませんでしたか？ここにコールバックURLまたはコードを貼り付けてください：",
                 "manual_placeholder": "コールバックURLまたはコードを貼り付け...",
-                "error_no_flow": "まず「OAuth認証を開始」をクリックしてください"
+                "error_no_flow": "まず「OAuth認証を開始」をクリックしてください",
+                "error_no_url": "OAuth URLを取得できませんでした",
+                "popup_blocked": "ポップアップがブロックされました",
+                "manual_submitting": "認可コードを送信中...",
+                "manual_submitted": "認可コードを送信しました。バックエンドで処理中です..."
             },
             "token": {
                 "label": "リフレッシュトークン",
@@ -379,7 +385,7 @@
             "support_desc": "このプロジェクトがお役に立てば、コーヒーを一杯ご馳走してください！皆様のサポートが、プロジェクトを継続する最大の動機です。",
             "support_alipay": "Alipay",
             "support_wechat": "WeChat Pay",
-            "support_buymeacoffee": "Buy Me a Coffee"
+            "support_buymeacoffee": "コーヒーを奢る"
         },
         "quota_protection": {
             "auto_restore_info": "クォータがリセットされると、アカウントは自動的に再度有効になります",
@@ -414,6 +420,9 @@
     },
     "proxy": {
         "title": "APIプロキシサービス",
+        "error": {
+            "load_failed": "設定の読み込みに失敗しました"
+        },
         "status": {
             "running": "サービス稼働中",
             "stopped": "サービス停止中",
@@ -869,7 +878,32 @@
             "clear_msg": "すべてのプロキシログをクリアしてもよろしいですか？この操作は取り消せません。"
         },
         "network": {
-            "title": "ネットワークモニター"
+            "title": "ネットワークモニター",
+            "open": "ネットワークモニターを開く",
+            "requests_count": "{{count}} 件",
+            "start_recording": "記録を開始",
+            "stop_recording": "記録を停止",
+            "clear_requests": "リクエストをクリア",
+            "empty": "記録されたリクエストはありません",
+            "waiting": "応答待ち...",
+            "badge_error": "エラー",
+            "table": {
+                "status": "状態",
+                "command": "コマンド",
+                "time": "時刻",
+                "duration": "所要時間"
+            },
+            "sections": {
+                "general": "概要",
+                "request_args": "リクエスト引数",
+                "error_details": "エラー詳細",
+                "response": "レスポンス"
+            },
+            "fields": {
+                "status": "状態",
+                "start_time": "開始時刻",
+                "duration": "所要時間"
+            }
         }
     },
     "update_notification": {

--- a/src/pages/ApiProxy.tsx
+++ b/src/pages/ApiProxy.tsx
@@ -863,7 +863,7 @@ print(response.text)`;
                         <div className="flex flex-col items-center gap-4">
                             <RefreshCw size={32} className="animate-spin text-blue-500" />
                             <span className="text-sm text-gray-500 dark:text-gray-400">
-                                {t('common.loading') || 'Loading...'}
+                                {t('common.loading')}
                             </span>
                         </div>
                     </div>
@@ -878,7 +878,7 @@ print(response.text)`;
                             </div>
                             <div className="space-y-2">
                                 <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                                    {t('proxy.error.load_failed') || 'Failed to load configuration'}
+                                    {t('proxy.error.load_failed')}
                                 </h3>
                                 <p className="text-sm text-gray-500 dark:text-gray-400 max-w-md">
                                     {configError}
@@ -889,7 +889,7 @@ print(response.text)`;
                                 className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm font-medium flex items-center gap-2 transition-colors"
                             >
                                 <RefreshCw size={16} />
-                                {t('common.retry') || 'Retry'}
+                                {t('common.retry')}
                             </button>
                         </div>
                     </div>
@@ -909,7 +909,7 @@ print(response.text)`;
                                     <div className={`w-2 h-2 rounded-full ${status.running ? 'bg-green-500 animate-pulse' : 'bg-gray-400'}`} />
                                     <span className={`text-xs font-medium ${status.running ? 'text-green-600' : 'text-gray-500'}`}>
                                         {status.running
-                                            ? `${t('proxy.status.running')} (${status.active_accounts} ${t('common.accounts') || 'Accounts'})`
+                                            ? `${t('proxy.status.running')} (${status.active_accounts} ${t('common.accounts')})`
                                             : t('proxy.status.stopped')}
                                     </span>
                                 </div>
@@ -1360,7 +1360,7 @@ print(response.text)`;
                                                                 value=""
                                                                 onChange={(e) => e.target.value && updateZaiDefaultModels({ [family]: e.target.value })}
                                                             >
-                                                                <option value="">Select</option>
+                                                                <option value="">{t('proxy.config.zai.models.select_placeholder')}</option>
                                                                 {zaiModelOptions.map(m => <option key={m} value={m}>{m}</option>)}
                                                             </select>
                                                         )}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -898,7 +898,7 @@ function Settings() {
                                                 v4.0.8
                                             </span>
                                             <span className="text-gray-400 dark:text-gray-600">•</span>
-                                            <span className="text-gray-500 dark:text-gray-400">Professional Account Management</span>
+                                            <span className="text-gray-500 dark:text-gray-400">{t('settings.branding.subtitle')}</span>
                                         </div>
                                     </div>
                                 </div>
@@ -1069,7 +1069,7 @@ function Settings() {
                                     <div className="w-full aspect-square relative bg-white rounded-xl overflow-hidden shadow-sm border border-gray-100">
                                         <img src="/images/donate/coffee.png" alt="Buy Me A Coffee" className="w-full h-full object-contain" />
                                     </div>
-                                    <span className="text-xs font-bold text-gray-700 dark:text-gray-300">Buy Me a Coffee</span>
+                                    <span className="text-xs font-bold text-gray-700 dark:text-gray-300">{t('settings.about.support_buymeacoffee')}</span>
                                 </div>
                             </div>
 


### PR DESCRIPTION
## Summary
- Localize remaining UI strings and remove English fallbacks (Network Monitor, Proxy Monitor, Proxy settings, Settings > About, OAuth web flow).
- Add missing i18n keys for Japanese and keep English locale in sync.

## Test Plan
- [ ] Switch language to Japanese and verify affected screens show Japanese text (model names unchanged).
- [ ] Smoke test: Proxy page, Monitor page, Settings > About, Add Account (OAuth web).