### PR TITLE
Feat/优先使用刷新时间更近的账号进行请求轮换

### DIFF
--- a/src-tauri/src/modules/account_service.rs
+++ b/src-tauri/src/modules/account_service.rs
@@ -26,7 +26,7 @@ impl AccountService {
 
         // 4. 构造 TokenData
         let token = TokenData::new(
-            token_res.access_token,
+            token_res.access_token.clone(),
             refresh_token.to_string(),
             token_res.expires_in,
             Some(user_info.email.clone()),
@@ -35,13 +35,43 @@ impl AccountService {
         );
 
         // 5. 持久化
-        let account = modules::upsert_account(
-            user_info.email.clone(),
-            user_info.get_display_name(),
-            token
-        )?;
+        let mut account =
+            modules::upsert_account(user_info.email.clone(), user_info.get_display_name(), token)?;
 
-        modules::logger::log_info(&format!("[Service] Added/Updated account: {}", account.email));
+        // 6. [NEW] 自动获取配额信息（用于刷新时间排序）
+        let email_for_log = account.email.clone();
+        let access_token = token_res.access_token.clone();
+        match modules::quota::fetch_quota(&access_token, &email_for_log).await {
+            Ok((quota_data, new_project_id)) => {
+                account.quota = Some(quota_data);
+                if let Some(pid) = new_project_id {
+                    account.token.project_id = Some(pid);
+                }
+                // 保存更新后的账号信息
+                if let Err(e) = modules::account::save_account(&account) {
+                    modules::logger::log_warn(&format!(
+                        "[Service] Failed to save quota for {}: {}",
+                        email_for_log, e
+                    ));
+                } else {
+                    modules::logger::log_info(&format!(
+                        "[Service] Fetched quota for new account: {}",
+                        email_for_log
+                    ));
+                }
+            }
+            Err(e) => {
+                modules::logger::log_warn(&format!(
+                    "[Service] Failed to fetch quota for {}: {}",
+                    email_for_log, e
+                ));
+            }
+        }
+
+        modules::logger::log_info(&format!(
+            "[Service] Added/Updated account: {}",
+            account.email
+        ));
         Ok(account)
     }
 
@@ -99,14 +129,21 @@ impl AccountService {
         modules::oauth_server::cancel_oauth_flow();
     }
 
-    pub async fn submit_oauth_code(&self, code: String, state: Option<String>) -> Result<(), String> {
+    pub async fn submit_oauth_code(
+        &self,
+        code: String,
+        state: Option<String>,
+    ) -> Result<(), String> {
         modules::oauth_server::submit_oauth_code(code, state).await
     }
 
-    async fn process_oauth_token(&self, token_res: modules::oauth::TokenResponse) -> Result<Account, String> {
-        let refresh_token = token_res.refresh_token.ok_or_else(|| {
-            "未获取到 Refresh Token。请撤销权限后重试。".to_string()
-        })?;
+    async fn process_oauth_token(
+        &self,
+        token_res: modules::oauth::TokenResponse,
+    ) -> Result<Account, String> {
+        let refresh_token = token_res
+            .refresh_token
+            .ok_or_else(|| "未获取到 Refresh Token。请撤销权限后重试。".to_string())?;
 
         let user_info = modules::oauth::get_user_info(&token_res.access_token).await?;
         let project_id = crate::proxy::project_resolver::fetch_project_id(&token_res.access_token)

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -16,25 +16,25 @@ pub struct ProxyToken {
     pub expires_in: i64,
     pub timestamp: i64,
     pub email: String,
-    pub account_path: PathBuf,  // 账号文件路径，用于更新
+    pub account_path: PathBuf, // 账号文件路径，用于更新
     pub project_id: Option<String>,
     pub subscription_tier: Option<String>, // "FREE" | "PRO" | "ULTRA"
-    pub remaining_quota: Option<i32>, // [FIX #563] Remaining quota for priority sorting
+    pub remaining_quota: Option<i32>,      // [FIX #563] Remaining quota for priority sorting
     pub protected_models: HashSet<String>, // [NEW #621]
-    pub health_score: f32, // [NEW] 健康分数 (0.0 - 1.0)
+    pub health_score: f32,                 // [NEW] 健康分数 (0.0 - 1.0)
+    pub reset_time: Option<i64>,           // [NEW] 配额刷新时间戳（用于排序优化）
 }
 
-
 pub struct TokenManager {
-    tokens: Arc<DashMap<String, ProxyToken>>,  // account_id -> ProxyToken
+    tokens: Arc<DashMap<String, ProxyToken>>, // account_id -> ProxyToken
     current_index: Arc<AtomicUsize>,
     last_used_account: Arc<tokio::sync::Mutex<Option<(String, std::time::Instant)>>>,
     data_dir: PathBuf,
-    rate_limit_tracker: Arc<RateLimitTracker>,  // 新增: 限流跟踪器
+    rate_limit_tracker: Arc<RateLimitTracker>, // 新增: 限流跟踪器
     sticky_config: Arc<tokio::sync::RwLock<StickySessionConfig>>, // 新增：调度配置
     session_accounts: Arc<DashMap<String, String>>, // 新增：会话与账号映射 (SessionID -> AccountID)
     preferred_account_id: Arc<tokio::sync::RwLock<Option<String>>>, // [FIX #820] 优先使用的账号ID（固定账号模式）
-    health_scores: Arc<DashMap<String, f32>>, // account_id -> health_score
+    health_scores: Arc<DashMap<String, f32>>,                       // account_id -> health_score
     circuit_breaker_config: Arc<tokio::sync::RwLock<crate::models::CircuitBreakerConfig>>, // [NEW] 熔断配置缓存
 }
 
@@ -51,7 +51,9 @@ impl TokenManager {
             session_accounts: Arc::new(DashMap::new()),
             preferred_account_id: Arc::new(tokio::sync::RwLock::new(None)), // [FIX #820]
             health_scores: Arc::new(DashMap::new()),
-            circuit_breaker_config: Arc::new(tokio::sync::RwLock::new(crate::models::CircuitBreakerConfig::default())),
+            circuit_breaker_config: Arc::new(tokio::sync::RwLock::new(
+                crate::models::CircuitBreakerConfig::default(),
+            )),
         }
     }
 
@@ -64,17 +66,20 @@ impl TokenManager {
                 interval.tick().await;
                 let cleaned = tracker.cleanup_expired();
                 if cleaned > 0 {
-                    tracing::info!("🧹 Auto-cleanup: Removed {} expired rate limit record(s)", cleaned);
+                    tracing::info!(
+                        "🧹 Auto-cleanup: Removed {} expired rate limit record(s)",
+                        cleaned
+                    );
                 }
             }
         });
         tracing::info!("✅ Rate limit auto-cleanup task started (interval: 15s)");
     }
-    
+
     /// 从主应用账号目录加载所有账号
     pub async fn load_accounts(&self) -> Result<usize, String> {
         let accounts_dir = self.data_dir.join("accounts");
-        
+
         if !accounts_dir.exists() {
             return Err(format!("账号目录不存在: {:?}", accounts_dir));
         }
@@ -86,42 +91,45 @@ impl TokenManager {
             let mut last_used = self.last_used_account.lock().await;
             *last_used = None;
         }
-        
-        let entries = std::fs::read_dir(&accounts_dir)
-            .map_err(|e| format!("读取账号目录失败: {}", e))?;
-        
+
+        let entries =
+            std::fs::read_dir(&accounts_dir).map_err(|e| format!("读取账号目录失败: {}", e))?;
+
         let mut count = 0;
-        
+
         for entry in entries {
             let entry = entry.map_err(|e| format!("读取目录项失败: {}", e))?;
             let path = entry.path();
-            
+
             if path.extension().and_then(|s| s.to_str()) != Some("json") {
                 continue;
             }
-            
+
             // 尝试加载账号
             match self.load_single_account(&path).await {
                 Ok(Some(token)) => {
                     let account_id = token.account_id.clone();
                     self.tokens.insert(account_id, token);
                     count += 1;
-                },
+                }
                 Ok(None) => {
                     // 跳过无效账号
-                },
+                }
                 Err(e) => {
                     tracing::debug!("加载账号失败 {:?}: {}", path, e);
                 }
             }
         }
