### PR TITLE
修复: Claude thinking 模型 thinking_budget 超限 400 错误

### DIFF
--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -1618,10 +1618,13 @@ fn build_generation_config(
 
             if let Some(budget_tokens) = thinking.budget_tokens {
                 let mut budget = budget_tokens;
-                // [FIX] Broaden check to support all Flash thinking models (e.g. gemini-2.0-flash-thinking)
-                let is_flash_model =
-                    has_web_search || claude_req.model.to_lowercase().contains("flash");
-                if is_flash_model {
+                // [FIX] 所有转发到 Gemini 的 thinking 模型都受 24576 上限约束
+                // 包括: flash 模型、claude-*-thinking 模型、带 web_search 的请求
+                let model_lower = claude_req.model.to_lowercase();
+                let is_gemini_limited = has_web_search 
+                    || model_lower.contains("flash")
+                    || model_lower.ends_with("-thinking");  // claude-opus-4-5-thinking 等
+                if is_gemini_limited {
                     budget = budget.min(24576);
                 }
                 thinking_config["thinkingBudget"] = json!(budget);


### PR DESCRIPTION
## 问题现象
使用 `claude-opus-4-5-thinking`、`claude-sonnet-4-5-thinking` 等模型时，API 返回 400 错误：
```
400 Unable to submit request because thinking_budget is out of range; 
supported values are integers from 1 to 24576.
```

## 根本原因
1. 代理默认将 `thinking_budget` 设置为 `32000`
2. `claude-*-thinking` 模型在 Antigravity 中被转发到 Gemini API
3. 现有的限流逻辑只检查模型名是否包含 `"flash"`，而 `claude-opus-4-5-thinking` 不匹配
4. 导致 `32000` 超过 Gemini 的硬限制 `24576`

## 解决方案
扩展 `thinking_budget` 限流逻辑，使所有转发到 Gemini 的 thinking 模型都受 `24576` 上限约束：

**openai/request.rs:**
```rust
let is_gemini_limited = mapped_model_lower.contains("flash") 
    || mapped_model_lower.contains("gemini-1.5")
    || is_claude_thinking;  // 新增
```

**claude/request.rs:**
```rust
let is_gemini_limited = has_web_search 
    || model_lower.contains("flash")
    || model_lower.ends_with("-thinking");  // 新增
```

## 影响范围
- 所有以 `-thinking` 结尾的 Claude 模型（`claude-opus-4-5-thinking`、`claude-sonnet-4-5-thinking`）
- 无功能影响：24576 tokens 的思考预算对绝大多数任务足够充裕
- 现有测试全部通过

## 测试验证
```
test proxy::mappers::openai::request::tests::test_flash_thinking_budget_capping ... ok
test proxy::mappers::claude::request::tests::test_claude_flash_thinking_budget_capping ... ok
test proxy::mappers::gemini::wrapper::tests::test_gemini_flash_thinking_budget_capping ... ok
```