-        
+
         Ok(count)
     }
 
     /// 重新加载指定账号（用于配额更新后的实时同步）
     pub async fn reload_account(&self, account_id: &str) -> Result<(), String> {
-        let path = self.data_dir.join("accounts").join(format!("{}.json", account_id));
+        let path = self
+            .data_dir
+            .join("accounts")
+            .join(format!("{}.json", account_id));
         if !path.exists() {
             return Err(format!("账号文件不存在: {:?}", path));
         }
@@ -145,14 +153,13 @@ impl TokenManager {
         self.clear_all_rate_limits();
         Ok(count)
     }
-    
+
     /// 加载单个账号
     async fn load_single_account(&self, path: &PathBuf) -> Result<Option<ProxyToken>, String> {
-        let content = std::fs::read_to_string(path)
-            .map_err(|e| format!("读取文件失败: {}", e))?;
-        
-        let mut account: serde_json::Value = serde_json::from_str(&content)
-            .map_err(|e| format!("解析 JSON 失败: {}", e))?;
+        let content = std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?;
+
+        let mut account: serde_json::Value =
+            serde_json::from_str(&content).map_err(|e| format!("解析 JSON 失败: {}", e))?;
 
         if account
             .get("disabled")
@@ -162,27 +169,34 @@ impl TokenManager {
             tracing::debug!(
                 "Skipping disabled account file: {:?} (email={})",
                 path,
-                account.get("email").and_then(|v| v.as_str()).unwrap_or("<unknown>")
+                account
+                    .get("email")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>")
             );
             return Ok(None);
         }
 
-
         // [修复 #1344] 先检查账号是否被手动禁用(非配额保护原因)
-        let is_proxy_disabled = account.get("proxy_disabled")
+        let is_proxy_disabled = account
+            .get("proxy_disabled")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        
-        let disabled_reason = account.get("proxy_disabled_reason")
+
+        let disabled_reason = account
+            .get("proxy_disabled_reason")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        
+
         if is_proxy_disabled && disabled_reason != "quota_protection" {
             // 账号被手动禁用(非配额保护原因)
             tracing::debug!(
                 "Account skipped due to manual disable: {:?} (email={}, reason={})",
                 path,
-                account.get("email").and_then(|v| v.as_str()).unwrap_or("<unknown>"),
+                account
+                    .get("email")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>"),
                 disabled_reason
             );
             return Ok(None);
@@ -194,7 +208,10 @@ impl TokenManager {
             tracing::debug!(
                 "Account skipped due to quota protection: {:?} (email={})",
                 path,
-                account.get("email").and_then(|v| v.as_str()).unwrap_or("<unknown>")
+                account
+                    .get("email")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>")
             );
             return Ok(None);
         }
@@ -210,56 +227,61 @@ impl TokenManager {
             tracing::debug!(
                 "Skipping proxy-disabled account file: {:?} (email={})",
                 path,
-                account.get("email").and_then(|v| v.as_str()).unwrap_or("<unknown>")
+                account
+                    .get("email")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>")
             );
             return Ok(None);
         }
 
+        let account_id = account["id"].as_str().ok_or("缺少 id 字段")?.to_string();
 
-        let account_id = account["id"].as_str()
-            .ok_or("缺少 id 字段")?
-            .to_string();
-        
-        let email = account["email"].as_str()
+        let email = account["email"]
+            .as_str()
             .ok_or("缺少 email 字段")?
             .to_string();
-        
-        let token_obj = account["token"].as_object()
-            .ok_or("缺少 token 字段")?;
-        
-        let access_token = token_obj["access_token"].as_str()
+
+        let token_obj = account["token"].as_object().ok_or("缺少 token 字段")?;
+
+        let access_token = token_obj["access_token"]
+            .as_str()
             .ok_or("缺少 access_token")?
             .to_string();
-        
-        let refresh_token = token_obj["refresh_token"].as_str()
+
+        let refresh_token = token_obj["refresh_token"]
+            .as_str()
             .ok_or("缺少 refresh_token")?
             .to_string();
-        
-        let expires_in = token_obj["expires_in"].as_i64()
-            .ok_or("缺少 expires_in")?;
-        
-        let timestamp = token_obj["expiry_timestamp"].as_i64()
+
+        let expires_in = token_obj["expires_in"].as_i64().ok_or("缺少 expires_in")?;
+
+        let timestamp = token_obj["expiry_timestamp"]
+            .as_i64()
             .ok_or("缺少 expiry_timestamp")?;
-        
+
         // project_id 是可选的
-        let project_id = token_obj.get("project_id")
+        let project_id = token_obj
+            .get("project_id")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
-        
-        
+
         // 【新增】提取订阅等级 (subscription_tier 为 "FREE" | "PRO" | "ULTRA")
-        let subscription_tier = account.get("quota")
+        let subscription_tier = account
+            .get("quota")
             .and_then(|q| q.get("subscription_tier"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
-        
+
         // [FIX #563] 提取最大剩余配额百分比用于优先级排序 (Option<i32> now)
-        let remaining_quota = account.get("quota")
+        let remaining_quota = account
+            .get("quota")
             .and_then(|q| self.calculate_quota_stats(q));
-            // .filter(|&r| r > 0); // 移除 >0 过滤，因为 0% 也是有效数据，只是优先级低
-        
+        // .filter(|&r| r > 0); // 移除 >0 过滤，因为 0% 也是有效数据，只是优先级低
+
         // 【新增 #621】提取受限模型列表
-        let protected_models: HashSet<String> = account.get("protected_models")
+        let protected_models: HashSet<String> = account
+            .get("protected_models")
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
@@ -268,9 +290,16 @@ impl TokenManager {
                     .collect()
             })
             .unwrap_or_default();
-        
-        let health_score = self.health_scores.get(&account_id).map(|v| *v).unwrap_or(1.0);
-        
+
+        let health_score = self
+            .health_scores
+            .get(&account_id)
+            .map(|v| *v)
+            .unwrap_or(1.0);
+
+        // [NEW] 提取最近的配额刷新时间（用于排序优化：刷新时间越近优先级越高）
+        let reset_time = self.extract_earliest_reset_time(&account);
+
         Ok(Some(ProxyToken {
             account_id,
             access_token,
@@ -284,23 +313,27 @@ impl TokenManager {
             remaining_quota,
             protected_models,
             health_score,
+            reset_time,
         }))
     }
 
-    
     /// 检查账号是否应该被配额保护
     /// 如果配额低于阈值，自动禁用账号并返回 true
-    async fn check_and_protect_quota(&self, account_json: &mut serde_json::Value, account_path: &PathBuf) -> bool {
+    async fn check_and_protect_quota(
+        &self,
+        account_json: &mut serde_json::Value,
+        account_path: &PathBuf,
+    ) -> bool {
         // 1. 加载配额保护配置
         let config = match crate::modules::config::load_app_config() {
             Ok(cfg) => cfg.quota_protection,
             Err(_) => return false, // 配置加载失败，跳过保护
         };
-        
+
         if !config.enabled {
             return false; // 配额保护未启用
         }
-        
+
         // 2. 获取配额信息
         // 注意：我们需要 clone 配额信息来遍历，避免借用冲突，但修改是针对 account_json 的
         let quota = match account_json.get("quota") {
@@ -309,21 +342,25 @@ impl TokenManager {
         };
 
         // 3. [兼容性 #621] 检查是否被旧版账号级配额保护禁用,尝试恢复并转为模型级
-        let is_proxy_disabled = account_json.get("proxy_disabled")
+        let is_proxy_disabled = account_json
+            .get("proxy_disabled")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        
-        let reason = account_json.get("proxy_disabled_reason")
+
+        let reason = account_json
+            .get("proxy_disabled_reason")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        
+
         if is_proxy_disabled && reason == "quota_protection" {
             // 如果是被旧版账号级保护禁用的,尝试恢复并转为模型级
-            return self.check_and_restore_quota(account_json, account_path, &quota, &config).await;
+            return self
+                .check_and_restore_quota(account_json, account_path, &quota, &config)
+                .await;
         }
-        
+
         // [修复 #1344] 不再处理其他禁用原因,让调用方负责检查手动禁用
-        
+
         // 4. 获取模型列表
         let models = match quota.get("models").and_then(|m| m.as_array()) {
             Some(m) => m,
@@ -333,45 +370,67 @@ impl TokenManager {
         // 5. 遍历受监控的模型，检查保护与恢复
         let threshold = config.threshold_percentage as i32;
 
-
         let mut changed = false;
 
         for model in models {
             let name = model.get("name").and_then(|v| v.as_str()).unwrap_or("");
             if !config.monitored_models.iter().any(|m| m == name) {
-                continue; 
+                continue;
             }
 
-            let percentage = model.get("percentage").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-            let account_id = account_json.get("id").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+            let percentage = model
+                .get("percentage")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0) as i32;
+            let account_id = account_json
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string();
 
             if percentage <= threshold {
                 // 触发保护 (Issue #621 改为模型级)
-                if self.trigger_quota_protection(account_json, &account_id, account_path, percentage, threshold, name).await.unwrap_or(false) {
+                if self
+                    .trigger_quota_protection(
+                        account_json,
+                        &account_id,
+                        account_path,
+                        percentage,
+                        threshold,
+                        name,
+                    )
+                    .await
+                    .unwrap_or(false)
+                {
                     changed = true;
                 }
             } else {
                 // 尝试恢复 (如果之前受限)
-                let protected_models = account_json.get("protected_models").and_then(|v| v.as_array());
-                let is_protected = protected_models.map_or(false, |arr| {
-                    arr.iter().any(|m| m.as_str() == Some(name))
-                });
+                let protected_models = account_json
+                    .get("protected_models")
+                    .and_then(|v| v.as_array());
+                let is_protected = protected_models
+                    .map_or(false, |arr| arr.iter().any(|m| m.as_str() == Some(name)));
 
                 if is_protected {
-                    if self.restore_quota_protection(account_json, &account_id, account_path, name).await.unwrap_or(false) {
+                    if self
+                        .restore_quota_protection(account_json, &account_id, account_path, name)
+                        .await
+                        .unwrap_or(false)
+                    {
                         changed = true;
                     }
                 }
             }
         }
-        
+
         let _ = changed; // 避免 unused 警告，如果后续逻辑需要可以继续使用
-        
+
         // 我们不再因为配额原因返回 true（即不再跳过账号），
         // 而是加载并在 get_token 时进行过滤。
         false
     }
-    
+
     /// 计算账号的最大剩余配额百分比（用于排序）
     /// 返回值: Option<i32> (max_percentage)
     fn calculate_quota_stats(&self, quota: &serde_json::Value) -> Option<i32> {
@@ -379,10 +438,10 @@ impl TokenManager {
             Some(m) => m,
             None => return None,
         };
-        
+
         let mut max_percentage = 0;
         let mut has_data = false;
-        
+
         for model in models {
             if let Some(pct) = model.get("percentage").and_then(|v| v.as_i64()) {
                 let pct_i32 = pct as i32;
@@ -392,14 +451,14 @@ impl TokenManager {
                 has_data = true;
             }
         }
-        
+
         if has_data {
             Some(max_percentage)
         } else {
             None
         }
     }
-    
+
     /// 触发配额保护，限制特定模型 (Issue #621)
     /// 返回 true 如果发生了改变
     async fn trigger_quota_protection(
@@ -415,28 +474,37 @@ impl TokenManager {
         if account_json.get("protected_models").is_none() {
             account_json["protected_models"] = serde_json::Value::Array(Vec::new());
         }
-        
+
         let protected_models = account_json["protected_models"].as_array_mut().unwrap();
-        
+
         // 2. 检查是否已存在
-        if !protected_models.iter().any(|m| m.as_str() == Some(model_name)) {
+        if !protected_models
+            .iter()
+            .any(|m| m.as_str() == Some(model_name))
+        {
             protected_models.push(serde_json::Value::String(model_name.to_string()));
-            
+
             tracing::info!(
                 "账号 {} 的模型 {} 因配额受限（{}% <= {}%）已被加入保护列表",
-                account_id, model_name, current_val, threshold
+                account_id,
+                model_name,
+                current_val,
+                threshold
             );
-            
+
             // 3. 写入磁盘
-            std::fs::write(account_path, serde_json::to_string_pretty(account_json).unwrap())
-                .map_err(|e| format!("写入文件失败: {}", e))?;
-            
+            std::fs::write(
+                account_path,
+                serde_json::to_string_pretty(account_json).unwrap(),
+            )
+            .map_err(|e| format!("写入文件失败: {}", e))?;
+
             return Ok(true);
         }
-        
+
         Ok(false)
     }
-    
+
     /// 检查并从账号级保护恢复（迁移至模型级，Issue #621）
     async fn check_and_restore_quota(
         &self,
@@ -449,7 +517,10 @@ impl TokenManager {
         // 我们将其 proxy_disabled 设为 false，但同时更新其 protected_models 列表。
         tracing::info!(
             "正在迁移账号 {} 从全局配额保护模式至模型级保护模式",
-            account_json.get("email").and_then(|v| v.as_str()).unwrap_or("unknown")
+            account_json
+                .get("email")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
         );
 
         account_json["proxy_disabled"] = serde_json::Value::Bool(false);
@@ -462,22 +533,30 @@ impl TokenManager {
         if let Some(models) = quota.get("models").and_then(|m| m.as_array()) {
             for model in models {
                 let name = model.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                if !config.monitored_models.iter().any(|m| m == name) { continue; }
-                
-                let percentage = model.get("percentage").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+                if !config.monitored_models.iter().any(|m| m == name) {
+                    continue;
+                }
+
+                let percentage = model
+                    .get("percentage")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0) as i32;
                 if percentage <= threshold {
                     protected_list.push(serde_json::Value::String(name.to_string()));
                 }
             }
         }
-        
+
         account_json["protected_models"] = serde_json::Value::Array(protected_list);
-        
-        let _ = std::fs::write(account_path, serde_json::to_string_pretty(account_json).unwrap());
-        
+
+        let _ = std::fs::write(
+            account_path,
+            serde_json::to_string_pretty(account_json).unwrap(),
+        );
+
         false // 返回 false 表示现在已可以尝试加载该账号（模型级过滤会在 get_token 时发生）
     }
-    
+
     /// 恢复特定模型的配额保护 (Issue #621)
     /// 返回 true 如果发生了改变
     async fn restore_quota_protection(
@@ -487,60 +566,78 @@ impl TokenManager {
         account_path: &PathBuf,
         model_name: &str,
     ) -> Result<bool, String> {
-        if let Some(arr) = account_json.get_mut("protected_models").and_then(|v| v.as_array_mut()) {
+        if let Some(arr) = account_json
+            .get_mut("protected_models")
+            .and_then(|v| v.as_array_mut())
+        {
             let original_len = arr.len();
             arr.retain(|m| m.as_str() != Some(model_name));
-            
+
             if arr.len() < original_len {
-                tracing::info!("账号 {} 的模型 {} 配额已恢复，移出保护列表", account_id, model_name);
-                std::fs::write(account_path, serde_json::to_string_pretty(account_json).unwrap())
-                    .map_err(|e| format!("写入文件失败: {}", e))?;
+                tracing::info!(
+                    "账号 {} 的模型 {} 配额已恢复，移出保护列表",
+                    account_id,
+                    model_name
+                );
+                std::fs::write(
+                    account_path,
+                    serde_json::to_string_pretty(account_json).unwrap(),
+                )
+                .map_err(|e| format!("写入文件失败: {}", e))?;
                 return Ok(true);
             }
         }
-        
+
         Ok(false)
     }
 
-    
     /// 获取当前可用的 Token（支持粘性会话与智能调度）
     /// 参数 `quota_group` 用于区分 "claude" vs "gemini" 组
     /// 参数 `force_rotate` 为 true 时将忽略锁定，强制切换账号
     /// 参数 `session_id` 用于跨请求维持会话粘性
     /// 参数 `target_model` 用于检查配额保护 (Issue #621)
     pub async fn get_token(
-        &self, 
-        quota_group: &str, 
-        force_rotate: bool, 
+        &self,
+        quota_group: &str,
+        force_rotate: bool,
         session_id: Option<&str>,
         target_model: &str,
     ) -> Result<(String, String, String, u64), String> {
         // 【优化 Issue #284】添加 5 秒超时，防止死锁
         let timeout_duration = std::time::Duration::from_secs(5);
-        match tokio::time::timeout(timeout_duration, self.get_token_internal(quota_group, force_rotate, session_id, target_model)).await {
+        match tokio::time::timeout(
+            timeout_duration,
+            self.get_token_internal(quota_group, force_rotate, session_id, target_model),
+        )
+        .await
+        {
             Ok(result) => result,
-            Err(_) => Err("Token acquisition timeout (5s) - system too busy or deadlock detected".to_string()),
+            Err(_) => Err(
+                "Token acquisition timeout (5s) - system too busy or deadlock detected".to_string(),
+            ),
         }
     }
 
     /// 内部实现：获取 Token 的核心逻辑
     async fn get_token_internal(
-        &self, 
-        quota_group: &str, 
-        force_rotate: bool, 
+        &self,
+        quota_group: &str,
+        force_rotate: bool,
         session_id: Option<&str>,
         target_model: &str,
     ) -> Result<(String, String, String, u64), String> {
-        let mut tokens_snapshot: Vec<ProxyToken> = self.tokens.iter().map(|e| e.value().clone()).collect();
+        let mut tokens_snapshot: Vec<ProxyToken> =
+            self.tokens.iter().map(|e| e.value().clone()).collect();
         let total = tokens_snapshot.len();
         if total == 0 {
             return Err("Token pool is empty".to_string());
         }
 
-        // ===== 【优化】根据订阅等级和剩余配额排序 =====
-        // [FIX #563] 优先级: ULTRA > PRO > FREE, 同tier内优先高配额账号
-        // 理由: ULTRA/PRO 重置快，优先消耗；FREE 重置慢，用于兜底
-        //       高配額账号优先使用，避免低配额账号被用光
+        // ===== 【优化】根据订阅等级、健康分、刷新时间、剩余配额排序 =====
+        // 优先级: 订阅等级 > 健康分 > 刷新时间（越近越优先）> 剩余配额
+        // 刷新时间差异 < 10 分钟视为相同优先级
+        const RESET_TIME_THRESHOLD_SECS: i64 = 600; // 10 分钟阈值
+
         tokens_snapshot.sort_by(|a, b| {
             let tier_priority = |tier: &Option<String>| match tier.as_deref() {
                 Some("ULTRA") => 0,
@@ -548,42 +645,71 @@ impl TokenManager {
                 Some("FREE") => 2,
                 _ => 3,
             };
-            
+
             // First: compare by subscription tier
-            let tier_cmp = tier_priority(&a.subscription_tier)
-                .cmp(&tier_priority(&b.subscription_tier));
-            
+            let tier_cmp =
+                tier_priority(&a.subscription_tier).cmp(&tier_priority(&b.subscription_tier));
+
             if tier_cmp != std::cmp::Ordering::Equal {
                 return tier_cmp;
             }
-            
-            // [FIX #563] Second: compare by remaining quota percentage (higher is better)
-            // Accounts with unknown/zero percentage go last within their tier
+
+            // Second: compare by health score (higher is better)
+            let health_cmp = b
+                .health_score
+                .partial_cmp(&a.health_score)
+                .unwrap_or(std::cmp::Ordering::Equal);
+
+            if health_cmp != std::cmp::Ordering::Equal {
+                return health_cmp;
+            }
+
+            // Third: compare by reset time (earlier/closer is better)
+            // 差异 < 10 分钟视为相同优先级，避免频繁切换
+            let reset_a = a.reset_time.unwrap_or(i64::MAX);
+            let reset_b = b.reset_time.unwrap_or(i64::MAX);
+            let reset_diff = (reset_a - reset_b).abs();
+
+            if reset_diff >= RESET_TIME_THRESHOLD_SECS {
+                let reset_cmp = reset_a.cmp(&reset_b);
+                if reset_cmp != std::cmp::Ordering::Equal {
+                    return reset_cmp;
+                }
+            }
+
+            // Fourth: compare by remaining quota percentage (higher is better)
             let quota_a = a.remaining_quota.unwrap_or(0);
             let quota_b = b.remaining_quota.unwrap_or(0);
-            let quota_cmp = quota_b.cmp(&quota_a);
-            
-            if quota_cmp != std::cmp::Ordering::Equal {
-                return quota_cmp;
-            }
-            
-            // [NEW] Third: compare by health score (higher is better)
-            b.health_score.partial_cmp(&a.health_score).unwrap_or(std::cmp::Ordering::Equal)
+            quota_b.cmp(&quota_a)
         });
-        
+
         // 【调试日志】打印排序后的账号顺序
         tracing::debug!(
             "🔄 [Token Rotation] Accounts: {:?}",
-            tokens_snapshot.iter().map(|t| format!(
-                "{}(protected={:?})", 
-                t.email, t.protected_models
-            )).collect::<Vec<_>>()
+            tokens_snapshot
+                .iter()
+                .map(|t| format!(
+                    "{}(reset={:?}, quota={:?}, health={:.2})",
+                    t.email,
+                    t.reset_time.map(|ts| {
+                        let now = chrono::Utc::now().timestamp();
+                        let diff_secs = ts - now;
+                        if diff_secs > 0 {
+                            format!("{}m", diff_secs / 60)
+                        } else {
+                            "now".to_string()
+                        }
+                    }),
+                    t.remaining_quota,
+                    t.health_score
+                ))
+                .collect::<Vec<_>>()
         );
 
         // 0. 读取当前调度配置
         let scheduling = self.sticky_config.read().await.clone();
         use crate::proxy::sticky_config::SchedulingMode;
-        
+
         // 【新增】检查配额保护是否启用（如果关闭，则忽略 protected_models 检查）
         let quota_protection_enabled = crate::modules::config::load_app_config()
             .map(|cfg| cfg.quota_protection.enabled)
@@ -593,13 +719,20 @@ impl TokenManager {
         let preferred_id = self.preferred_account_id.read().await.clone();
         if let Some(ref pref_id) = preferred_id {
             // 查找优先账号
-            if let Some(preferred_token) = tokens_snapshot.iter().find(|t| &t.account_id == pref_id) {
+            if let Some(preferred_token) = tokens_snapshot.iter().find(|t| &t.account_id == pref_id)
+            {
                 // 检查账号是否可用（未限流、未被配额保护）
-                let normalized_target = crate::proxy::common::model_mapping::normalize_to_standard_id(target_model)
-                    .unwrap_or_else(|| target_model.to_string());
+                let normalized_target =
+                    crate::proxy::common::model_mapping::normalize_to_standard_id(target_model)
+                        .unwrap_or_else(|| target_model.to_string());
 
-                let is_rate_limited = self.is_rate_limited(&preferred_token.account_id, Some(&normalized_target)).await;
-                let is_quota_protected = quota_protection_enabled && preferred_token.protected_models.contains(&normalized_target);
+                let is_rate_limited = self
+                    .is_rate_limited(&preferred_token.account_id, Some(&normalized_target))
+                    .await;
+                let is_quota_protected = quota_protection_enabled
+                    && preferred_token
+                        .protected_models
+                        .contains(&normalized_target);
 
                 if !is_rate_limited && !is_quota_protected {
                     tracing::info!(
@@ -614,7 +747,9 @@ impl TokenManager {
                     let now = chrono::Utc::now().timestamp();
                     if now >= token.timestamp - 300 {
                         tracing::debug!("账号 {} 的 token 即将过期，正在刷新...", token.email);
-                        match crate::modules::oauth::refresh_access_token(&token.refresh_token).await {
+                        match crate::modules::oauth::refresh_access_token(&token.refresh_token)
+                            .await
+                        {
                             Ok(token_response) => {
                                 token.access_token = token_response.access_token.clone();
                                 token.expires_in = token_response.expires_in;
@@ -625,7 +760,9 @@ impl TokenManager {
                                     entry.expires_in = token.expires_in;
                                     entry.timestamp = token.timestamp;
                                 }
-                                let _ = self.save_refreshed_token(&token.account_id, &token_response).await;
+                                let _ = self
+                                    .save_refreshed_token(&token.account_id, &token_response)
+                                    .await;
                             }
                             Err(e) => {
                                 tracing::warn!("Preferred account token refresh failed: {}", e);
@@ -638,7 +775,9 @@ impl TokenManager {
                     let project_id = if let Some(pid) = &token.project_id {
                         pid.clone()
                     } else {
-                        match crate::proxy::project_resolver::fetch_project_id(&token.access_token).await {
+                        match crate::proxy::project_resolver::fetch_project_id(&token.access_token)
+                            .await
+                        {
                             Ok(pid) => {
                                 if let Some(mut entry) = self.tokens.get_mut(&token.account_id) {
                                     entry.project_id = Some(pid.clone());
@@ -646,7 +785,7 @@ impl TokenManager {
                                 let _ = self.save_project_id(&token.account_id, &pid).await;
                                 pid
                             }
-                            Err(_) => "bamboo-precept-lgxtn".to_string() // fallback
+                            Err(_) => "bamboo-precept-lgxtn".to_string(), // fallback
                         }
                     };
 
@@ -682,21 +821,29 @@ impl TokenManager {
 
             // ===== 【核心】粘性会话与智能调度逻辑 =====
             let mut target_token: Option<ProxyToken> = None;
-            
+
             // 归一化目标模型名为标准 ID，用于配额保护检查
-            let normalized_target = crate::proxy::common::model_mapping::normalize_to_standard_id(target_model)
-                .unwrap_or_else(|| target_model.to_string());
-            
+            let normalized_target =
+                crate::proxy::common::model_mapping::normalize_to_standard_id(target_model)
+                    .unwrap_or_else(|| target_model.to_string());
+
             // 模式 A: 粘性会话处理 (CacheFirst 或 Balance 且有 session_id)
-            if !rotate && session_id.is_some() && scheduling.mode != SchedulingMode::PerformanceFirst {
+            if !rotate
+                && session_id.is_some()
+                && scheduling.mode != SchedulingMode::PerformanceFirst
+            {
                 let sid = session_id.unwrap();
-                
+
                 // 1. 检查会话是否已绑定账号
                 if let Some(bound_id) = self.session_accounts.get(sid).map(|v| v.clone()) {
                     // 【修复】先通过 account_id 找到对应的账号，获取其 email
                     // 2. 转换 email -> account_id 检查绑定的账号是否限流
-                    if let Some(bound_token) = tokens_snapshot.iter().find(|t| t.account_id == bound_id) {
-                        let key = self.email_to_account_id(&bound_token.email).unwrap_or_else(|| bound_token.account_id.clone());
+                    if let Some(bound_token) =
+                        tokens_snapshot.iter().find(|t| t.account_id == bound_id)
+                    {
+                        let key = self
+                            .email_to_account_id(&bound_token.email)
+                            .unwrap_or_else(|| bound_token.account_id.clone());
                         // [FIX] Pass None for specific model wait time if not applicable
                         let reset_sec = self.rate_limit_tracker.get_remaining_wait(&key, None);
                         if reset_sec > 0 {
@@ -707,17 +854,25 @@ impl TokenManager {
                                 bound_token.email, reset_sec
                             );
                             self.session_accounts.remove(sid);
-                        } else if !attempted.contains(&bound_id) && !(quota_protection_enabled && bound_token.protected_models.contains(&normalized_target)) {
+                        } else if !attempted.contains(&bound_id)
+                            && !(quota_protection_enabled
+                                && bound_token.protected_models.contains(&normalized_target))
+                        {
                             // 3. 账号可用且未被标记为尝试失败，优先复用
                             tracing::debug!("Sticky Session: Successfully reusing bound account {} for session {}", bound_token.email, sid);
                             target_token = Some(bound_token.clone());
-                        } else if quota_protection_enabled && bound_token.protected_models.contains(&normalized_target) {
+                        } else if quota_protection_enabled
+                            && bound_token.protected_models.contains(&normalized_target)
+                        {
                             tracing::debug!("Sticky Session: Bound account {} is quota-protected for model {} [{}], unbinding and switching.", bound_token.email, normalized_target, target_model);
                             self.session_accounts.remove(sid);
                         }
                     } else {
                         // 绑定的账号已不存在（可能被删除），解绑
-                        tracing::debug!("Sticky Session: Bound account not found for session {}, unbinding", sid);
+                        tracing::debug!(
+                            "Sticky Session: Bound account not found for session {}, unbinding",
+                            sid
+                        );
                         self.session_accounts.remove(sid);
                     }
                 }
@@ -725,19 +880,39 @@ impl TokenManager {
 
             // 模式 B: 原子化 60s 全局锁定 (针对无 session_id 情况的默认保护)
             // 【修复】性能优先模式应跳过 60s 锁定；
-            if target_token.is_none() && !rotate && quota_group != "image_gen" && scheduling.mode != SchedulingMode::PerformanceFirst {
+            if target_token.is_none()
+                && !rotate
+                && quota_group != "image_gen"
+                && scheduling.mode != SchedulingMode::PerformanceFirst
+            {
                 // 【优化】使用预先获取的快照，不再在循环内加锁
                 if let Some((account_id, last_time)) = &last_used_account_id {
                     // [FIX #3] 60s 锁定逻辑应检查 `attempted` 集合，避免重复尝试失败的账号
                     if last_time.elapsed().as_secs() < 60 && !attempted.contains(account_id) {
-                        if let Some(found) = tokens_snapshot.iter().find(|t| &t.account_id == account_id) {
+                        if let Some(found) =
+                            tokens_snapshot.iter().find(|t| &t.account_id == account_id)
+                        {
                             // 【修复】检查限流状态和配额保护，避免复用已被锁定的账号
-                            if !self.is_rate_limited(&found.account_id, Some(&normalized_target)).await && !(quota_protection_enabled && found.protected_models.contains(&normalized_target)) {
-                                tracing::debug!("60s Window: Force reusing last account: {}", found.email);
+                            if !self
+                                .is_rate_limited(&found.account_id, Some(&normalized_target))
+                                .await
+                                && !(quota_protection_enabled
+                                    && found.protected_models.contains(&normalized_target))
+                            {
+                                tracing::debug!(
+                                    "60s Window: Force reusing last account: {}",
+                                    found.email
+                                );
                                 target_token = Some(found.clone());
                             } else {
-                                if self.is_rate_limited(&found.account_id, Some(&normalized_target)).await {
-                                    tracing::debug!("60s Window: Last account {} is rate-limited, skipping", found.email);
+                                if self
+                                    .is_rate_limited(&found.account_id, Some(&normalized_target))
+                                    .await
+                                {
+                                    tracing::debug!(
+                                        "60s Window: Last account {} is rate-limited, skipping",
+                                        found.email
+                                    );
                                 } else {
                                     tracing::debug!("60s Window: Last account {} is quota-protected for model {} [{}], skipping", found.email, normalized_target, target_model);
                                 }
@@ -745,7 +920,7 @@ impl TokenManager {
                         }
                     }
                 }
-                
+
                 // 若无锁定，则轮询选择新账号
                 if target_token.is_none() {
                     let start_idx = self.current_index.fetch_add(1, Ordering::SeqCst) % total;
@@ -757,25 +932,42 @@ impl TokenManager {
                         }
 
                         // 【新增 #621】模型级限流检查
-                        if quota_protection_enabled && candidate.protected_models.contains(&normalized_target) {
-                            tracing::debug!("Account {} is quota-protected for model {} [{}], skipping", candidate.email, normalized_target, target_model);
+                        if quota_protection_enabled
+                            && candidate.protected_models.contains(&normalized_target)
+                        {
+                            tracing::debug!(
+                                "Account {} is quota-protected for model {} [{}], skipping",
+                                candidate.email,
+                                normalized_target,
+                                target_model
+                            );
                             continue;
                         }
 
                         // 【新增】主动避开限流或 5xx 锁定的账号 (高可用优化)
-                        if self.is_rate_limited(&candidate.account_id, Some(&normalized_target)).await { // Changed to account_id
+                        if self
+                            .is_rate_limited(&candidate.account_id, Some(&normalized_target))
+                            .await
+                        {
+                            // Changed to account_id
                             continue;
                         }
 
                         target_token = Some(candidate.clone());
                         // 【优化】标记需要更新，稍后统一写回
-                        need_update_last_used = Some((candidate.account_id.clone(), std::time::Instant::now()));
-                        
+                        need_update_last_used =
+                            Some((candidate.account_id.clone(), std::time::Instant::now()));
+
                         // 如果是会话首次分配且需要粘性，在此建立绑定
                         if let Some(sid) = session_id {
                             if scheduling.mode != SchedulingMode::PerformanceFirst {
-                                self.session_accounts.insert(sid.to_string(), candidate.account_id.clone());
-                                tracing::debug!("Sticky Session: Bound new account {} to session {}", candidate.email, sid);
+                                self.session_accounts
+                                    .insert(sid.to_string(), candidate.account_id.clone());
+                                tracing::debug!(
+                                    "Sticky Session: Bound new account {} to session {}",
+                                    candidate.email,
+                                    sid
+                                );
                             }
                         }
                         break;
@@ -784,48 +976,68 @@ impl TokenManager {
             } else if target_token.is_none() {
                 // 模式 C: 纯轮询模式 (Round-robin) 或强制轮换
                 let start_idx = self.current_index.fetch_add(1, Ordering::SeqCst) % total;
-                tracing::debug!("🔄 [Mode C] Round-robin from idx {}, total: {}", start_idx, total);
+                tracing::debug!(
+                    "🔄 [Mode C] Round-robin from idx {}, total: {}",
+                    start_idx,
+                    total
+                );
                 for offset in 0..total {
                     let idx = (start_idx + offset) % total;
                     let candidate = &tokens_snapshot[idx];
-                    
+
                     if attempted.contains(&candidate.account_id) {
-                        tracing::debug!("  [{}] {} - SKIP: already attempted", idx, candidate.email);
+                        tracing::debug!(
+                            "  [{}] {} - SKIP: already attempted",
+                            idx,
+                            candidate.email
+                        );
                         continue;
                     }
 
                     // 【新增 #621】模型级限流检查
-                    if quota_protection_enabled && candidate.protected_models.contains(&normalized_target) {
-                        tracing::debug!("  ⛔ {} - SKIP: quota-protected for {} [{}]", candidate.email, normalized_target, target_model);
+                    if quota_protection_enabled
+                        && candidate.protected_models.contains(&normalized_target)
+                    {
+                        tracing::debug!(
+                            "  ⛔ {} - SKIP: quota-protected for {} [{}]",
+                            candidate.email,
+                            normalized_target,
+                            target_model
+                        );
                         continue;
                     }
 
                     // 【新增】主动避开限流或 5xx 锁定的账号
-                    if self.is_rate_limited(&candidate.account_id, Some(&normalized_target)).await { // Changed to account_id
+                    if self
+                        .is_rate_limited(&candidate.account_id, Some(&normalized_target))
+                        .await
+                    {
+                        // Changed to account_id
                         tracing::debug!("  ⏳ {} - SKIP: rate-limited", candidate.email);
                         continue;
                     }
 
                     tracing::debug!("  [{}] {} - SELECTED", idx, candidate.email);
                     target_token = Some(candidate.clone());
-                    
+
                     if rotate {
                         tracing::debug!("Force Rotation: Switched to account: {}", candidate.email);
                     }
                     break;
                 }
             }
-            
+
             let mut token = match target_token {
                 Some(t) => t,
                 None => {
                     let mut wait_ms = 0;
                     // 乐观重置策略: 双层防护机制
                     // 计算最短等待时间
-                    let min_wait = tokens_snapshot.iter()
+                    let min_wait = tokens_snapshot
+                        .iter()
                         .filter_map(|t| self.rate_limit_tracker.get_reset_seconds(&t.account_id))
                         .min();
-                    
+
                     // Layer 1: 如果最短等待时间 <= 2秒,执行缓冲延迟
                     if let Some(wait_sec) = min_wait {
                         if wait_sec <= 2 {
@@ -834,16 +1046,21 @@ impl TokenManager {
                                 "All accounts rate-limited but shortest wait is {}s. Applying {}ms buffer for state sync...",
                                 wait_sec, wait_ms
                             );
-                            
+
                             // 缓冲延迟
                             tokio::time::sleep(tokio::time::Duration::from_millis(wait_ms)).await;
-                            
+
                             // 重新尝试选择账号
-                            let retry_token = tokens_snapshot.iter()
-                                .find(|t| !attempted.contains(&t.account_id) && !self.is_rate_limited_sync(&t.account_id, None));
-                            
+                            let retry_token = tokens_snapshot.iter().find(|t| {
+                                !attempted.contains(&t.account_id)
+                                    && !self.is_rate_limited_sync(&t.account_id, None)
+                            });
+
                             if let Some(t) = retry_token {
-                                tracing::info!("✅ Buffer delay successful! Found available account: {}", t.email);
+                                tracing::info!(
+                                    "✅ Buffer delay successful! Found available account: {}",
+                                    t.email
+                                );
                                 t.clone()
                             } else {
                                 // Layer 2: 缓冲后仍无可用账号,执行乐观重置
@@ -851,19 +1068,25 @@ impl TokenManager {
                                     "Buffer delay failed. Executing optimistic reset for all {} accounts...",
                                     tokens_snapshot.len()
                                 );
-                                
+
                                 // 清除所有限流记录
                                 self.rate_limit_tracker.clear_all();
-                                
+
                                 // 再次尝试选择账号
-                                let final_token = tokens_snapshot.iter()
+                                let final_token = tokens_snapshot
+                                    .iter()
                                     .find(|t| !attempted.contains(&t.account_id));
-                                
+
                                 if let Some(t) = final_token {
-                                    tracing::info!("✅ Optimistic reset successful! Using account: {}", t.email);
+                                    tracing::info!(
+                                        "✅ Optimistic reset successful! Using account: {}",
+                                        t.email
+                                    );
                                     t.clone()
                                 } else {
-                                    return Err("All accounts failed after optimistic reset.".to_string());
+                                    return Err(
+                                        "All accounts failed after optimistic reset.".to_string()
+                                    );
                                 }
                             }
                         } else {
@@ -875,7 +1098,6 @@ impl TokenManager {
                 }
             };
 
-        
             // 3. 检查 token 是否过期（提前5分钟刷新）
             let now = chrono::Utc::now().timestamp();
             if now >= token.timestamp - 300 {
@@ -899,7 +1121,10 @@ impl TokenManager {
                         }
 
                         // 同步落盘（避免重启后继续使用过期 timestamp 导致频繁刷新）
-                        if let Err(e) = self.save_refreshed_token(&token.account_id, &token_response).await {
+                        if let Err(e) = self
+                            .save_refreshed_token(&token.account_id, &token_response)
+                            .await
+                        {
                             tracing::debug!("保存刷新后的 token 失败 ({}): {}", token.email, e);
                         }
                     }
@@ -911,7 +1136,10 @@ impl TokenManager {
                                 token.email
                             );
                             let _ = self
-                                .disable_account(&token.account_id, &format!("invalid_grant: {}", e))
+                                .disable_account(
+                                    &token.account_id,
+                                    &format!("invalid_grant: {}", e),
+                                )
                                 .await;
                             self.tokens.remove(&token.account_id);
                         }
@@ -921,8 +1149,11 @@ impl TokenManager {
 
                         // 【优化】标记需要清除锁定，避免在循环内加锁
                         if quota_group != "image_gen" {
-                            if matches!(&last_used_account_id, Some((id, _)) if id == &token.account_id) {
-                                need_update_last_used = Some((String::new(), std::time::Instant::now())); // 空字符串表示需要清除
+                            if matches!(&last_used_account_id, Some((id, _)) if id == &token.account_id)
+                            {
+                                need_update_last_used =
+                                    Some((String::new(), std::time::Instant::now()));
+                                // 空字符串表示需要清除
                             }
                         }
                         continue;
@@ -945,13 +1176,19 @@ impl TokenManager {
                     }
                     Err(e) => {
                         tracing::error!("Failed to fetch project_id for {}: {}", token.email, e);
-                        last_error = Some(format!("Failed to fetch project_id for {}: {}", token.email, e));
+                        last_error = Some(format!(
+                            "Failed to fetch project_id for {}: {}",
+                            token.email, e
+                        ));
                         attempted.insert(token.account_id.clone());
 
                         // 【优化】标记需要清除锁定，避免在循环内加锁
                         if quota_group != "image_gen" {
-                            if matches!(&last_used_account_id, Some((id, _)) if id == &token.account_id) {
-                                need_update_last_used = Some((String::new(), std::time::Instant::now())); // 空字符串表示需要清除
+                            if matches!(&last_used_account_id, Some((id, _)) if id == &token.account_id)
+                            {
+                                need_update_last_used =
+                                    Some((String::new(), std::time::Instant::now()));
+                                // 空字符串表示需要清除
                             }
                         }
                         continue;
@@ -999,7 +1236,7 @@ impl TokenManager {
 
         std::fs::write(&path, serde_json::to_string_pretty(&content).unwrap())
             .map_err(|e| format!("写入文件失败: {}", e))?;
-        
+
         // 【修复 Issue #3】从内存中移除禁用的账号，防止被60s锁定逻辑继续使用
         self.tokens.remove(account_id);
 
@@ -1009,55 +1246,65 @@ impl TokenManager {
 
     /// 保存 project_id 到账号文件
     async fn save_project_id(&self, account_id: &str, project_id: &str) -> Result<(), String> {
-        let entry = self.tokens.get(account_id)
-            .ok_or("账号不存在")?;
-        
+        let entry = self.tokens.get(account_id).ok_or("账号不存在")?;
+
         let path = &entry.account_path;
-        
+
         let mut content: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?
-        ).map_err(|e| format!("解析 JSON 失败: {}", e))?;
-        
+            &std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?,
+        )
+        .map_err(|e| format!("解析 JSON 失败: {}", e))?;
+
         content["token"]["project_id"] = serde_json::Value::String(project_id.to_string());
-        
+
         std::fs::write(path, serde_json::to_string_pretty(&content).unwrap())
             .map_err(|e| format!("写入文件失败: {}", e))?;
-        
+
         tracing::debug!("已保存 project_id 到账号 {}", account_id);
         Ok(())
     }
-    
+
     /// 保存刷新后的 token 到账号文件
-    async fn save_refreshed_token(&self, account_id: &str, token_response: &crate::modules::oauth::TokenResponse) -> Result<(), String> {
-        let entry = self.tokens.get(account_id)
-            .ok_or("账号不存在")?;
-        
+    async fn save_refreshed_token(
+        &self,
+        account_id: &str,
+        token_response: &crate::modules::oauth::TokenResponse,
+    ) -> Result<(), String> {
+        let entry = self.tokens.get(account_id).ok_or("账号不存在")?;
+
         let path = &entry.account_path;
-        
+
         let mut content: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?
-        ).map_err(|e| format!("解析 JSON 失败: {}", e))?;
-        
+            &std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?,
+        )
+        .map_err(|e| format!("解析 JSON 失败: {}", e))?;
+
         let now = chrono::Utc::now().timestamp();
-        
-        content["token"]["access_token"] = serde_json::Value::String(token_response.access_token.clone());
-        content["token"]["expires_in"] = serde_json::Value::Number(token_response.expires_in.into());
-        content["token"]["expiry_timestamp"] = serde_json::Value::Number((now + token_response.expires_in).into());
-        
+
+        content["token"]["access_token"] =
+            serde_json::Value::String(token_response.access_token.clone());
+        content["token"]["expires_in"] =
+            serde_json::Value::Number(token_response.expires_in.into());
+        content["token"]["expiry_timestamp"] =
+            serde_json::Value::Number((now + token_response.expires_in).into());
+
         std::fs::write(path, serde_json::to_string_pretty(&content).unwrap())
             .map_err(|e| format!("写入文件失败: {}", e))?;
-        
+
         tracing::debug!("已保存刷新后的 token 到账号 {}", account_id);
         Ok(())
     }
-    
+
     pub fn len(&self) -> usize {
         self.tokens.len()
     }
 
     /// 通过 email 获取指定账号的 Token（用于预热等需要指定账号的场景）
     /// 此方法会自动刷新过期的 token
-    pub async fn get_token_by_email(&self, email: &str) -> Result<(String, String, String, u64), String> {
+    pub async fn get_token_by_email(
+        &self,
+        email: &str,
+    ) -> Result<(String, String, String, u64), String> {
         // 查找账号信息
         let token_info = {
             let mut found = None;
@@ -1093,7 +1340,7 @@ impl TokenManager {
         };
 
         let project_id = project_id_opt.unwrap_or_else(|| "bamboo-precept-lgxtn".to_string());
-        
+
         // 检查是否过期 (提前5分钟)
         if now < timestamp + expires_in - 300 {
             return Ok((current_access_token, project_id, email.to_string(), 0));
@@ -1106,7 +1353,7 @@ impl TokenManager {
             Ok(token_response) => {
                 tracing::info!("[Warmup] Token refresh successful for {}", email);
                 let new_now = chrono::Utc::now().timestamp();
-                
+
                 // 更新缓存
                 if let Some(mut entry) = self.tokens.get_mut(&account_id) {
                     entry.access_token = token_response.access_token.clone();
@@ -1115,16 +1362,26 @@ impl TokenManager {
                 }
 
                 // 保存到磁盘
-                let _ = self.save_refreshed_token(&account_id, &token_response).await;
+                let _ = self
+                    .save_refreshed_token(&account_id, &token_response)
+                    .await;
 
-                Ok((token_response.access_token, project_id, email.to_string(), 0))
+                Ok((
+                    token_response.access_token,
+                    project_id,
+                    email.to_string(),
+                    0,
+                ))
             }
-            Err(e) => Err(format!("[Warmup] Token refresh failed for {}: {}", email, e)),
+            Err(e) => Err(format!(
+                "[Warmup] Token refresh failed for {}: {}",
+                email, e
+            )),
         }
     }
-    
+
     // ===== 限流管理方法 =====
-    
+
     /// 标记账号限流(从外部调用,通常在 handler 中)
     /// 参数为 email，内部会自动转换为 account_id
     pub async fn mark_rate_limited(
@@ -1141,8 +1398,10 @@ impl TokenManager {
         }
 
         // 【替代方案】转换 email -> account_id
-        let key = self.email_to_account_id(email).unwrap_or_else(|| email.to_string());
-        
+        let key = self
+            .email_to_account_id(email)
+            .unwrap_or_else(|| email.to_string());
+
         self.rate_limit_tracker.parse_from_error(
             &key,
             status,
@@ -1152,7 +1411,6 @@ impl TokenManager {
             &config.backoff_steps, // [NEW] 传入配置
         );
     }
-    
 
     /// 检查账号是否在限流中 (支持模型级)
     pub async fn is_rate_limited(&self, account_id: &str, model: Option<&str>) -> bool {
@@ -1173,27 +1431,28 @@ impl TokenManager {
         }
         self.rate_limit_tracker.is_rate_limited(account_id, model)
     }
-    
+
     /// 获取距离限流重置还有多少秒
     #[allow(dead_code)]
     pub fn get_rate_limit_reset_seconds(&self, account_id: &str) -> Option<u64> {
         self.rate_limit_tracker.get_reset_seconds(account_id)
     }
-    
+
     /// 清除过期的限流记录
     #[allow(dead_code)]
     pub fn clean_expired_rate_limits(&self) {
         self.rate_limit_tracker.cleanup_expired();
     }
-    
+
     /// 【替代方案】通过 email 查找对应的 account_id
     /// 用于将 handlers 传入的 email 转换为 tracker 使用的 account_id
     fn email_to_account_id(&self, email: &str) -> Option<String> {
-        self.tokens.iter()
+        self.tokens
+            .iter()
             .find(|entry| entry.value().email == email)
             .map(|entry| entry.value().account_id.clone())
     }
-    
+
     /// 清除指定账号的限流记录
     pub fn clear_rate_limit(&self, account_id: &str) -> bool {
         self.rate_limit_tracker.clear(account_id)
@@ -1203,27 +1462,27 @@ impl TokenManager {
     pub fn clear_all_rate_limits(&self) {
         self.rate_limit_tracker.clear_all();
     }
-    
+
     /// 标记账号请求成功，重置连续失败计数
-    /// 
+    ///
     /// 在请求成功完成后调用，将该账号的失败计数归零，
     /// 下次失败时从最短的锁定时间开始（智能限流）。
     pub fn mark_account_success(&self, account_id: &str) {
         self.rate_limit_tracker.mark_success(account_id);
     }
-    
+
     /// 检查是否有可用的 Google 账号
-    /// 
+    ///
     /// 用于"仅兜底"模式的智能判断:当所有 Google 账号不可用时才使用外部提供商。
-    /// 
+    ///
     /// # 参数
     /// - `quota_group`: 配额组("claude" 或 "gemini"),暂未使用但保留用于未来扩展
     /// - `target_model`: 目标模型名称(已归一化),用于配额保护检查
-    /// 
+    ///
     /// # 返回值
     /// - `true`: 至少有一个可用账号(未限流且未被配额保护)
     /// - `false`: 所有账号都不可用(被限流或被配额保护)
-    /// 
+    ///
     /// # 示例
     /// ```ignore
     /// // 检查是否有可用账号处理 claude-sonnet 请求
@@ -1237,11 +1496,11 @@ impl TokenManager {
         let quota_protection_enabled = crate::modules::config::load_app_config()
             .map(|cfg| cfg.quota_protection.enabled)
             .unwrap_or(false);
-        
+
         // 遍历所有账号,检查是否有可用的
         for entry in self.tokens.iter() {
             let token = entry.value();
-            
+
             // 1. 检查是否被限流
             if self.is_rate_limited(&token.account_id, None).await {
                 tracing::debug!(
@@ -1250,7 +1509,7 @@ impl TokenManager {
                 );
                 continue;
             }
-            
+
             // 2. 检查是否被配额保护(如果启用)
             if quota_protection_enabled && token.protected_models.contains(target_model) {
                 tracing::debug!(
@@ -1260,7 +1519,7 @@ impl TokenManager {
                 );
                 continue;
             }
-            
+
             // 找到至少一个可用账号
             tracing::debug!(
                 "[Fallback Check] Found available account: {} for model {}",
@@ -1269,7 +1528,7 @@ impl TokenManager {
             );
             return true;
         }
-        
+
         // 所有账号都不可用
         tracing::info!(
             "[Fallback Check] No available Google accounts for model {}, fallback should be triggered",
@@ -1277,14 +1536,14 @@ impl TokenManager {
         );
         false
     }
-    
+
     /// 从账号文件获取配额刷新时间
-    /// 
+    ///
     /// 返回该账号最近的配额刷新时间字符串（ISO 8601 格式）
     pub fn get_quota_reset_time(&self, email: &str) -> Option<String> {
         // 尝试从账号文件读取配额信息
         let accounts_dir = self.data_dir.join("accounts");
-        
+
         // 遍历账号文件查找对应的 email
         if let Ok(entries) = std::fs::read_dir(&accounts_dir) {
             for entry in entries.flatten() {
@@ -1296,14 +1555,18 @@ impl TokenManager {
                             if let Some(models) = account
                                 .get("quota")
                                 .and_then(|q| q.get("models"))
-                                .and_then(|m| m.as_array()) 
+                                .and_then(|m| m.as_array())
                             {
                                 // 找到最早的 reset_time（最保守的锁定策略）
                                 let mut earliest_reset: Option<&str> = None;
                                 for model in models {
-                                    if let Some(reset_time) = model.get("reset_time").and_then(|r| r.as_str()) {
+                                    if let Some(reset_time) =
+                                        model.get("reset_time").and_then(|r| r.as_str())
+                                    {
                                         if !reset_time.is_empty() {
-                                            if earliest_reset.is_none() || reset_time < earliest_reset.unwrap() {
+                                            if earliest_reset.is_none()
+                                                || reset_time < earliest_reset.unwrap()
+                                            {
                                                 earliest_reset = Some(reset_time);
                                             }
                                         }
@@ -1320,30 +1583,36 @@ impl TokenManager {
         }
         None
     }
-    
+
     /// 使用配额刷新时间精确锁定账号
-    /// 
+    ///
     /// 当 API 返回 429 但没有 quotaResetDelay 时,尝试使用账号的配额刷新时间
-    /// 
+    ///
     /// # 参数
     /// - `model`: 可选的模型名称,用于模型级别限流
-    pub fn set_precise_lockout(&self, email: &str, reason: crate::proxy::rate_limit::RateLimitReason, model: Option<String>) -> bool {
+    pub fn set_precise_lockout(
+        &self,
+        email: &str,
+        reason: crate::proxy::rate_limit::RateLimitReason,
+        model: Option<String>,
+    ) -> bool {
         if let Some(reset_time_str) = self.get_quota_reset_time(email) {
             tracing::info!("找到账号 {} 的配额刷新时间: {}", email, reset_time_str);
-            self.rate_limit_tracker.set_lockout_until_iso(email, &reset_time_str, reason, model)
+            self.rate_limit_tracker
+                .set_lockout_until_iso(email, &reset_time_str, reason, model)
         } else {
             tracing::debug!("未找到账号 {} 的配额刷新时间,将使用默认退避策略", email);
             false
         }
     }
-    
+
     /// 实时刷新配额并精确锁定账号
-    /// 
+    ///
     /// 当 429 发生时调用此方法:
     /// 1. 实时调用配额刷新 API 获取最新的 reset_time
     /// 2. 使用最新的 reset_time 精确锁定账号
     /// 3. 如果获取失败,返回 false 让调用方使用回退策略
-    /// 
+    ///
     /// # 参数
     /// - `model`: 可选的模型名称,用于模型级别限流
     pub async fn fetch_and_lock_with_realtime_quota(
@@ -1363,7 +1632,7 @@ impl TokenManager {
             }
             found_token
         };
-        
+
         let access_token = match access_token {
             Some(t) => t,
             None => {
@@ -1371,13 +1640,15 @@ impl TokenManager {
                 return false;
             }
         };
-        
+
         // 2. 调用配额刷新 API
         tracing::info!("账号 {} 正在实时刷新配额...", email);
         match crate::modules::quota::fetch_quota(&access_token, email).await {
             Ok((quota_data, _project_id)) => {
                 // 3. 从最新配额中提取 reset_time
-                let earliest_reset = quota_data.models.iter()
+                let earliest_reset = quota_data
+                    .models
+                    .iter()
                     .filter_map(|m| {
                         if !m.reset_time.is_empty() {
                             Some(m.reset_time.as_str())
@@ -1386,33 +1657,39 @@ impl TokenManager {
                         }
                     })
                     .min();
-                
+
                 if let Some(reset_time_str) = earliest_reset {
                     tracing::info!(
                         "账号 {} 实时配额刷新成功,reset_time: {}",
-                        email, reset_time_str
+                        email,
+                        reset_time_str
                     );
-                    self.rate_limit_tracker.set_lockout_until_iso(email, reset_time_str, reason, model)
+                    self.rate_limit_tracker.set_lockout_until_iso(
+                        email,
+                        reset_time_str,
+                        reason,
+                        model,
+                    )
                 } else {
                     tracing::warn!("账号 {} 配额刷新成功但未找到 reset_time", email);
                     false
                 }
-            },
+            }
             Err(e) => {
                 tracing::warn!("账号 {} 实时配额刷新失败: {:?}", email, e);
                 false
             }
         }
     }
-    
+
     /// 标记账号限流(异步版本,支持实时配额刷新)
-    /// 
+    ///
     /// 三级降级策略:
     /// 1. 优先: API 返回 quotaResetDelay → 直接使用
     /// 2. 次优: 实时刷新配额 → 获取最新 reset_time
     /// 3. 保底: 使用本地缓存配额 → 读取账号文件
     /// 4. 兜底: 指数退避策略 → 默认锁定时间
-    /// 
+    ///
     /// # 参数
     /// - `model`: 可选的模型名称,用于模型级别限流。传入实际使用的模型可以避免不同模型配额互相影响
     pub async fn mark_rate_limited_async(
@@ -1421,7 +1698,7 @@ impl TokenManager {
         status: u16,
         retry_after_header: Option<&str>,
         error_body: &str,
-        model: Option<&str>,  // 🆕 新增模型参数
+        model: Option<&str>, // 🆕 新增模型参数
     ) {
         // [NEW] 检查熔断是否启用
         let config = self.circuit_breaker_config.read().await.clone();
@@ -1430,18 +1707,27 @@ impl TokenManager {
         }
 
         // [FIX] Convert email to account_id for consistent tracking
-        let account_id = self.email_to_account_id(email).unwrap_or_else(|| email.to_string());
-        
+        let account_id = self
+            .email_to_account_id(email)
+            .unwrap_or_else(|| email.to_string());
+
         // 检查 API 是否返回了精确的重试时间
-        let has_explicit_retry_time = retry_after_header.is_some() || 
-            error_body.contains("quotaResetDelay");
-        
+        let has_explicit_retry_time =
+            retry_after_header.is_some() || error_body.contains("quotaResetDelay");
+
         if has_explicit_retry_time {
             // API 返回了精确时间(quotaResetDelay),直接使用,无需实时刷新
             if let Some(m) = model {
-                tracing::debug!("账号 {} 的模型 {} 的 429 响应包含 quotaResetDelay,直接使用 API 返回的时间", account_id, m);
+                tracing::debug!(
+                    "账号 {} 的模型 {} 的 429 响应包含 quotaResetDelay,直接使用 API 返回的时间",
+                    account_id,
+                    m
+                );
             } else {
-                tracing::debug!("账号 {} 的 429 响应包含 quotaResetDelay,直接使用 API 返回的时间", account_id);
+                tracing::debug!(
+                    "账号 {} 的 429 响应包含 quotaResetDelay,直接使用 API 返回的时间",
+                    account_id
+                );
             }
             self.rate_limit_tracker.parse_from_error(
                 &account_id,
@@ -1453,34 +1739,46 @@ impl TokenManager {
             );
             return;
         }
-        
+
         // 确定限流原因
         let reason = if error_body.to_lowercase().contains("model_capacity") {
             crate::proxy::rate_limit::RateLimitReason::ModelCapacityExhausted
-        } else if error_body.to_lowercase().contains("exhausted") || error_body.to_lowercase().contains("quota") {
+        } else if error_body.to_lowercase().contains("exhausted")
+            || error_body.to_lowercase().contains("quota")
+        {
             crate::proxy::rate_limit::RateLimitReason::QuotaExhausted
         } else {
             crate::proxy::rate_limit::RateLimitReason::Unknown
         };
-        
+
         // API 未返回 quotaResetDelay,需要实时刷新配额获取精确锁定时间
         if let Some(m) = model {
-            tracing::info!("账号 {} 的模型 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...", account_id, m);
+            tracing::info!(
+                "账号 {} 的模型 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...",
+                account_id,
+                m
+            );
         } else {
-            tracing::info!("账号 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...", account_id);
+            tracing::info!(
+                "账号 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...",
+                account_id
+            );
         }
-        
-        if self.fetch_and_lock_with_realtime_quota(&account_id, reason, model.map(|s| s.to_string())).await {
+
+        if self
+            .fetch_and_lock_with_realtime_quota(&account_id, reason, model.map(|s| s.to_string()))
+            .await
+        {
             tracing::info!("账号 {} 已使用实时配额精确锁定", account_id);
             return;
         }
-        
+
         // 实时刷新失败,尝试使用本地缓存的配额刷新时间
         if self.set_precise_lockout(&account_id, reason, model.map(|s| s.to_string())) {
             tracing::info!("账号 {} 已使用本地缓存配额锁定", account_id);
             return;
         }
-        
+
         // 都失败了,回退到指数退避策略
         tracing::warn!("账号 {} 无法获取配额刷新时间,使用指数退避策略", account_id);
         self.rate_limit_tracker.parse_from_error(
@@ -1551,8 +1849,12 @@ impl TokenManager {
 
     /// 使用 Authorization Code 交换 Refresh Token (Web OAuth)
     pub async fn exchange_code(&self, code: &str, redirect_uri: &str) -> Result<String, String> {
-        crate::modules::oauth::exchange_code(code, redirect_uri).await
-            .and_then(|t| t.refresh_token.ok_or_else(|| "No refresh token returned by Google".to_string()))
+        crate::modules::oauth::exchange_code(code, redirect_uri)
+            .await
+            .and_then(|t| {
+                t.refresh_token
+                    .ok_or_else(|| "No refresh token returned by Google".to_string())
+            })
     }
 
     /// 获取 OAuth URL (支持自定义 Redirect URI)
@@ -1561,11 +1863,15 @@ impl TokenManager {
     }
 
     /// 获取用户信息 (Email 等)
-    pub async fn get_user_info(&self, refresh_token: &str) -> Result<crate::modules::oauth::UserInfo, String> {
+    pub async fn get_user_info(
+        &self,
+        refresh_token: &str,
+    ) -> Result<crate::modules::oauth::UserInfo, String> {
         // 先获取 Access Token
-        let token = crate::modules::oauth::refresh_access_token(refresh_token).await
+        let token = crate::modules::oauth::refresh_access_token(refresh_token)
+            .await
             .map_err(|e| format!("刷新 Access Token 失败: {}", e))?;
-            
+
         crate::modules::oauth::get_user_info(&token.access_token).await
     }
 
@@ -1584,7 +1890,7 @@ impl TokenManager {
         // 3. 委托给 modules::account::add_account 处理 (包含文件写入、索引更新、锁)
         let email_clone = email.to_string();
         let refresh_token_clone = refresh_token.to_string();
-        
+
         tokio::task::spawn_blocking(move || {
             let token_data = crate::models::TokenData::new(
                 token_info.access_token,
@@ -1594,19 +1900,21 @@ impl TokenManager {
                 Some(project_id),
                 None, // session_id
             );
-            
+
             crate::modules::account::upsert_account(email_clone, None, token_data)
-        }).await
+        })
+        .await
         .map_err(|e| format!("Task join error: {}", e))?
         .map_err(|e| format!("Failed to save account: {}", e))?;
 
         // 4. 重新加载 (更新内存)
         self.reload_all_accounts().await.map(|_| ())
     }
-    
-/// 记录请求成功，增加健康分
+
+    /// 记录请求成功，增加健康分
     pub fn record_success(&self, account_id: &str) {
-        self.health_scores.entry(account_id.to_string())
+        self.health_scores
+            .entry(account_id.to_string())
             .and_modify(|s| *s = (*s + 0.05).min(1.0))
             .or_insert(1.0);
         tracing::debug!("📈 Health score increased for account {}", account_id);
@@ -1614,10 +1922,64 @@ impl TokenManager {
 
     /// 记录请求失败，降低健康分
     pub fn record_failure(&self, account_id: &str) {
-        self.health_scores.entry(account_id.to_string())
+        self.health_scores
+            .entry(account_id.to_string())
             .and_modify(|s| *s = (*s - 0.2).max(0.0))
             .or_insert(0.8);
         tracing::warn!("📉 Health score decreased for account {}", account_id);
+    }
+
+    /// [NEW] 从账号配额信息中提取最近的刷新时间戳
+    ///
+    /// Claude 模型（sonnet/opus）共用同一个刷新时间，只需取 claude 系列的 reset_time
+    /// 返回 Unix 时间戳（秒），用于排序时比较
+    fn extract_earliest_reset_time(&self, account: &serde_json::Value) -> Option<i64> {
+        let models = account
+            .get("quota")
+            .and_then(|q| q.get("models"))
+            .and_then(|m| m.as_array())?;
+
+        let mut earliest_ts: Option<i64> = None;
+
+        for model in models {
+            // 优先取 claude 系列的 reset_time（sonnet/opus 共用）
+            let model_name = model.get("name").and_then(|n| n.as_str()).unwrap_or("");
+            if !model_name.contains("claude") {
+                continue;
+            }
+
+            if let Some(reset_time_str) = model.get("reset_time").and_then(|r| r.as_str()) {
+                if reset_time_str.is_empty() {
+                    continue;
+                }
+                // 解析 ISO 8601 时间字符串为时间戳
+                if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(reset_time_str) {
+                    let ts = dt.timestamp();
+                    if earliest_ts.is_none() || ts < earliest_ts.unwrap() {
+                        earliest_ts = Some(ts);
+                    }
+                }
+            }
+        }
+
+        // 如果没有 claude 模型的时间，尝试取任意模型的最近时间
+        if earliest_ts.is_none() {
+            for model in models {
+                if let Some(reset_time_str) = model.get("reset_time").and_then(|r| r.as_str()) {
+                    if reset_time_str.is_empty() {
+                        continue;
+                    }
+                    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(reset_time_str) {
+                        let ts = dt.timestamp();
+                        if earliest_ts.is_none() || ts < earliest_ts.unwrap() {
+                            earliest_ts = Some(ts);
+                        }
+                    }
+                }
+            }
+        }
+
+        earliest_ts
     }
 }
 
@@ -1627,5 +1989,263 @@ fn truncate_reason(reason: &str, max_len: usize) -> String {
         reason.to_string()
     } else {
         format!("{}...", &reason[..max_len - 3])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cmp::Ordering;
+
+    /// 创建测试用的 ProxyToken
+    fn create_test_token(
+        email: &str,
+        tier: Option<&str>,
+        health_score: f32,
+        reset_time: Option<i64>,
+        remaining_quota: Option<i32>,
+    ) -> ProxyToken {
+        ProxyToken {
+            account_id: email.to_string(),
+            access_token: "test_token".to_string(),
+            refresh_token: "test_refresh".to_string(),
+            expires_in: 3600,
+            timestamp: chrono::Utc::now().timestamp() + 3600,
+            email: email.to_string(),
+            account_path: PathBuf::from("/tmp/test"),
+            project_id: None,
+            subscription_tier: tier.map(|s| s.to_string()),
+            remaining_quota,
+            protected_models: HashSet::new(),
+            health_score,
+            reset_time,
+        }
+    }
+
+    /// 测试排序比较函数（与 get_token_internal 中的逻辑一致）
+    fn compare_tokens(a: &ProxyToken, b: &ProxyToken) -> Ordering {
+        const RESET_TIME_THRESHOLD_SECS: i64 = 600; // 10 分钟阈值
+
+        let tier_priority = |tier: &Option<String>| match tier.as_deref() {
+            Some("ULTRA") => 0,
+            Some("PRO") => 1,
+            Some("FREE") => 2,
+            _ => 3,
+        };
+
+        // First: compare by subscription tier
+        let tier_cmp = tier_priority(&a.subscription_tier).cmp(&tier_priority(&b.subscription_tier));
+        if tier_cmp != Ordering::Equal {
+            return tier_cmp;
+        }
+
+        // Second: compare by health score (higher is better)
+        let health_cmp = b.health_score.partial_cmp(&a.health_score).unwrap_or(Ordering::Equal);
+        if health_cmp != Ordering::Equal {
+            return health_cmp;
+        }
+
+        // Third: compare by reset time (earlier/closer is better)
+        let reset_a = a.reset_time.unwrap_or(i64::MAX);
+        let reset_b = b.reset_time.unwrap_or(i64::MAX);
+        let reset_diff = (reset_a - reset_b).abs();
+
+        if reset_diff >= RESET_TIME_THRESHOLD_SECS {
+            let reset_cmp = reset_a.cmp(&reset_b);
+            if reset_cmp != Ordering::Equal {
+                return reset_cmp;
+            }
+        }
+
+        // Fourth: compare by remaining quota percentage (higher is better)
+        let quota_a = a.remaining_quota.unwrap_or(0);
+        let quota_b = b.remaining_quota.unwrap_or(0);
+        quota_b.cmp(&quota_a)
+    }
+
+    #[test]
+    fn test_sorting_tier_priority() {
+        // ULTRA > PRO > FREE
+        let ultra = create_test_token("ultra@test.com", Some("ULTRA"), 1.0, None, Some(50));
+        let pro = create_test_token("pro@test.com", Some("PRO"), 1.0, None, Some(50));
+        let free = create_test_token("free@test.com", Some("FREE"), 1.0, None, Some(50));
+
+        assert_eq!(compare_tokens(&ultra, &pro), Ordering::Less);
+        assert_eq!(compare_tokens(&pro, &free), Ordering::Less);
+        assert_eq!(compare_tokens(&ultra, &free), Ordering::Less);
+        assert_eq!(compare_tokens(&free, &ultra), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_sorting_health_score_priority() {
+        // 同等级下，健康分高的优先
+        let high_health = create_test_token("high@test.com", Some("PRO"), 1.0, None, Some(50));
+        let low_health = create_test_token("low@test.com", Some("PRO"), 0.5, None, Some(50));
+
+        assert_eq!(compare_tokens(&high_health, &low_health), Ordering::Less);
+        assert_eq!(compare_tokens(&low_health, &high_health), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_sorting_reset_time_priority() {
+        let now = chrono::Utc::now().timestamp();
+
+        // 刷新时间更近（30分钟后）的优先于更远（5小时后）的
+        let soon_reset = create_test_token("soon@test.com", Some("PRO"), 1.0, Some(now + 1800), Some(50));  // 30分钟后
+        let late_reset = create_test_token("late@test.com", Some("PRO"), 1.0, Some(now + 18000), Some(50)); // 5小时后
+
+        assert_eq!(compare_tokens(&soon_reset, &late_reset), Ordering::Less);
+        assert_eq!(compare_tokens(&late_reset, &soon_reset), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_sorting_reset_time_threshold() {
+        let now = chrono::Utc::now().timestamp();
+
+        // 差异小于10分钟（600秒）视为相同优先级，此时按配额排序
+        let reset_a = create_test_token("a@test.com", Some("PRO"), 1.0, Some(now + 1800), Some(80));  // 30分钟后, 80%配额
+        let reset_b = create_test_token("b@test.com", Some("PRO"), 1.0, Some(now + 2100), Some(50));  // 35分钟后, 50%配额
+
+        // 差5分钟 < 10分钟阈值，视为相同，按配额排序（80% > 50%）
+        assert_eq!(compare_tokens(&reset_a, &reset_b), Ordering::Less);
+    }
+
+    #[test]
+    fn test_sorting_reset_time_beyond_threshold() {
+        let now = chrono::Utc::now().timestamp();
+
+        // 差异超过10分钟，按刷新时间排序（忽略配额）
+        let soon_low_quota = create_test_token("soon@test.com", Some("PRO"), 1.0, Some(now + 1800), Some(20));   // 30分钟后, 20%
+        let late_high_quota = create_test_token("late@test.com", Some("PRO"), 1.0, Some(now + 18000), Some(90)); // 5小时后, 90%
+
+        // 差4.5小时 > 10分钟，刷新时间优先，30分钟 < 5小时
+        assert_eq!(compare_tokens(&soon_low_quota, &late_high_quota), Ordering::Less);
+    }
+
+    #[test]
+    fn test_sorting_quota_fallback() {
+        // 其他条件相同时，配额高的优先
+        let high_quota = create_test_token("high@test.com", Some("PRO"), 1.0, None, Some(80));
+        let low_quota = create_test_token("low@test.com", Some("PRO"), 1.0, None, Some(20));
+
+        assert_eq!(compare_tokens(&high_quota, &low_quota), Ordering::Less);
+        assert_eq!(compare_tokens(&low_quota, &high_quota), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_sorting_missing_reset_time() {
+        let now = chrono::Utc::now().timestamp();
+
+        // 没有 reset_time 的账号应该排在有 reset_time 的后面
+        let with_reset = create_test_token("with@test.com", Some("PRO"), 1.0, Some(now + 1800), Some(50));
+        let without_reset = create_test_token("without@test.com", Some("PRO"), 1.0, None, Some(50));
+
+        assert_eq!(compare_tokens(&with_reset, &without_reset), Ordering::Less);
+    }
+
+    #[test]
+    fn test_full_sorting_integration() {
+        let now = chrono::Utc::now().timestamp();
+
+        let mut tokens = vec![
+            create_test_token("free_high@test.com", Some("FREE"), 1.0, Some(now + 1800), Some(90)),
+            create_test_token("pro_low_health@test.com", Some("PRO"), 0.5, Some(now + 1800), Some(90)),
+            create_test_token("pro_soon@test.com", Some("PRO"), 1.0, Some(now + 1800), Some(50)),   // 30分钟后
+            create_test_token("pro_late@test.com", Some("PRO"), 1.0, Some(now + 18000), Some(90)),  // 5小时后
+            create_test_token("ultra@test.com", Some("ULTRA"), 1.0, Some(now + 36000), Some(10)),
+        ];
+
+        tokens.sort_by(compare_tokens);
+
+        // 预期顺序:
+        // 1. ULTRA (最高等级，即使刷新时间最远)
+        // 2. PRO + 高健康分 + 30分钟后刷新
+        // 3. PRO + 高健康分 + 5小时后刷新
+        // 4. PRO + 低健康分
+        // 5. FREE (最低等级，即使配额最高)
+        assert_eq!(tokens[0].email, "ultra@test.com");
+        assert_eq!(tokens[1].email, "pro_soon@test.com");
+        assert_eq!(tokens[2].email, "pro_late@test.com");
+        assert_eq!(tokens[3].email, "pro_low_health@test.com");
+        assert_eq!(tokens[4].email, "free_high@test.com");
+    }
+
+    #[test]
+    fn test_realistic_scenario() {
+        // 模拟用户描述的场景:
+        // a 账号 claude 4h55m 后刷新
+        // b 账号 claude 31m 后刷新
+        // 应该优先使用 b（31分钟后刷新）
+        let now = chrono::Utc::now().timestamp();
+
+        let account_a = create_test_token("a@test.com", Some("PRO"), 1.0, Some(now + 295 * 60), Some(80)); // 4h55m
+        let account_b = create_test_token("b@test.com", Some("PRO"), 1.0, Some(now + 31 * 60), Some(30));  // 31m
+
+        // b 应该排在 a 前面（刷新时间更近）
+        assert_eq!(compare_tokens(&account_b, &account_a), Ordering::Less);
+
+        let mut tokens = vec![account_a.clone(), account_b.clone()];
+        tokens.sort_by(compare_tokens);
+
+        assert_eq!(tokens[0].email, "b@test.com");
+        assert_eq!(tokens[1].email, "a@test.com");
+    }
+
+    #[test]
+    fn test_extract_earliest_reset_time() {
+        let manager = TokenManager::new(PathBuf::from("/tmp/test"));
+
+        // 测试包含 claude 模型的 reset_time 提取
+        let account_with_claude = serde_json::json!({
+            "quota": {
+                "models": [
+                    {"name": "gemini-flash", "reset_time": "2025-01-31T10:00:00Z"},
+                    {"name": "claude-sonnet", "reset_time": "2025-01-31T08:00:00Z"},
+                    {"name": "claude-opus", "reset_time": "2025-01-31T08:00:00Z"}
+                ]
+            }
+        });
+
+        let result = manager.extract_earliest_reset_time(&account_with_claude);
+        assert!(result.is_some());
+        // 应该返回 claude 的时间（08:00）而不是 gemini 的（10:00）
+        let expected_ts = chrono::DateTime::parse_from_rfc3339("2025-01-31T08:00:00Z")
+            .unwrap()
+            .timestamp();
+        assert_eq!(result.unwrap(), expected_ts);
+    }
+
+    #[test]
+    fn test_extract_reset_time_no_claude() {
+        let manager = TokenManager::new(PathBuf::from("/tmp/test"));
+
+        // 没有 claude 模型时，应该取任意模型的最近时间
+        let account_no_claude = serde_json::json!({
+            "quota": {
+                "models": [
+                    {"name": "gemini-flash", "reset_time": "2025-01-31T10:00:00Z"},
+                    {"name": "gemini-pro", "reset_time": "2025-01-31T08:00:00Z"}
+                ]
+            }
+        });
+
+        let result = manager.extract_earliest_reset_time(&account_no_claude);
+        assert!(result.is_some());
+        let expected_ts = chrono::DateTime::parse_from_rfc3339("2025-01-31T08:00:00Z")
+            .unwrap()
+            .timestamp();
+        assert_eq!(result.unwrap(), expected_ts);
+    }
+
+    #[test]
+    fn test_extract_reset_time_missing_quota() {
+        let manager = TokenManager::new(PathBuf::from("/tmp/test"));
+
+        // 没有 quota 字段时应返回 None
+        let account_no_quota = serde_json::json!({
+            "email": "test@test.com"
+        });
+
+        assert!(manager.extract_earliest_reset_time(&account_no_quota).is_none());
     }
 }


### PR DESCRIPTION
#### 问题背景

当前账号轮换策略在选择账号时，没有考虑配额刷新时间（reset_time）。这导致可能优先使用刷新时间较远的账号，而让刷新时间较近的账号闲置。

**举例：**

- 账号 A：4h55m 后刷新，配额 80%
- 账号 B：31m 后刷新，配额 30%

旧策略会优先使用配额高的 A，但更优的策略是：先用 B，31 分钟后 B 刷新满血，此时再轮换到 A，形成更好的账号利用循环。

#### 解决方案

1. **新增 `reset_time` 字段**：在 `ProxyToken` 结构体中添加配额刷新时间戳

2. **调整排序优先级**：

   ```
   订阅等级 > 健康分 > 刷新时间（越近越优先）> 剩余配额
   ```

3. **10 分钟阈值**：刷新时间差异 < 10 分钟视为相同优先级，避免频繁切换

4. **新账号自动获取配额**：添加账号后立即调用配额 API，确保 `reset_time` 可用

#### 修改的文件

| 文件                                     | 修改内容                                                     |
| ---------------------------------------- | ------------------------------------------------------------ |
| src-tauri/src/proxy/token_manager.rs     | 添加 `reset_time` 字段、修改排序逻辑、新增 `extract_earliest_reset_time` 方法、添加 12 个单元测试 |
| src-tauri/src/modules/account_service.rs | 新账号添加后自动获取配额信息                                 |

#### 测试

- ✅ 12 个单元测试全部通过
- ✅ 已添加相应单元测试

----

#### Problem

The current account rotation strategy does not consider quota reset time when selecting accounts. This may result in accounts with longer reset times being used first, while accounts with shorter reset times remain idle.

**Example:**

- Account A: resets in 4h55m, 80% quota remaining
- Account B: resets in 31m, 30% quota remaining

The old strategy would prefer A (higher quota), but a better approach is: use B first, then after 31 minutes B resets to full quota, switch to A, creating a better rotation cycle.

#### Solution

1. **Add `reset_time` field**: Added quota reset timestamp to `ProxyToken` struct

2. **Adjust sorting priority**:

   ```
   Subscription Tier > Health Score > Reset Time (sooner is better) > Remaining Quota
   ```

3. **10-minute threshold**: Reset time differences < 10 minutes are treated as equal priority to avoid frequent switching

4. **Auto-fetch quota for new accounts**: Automatically fetch quota info after adding an account to ensure `reset_time` is available

#### Changed Files

| File                                     | Changes                                                      |
| ---------------------------------------- | ------------------------------------------------------------ |
| src-tauri/src/proxy/token_manager.rs     | Added `reset_time` field, modified sorting logic, added `extract_earliest_reset_time` method, added 12 unit tests |
| src-tauri/src/modules/account_service.rs | Auto-fetch quota info after adding new account               |

#### Testing

- ✅ All 12 unit tests passed
- ✅ Compiles without errors