### PR TITLE
fix(proxy): prevent 503 account pool lockup and restore account tracking

### DIFF
--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -70,11 +70,11 @@ impl TokenManager {
         });
         tracing::info!("✅ Rate limit auto-cleanup task started (interval: 15s)");
     }
-    
+
     /// 从主应用账号目录加载所有账号
     pub async fn load_accounts(&self) -> Result<usize, String> {
         let accounts_dir = self.data_dir.join("accounts");
-        
+
         if !accounts_dir.exists() {
             return Err(format!("账号目录不存在: {:?}", accounts_dir));
         }
@@ -86,20 +86,20 @@ impl TokenManager {
             let mut last_used = self.last_used_account.lock().await;
             *last_used = None;
         }
-        
+
         let entries = std::fs::read_dir(&accounts_dir)
             .map_err(|e| format!("读取账号目录失败: {}", e))?;
-        
+
         let mut count = 0;
-        
+
         for entry in entries {
             let entry = entry.map_err(|e| format!("读取目录项失败: {}", e))?;
             let path = entry.path();
-            
+
             if path.extension().and_then(|s| s.to_str()) != Some("json") {
                 continue;
             }
-            
+
             // 尝试加载账号
             match self.load_single_account(&path).await {
                 Ok(Some(token)) => {
@@ -115,7 +115,7 @@ impl TokenManager {
                 }
             }
         }
-        
+
         Ok(count)
     }
 
@@ -145,12 +145,12 @@ impl TokenManager {
         self.clear_all_rate_limits();
         Ok(count)
     }
-    
+
     /// 加载单个账号
     async fn load_single_account(&self, path: &PathBuf) -> Result<Option<ProxyToken>, String> {
         let content = std::fs::read_to_string(path)
             .map_err(|e| format!("读取文件失败: {}", e))?;
-        
+
         let mut account: serde_json::Value = serde_json::from_str(&content)
             .map_err(|e| format!("解析 JSON 失败: {}", e))?;
 
@@ -172,11 +172,11 @@ impl TokenManager {
         let is_proxy_disabled = account.get("proxy_disabled")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        
+
         let disabled_reason = account.get("proxy_disabled_reason")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        
+
         if is_proxy_disabled && disabled_reason != "quota_protection" {
             // 账号被手动禁用(非配额保护原因)
             tracing::debug!(
@@ -219,45 +219,45 @@ impl TokenManager {
         let account_id = account["id"].as_str()
             .ok_or("缺少 id 字段")?
             .to_string();
-        
+
         let email = account["email"].as_str()
             .ok_or("缺少 email 字段")?
             .to_string();
-        
+
         let token_obj = account["token"].as_object()
             .ok_or("缺少 token 字段")?;
-        
+
         let access_token = token_obj["access_token"].as_str()
             .ok_or("缺少 access_token")?
             .to_string();
-        
+
         let refresh_token = token_obj["refresh_token"].as_str()
             .ok_or("缺少 refresh_token")?
             .to_string();
-        
+
         let expires_in = token_obj["expires_in"].as_i64()
             .ok_or("缺少 expires_in")?;
-        
+
         let timestamp = token_obj["expiry_timestamp"].as_i64()
             .ok_or("缺少 expiry_timestamp")?;
-        
+
         // project_id 是可选的
         let project_id = token_obj.get("project_id")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
-        
-        
+
+
         // 【新增】提取订阅等级 (subscription_tier 为 "FREE" | "PRO" | "ULTRA")
         let subscription_tier = account.get("quota")
             .and_then(|q| q.get("subscription_tier"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
-        
+
         // [FIX #563] 提取最大剩余配额百分比用于优先级排序 (Option<i32> now)
         let remaining_quota = account.get("quota")
             .and_then(|q| self.calculate_quota_stats(q));
             // .filter(|&r| r > 0); // 移除 >0 过滤，因为 0% 也是有效数据，只是优先级低
-        
+
         // 【新增 #621】提取受限模型列表
         let protected_models: HashSet<String> = account.get("protected_models")
             .and_then(|v| v.as_array())
@@ -268,9 +268,9 @@ impl TokenManager {
                     .collect()
             })
             .unwrap_or_default();
-        
+
         let health_score = self.health_scores.get(&account_id).map(|v| *v).unwrap_or(1.0);
-        
+
         Ok(Some(ProxyToken {
             account_id,
             access_token,
@@ -287,7 +287,7 @@ impl TokenManager {
         }))
     }
 
-    
+
     /// 检查账号是否应该被配额保护
     /// 如果配额低于阈值，自动禁用账号并返回 true
     async fn check_and_protect_quota(&self, account_json: &mut serde_json::Value, account_path: &PathBuf) -> bool {
@@ -296,11 +296,11 @@ impl TokenManager {
             Ok(cfg) => cfg.quota_protection,
             Err(_) => return false, // 配置加载失败，跳过保护
         };
-        
+
         if !config.enabled {
             return false; // 配额保护未启用
         }
-        
+
         // 2. 获取配额信息
         // 注意：我们需要 clone 配额信息来遍历，避免借用冲突，但修改是针对 account_json 的
         let quota = match account_json.get("quota") {
@@ -312,18 +312,18 @@ impl TokenManager {
         let is_proxy_disabled = account_json.get("proxy_disabled")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        
+
         let reason = account_json.get("proxy_disabled_reason")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        
+
         if is_proxy_disabled && reason == "quota_protection" {
             // 如果是被旧版账号级保护禁用的,尝试恢复并转为模型级
             return self.check_and_restore_quota(account_json, account_path, &quota, &config).await;
         }
-        
+
         // [修复 #1344] 不再处理其他禁用原因,让调用方负责检查手动禁用
-        
+
         // 4. 获取模型列表
         let models = match quota.get("models").and_then(|m| m.as_array()) {
             Some(m) => m,
@@ -339,7 +339,7 @@ impl TokenManager {
         for model in models {
             let name = model.get("name").and_then(|v| v.as_str()).unwrap_or("");
             if !config.monitored_models.iter().any(|m| m == name) {
-                continue; 
+                continue;
             }
 
             let percentage = model.get("percentage").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
@@ -364,14 +364,14 @@ impl TokenManager {
                 }
             }
         }
-        
+
         let _ = changed; // 避免 unused 警告，如果后续逻辑需要可以继续使用
-        
+
         // 我们不再因为配额原因返回 true（即不再跳过账号），
         // 而是加载并在 get_token 时进行过滤。
         false
     }
-    
+
     /// 计算账号的最大剩余配额百分比（用于排序）
     /// 返回值: Option<i32> (max_percentage)
     fn calculate_quota_stats(&self, quota: &serde_json::Value) -> Option<i32> {
@@ -379,10 +379,10 @@ impl TokenManager {
             Some(m) => m,
             None => return None,
         };
-        
+
         let mut max_percentage = 0;
         let mut has_data = false;
-        
+
         for model in models {
             if let Some(pct) = model.get("percentage").and_then(|v| v.as_i64()) {
                 let pct_i32 = pct as i32;
@@ -392,14 +392,14 @@ impl TokenManager {
                 has_data = true;
             }
         }
-        
+
         if has_data {
             Some(max_percentage)
         } else {
             None
         }
     }
-    
+
     /// 触发配额保护，限制特定模型 (Issue #621)
     /// 返回 true 如果发生了改变
     async fn trigger_quota_protection(
@@ -415,28 +415,28 @@ impl TokenManager {
         if account_json.get("protected_models").is_none() {
             account_json["protected_models"] = serde_json::Value::Array(Vec::new());
         }
-        
+
         let protected_models = account_json["protected_models"].as_array_mut().unwrap();
-        
+
         // 2. 检查是否已存在
         if !protected_models.iter().any(|m| m.as_str() == Some(model_name)) {
             protected_models.push(serde_json::Value::String(model_name.to_string()));
-            
+
             tracing::info!(
                 "账号 {} 的模型 {} 因配额受限（{}% <= {}%）已被加入保护列表",
                 account_id, model_name, current_val, threshold
             );
-            
+
             // 3. 写入磁盘
             std::fs::write(account_path, serde_json::to_string_pretty(account_json).unwrap())
                 .map_err(|e| format!("写入文件失败: {}", e))?;
-            
+
             return Ok(true);
         }
-        
+
         Ok(false)
     }
-    
+
     /// 检查并从账号级保护恢复（迁移至模型级，Issue #621）
     async fn check_and_restore_quota(
         &self,
@@ -463,21 +463,21 @@ impl TokenManager {
             for model in models {
                 let name = model.get("name").and_then(|v| v.as_str()).unwrap_or("");
                 if !config.monitored_models.iter().any(|m| m == name) { continue; }
-                
+
                 let percentage = model.get("percentage").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
                 if percentage <= threshold {
                     protected_list.push(serde_json::Value::String(name.to_string()));
                 }
             }
         }
-        
+
         account_json["protected_models"] = serde_json::Value::Array(protected_list);
-        
+
         let _ = std::fs::write(account_path, serde_json::to_string_pretty(account_json).unwrap());
-        
+
         false // 返回 false 表示现在已可以尝试加载该账号（模型级过滤会在 get_token 时发生）
     }
-    
+
     /// 恢复特定模型的配额保护 (Issue #621)
     /// 返回 true 如果发生了改变
     async fn restore_quota_protection(
@@ -490,7 +490,7 @@ impl TokenManager {
         if let Some(arr) = account_json.get_mut("protected_models").and_then(|v| v.as_array_mut()) {
             let original_len = arr.len();
             arr.retain(|m| m.as_str() != Some(model_name));
-            
+
             if arr.len() < original_len {
                 tracing::info!("账号 {} 的模型 {} 配额已恢复，移出保护列表", account_id, model_name);
                 std::fs::write(account_path, serde_json::to_string_pretty(account_json).unwrap())
@@ -498,20 +498,20 @@ impl TokenManager {
                 return Ok(true);
             }
         }
-        
+
         Ok(false)
     }
 
-    
+
     /// 获取当前可用的 Token（支持粘性会话与智能调度）
     /// 参数 `quota_group` 用于区分 "claude" vs "gemini" 组
     /// 参数 `force_rotate` 为 true 时将忽略锁定，强制切换账号
     /// 参数 `session_id` 用于跨请求维持会话粘性
     /// 参数 `target_model` 用于检查配额保护 (Issue #621)
     pub async fn get_token(
-        &self, 
-        quota_group: &str, 
-        force_rotate: bool, 
+        &self,
+        quota_group: &str,
+        force_rotate: bool,
         session_id: Option<&str>,
         target_model: &str,
     ) -> Result<(String, String, String, u64), String> {
@@ -525,9 +525,9 @@ impl TokenManager {
 
     /// 内部实现：获取 Token 的核心逻辑
     async fn get_token_internal(
-        &self, 
-        quota_group: &str, 
-        force_rotate: bool, 
+        &self,
+        quota_group: &str,
+        force_rotate: bool,
         session_id: Option<&str>,
         target_model: &str,
     ) -> Result<(String, String, String, u64), String> {
@@ -548,34 +548,34 @@ impl TokenManager {
                 Some("FREE") => 2,
                 _ => 3,
             };
-            
+
             // First: compare by subscription tier
             let tier_cmp = tier_priority(&a.subscription_tier)
                 .cmp(&tier_priority(&b.subscription_tier));
-            
+
             if tier_cmp != std::cmp::Ordering::Equal {
                 return tier_cmp;
             }
-            
+
             // [FIX #563] Second: compare by remaining quota percentage (higher is better)
             // Accounts with unknown/zero percentage go last within their tier
             let quota_a = a.remaining_quota.unwrap_or(0);
             let quota_b = b.remaining_quota.unwrap_or(0);
             let quota_cmp = quota_b.cmp(&quota_a);
-            
+
             if quota_cmp != std::cmp::Ordering::Equal {
                 return quota_cmp;
             }
-            
+
             // [NEW] Third: compare by health score (higher is better)
             b.health_score.partial_cmp(&a.health_score).unwrap_or(std::cmp::Ordering::Equal)
         });
-        
+
         // 【调试日志】打印排序后的账号顺序
         tracing::debug!(
             "🔄 [Token Rotation] Accounts: {:?}",
             tokens_snapshot.iter().map(|t| format!(
-                "{}(protected={:?})", 
+                "{}(protected={:?})",
                 t.email, t.protected_models
             )).collect::<Vec<_>>()
         );
@@ -583,7 +583,7 @@ impl TokenManager {
         // 0. 读取当前调度配置
         let scheduling = self.sticky_config.read().await.clone();
         use crate::proxy::sticky_config::SchedulingMode;
-        
+
         // 【新增】检查配额保护是否启用（如果关闭，则忽略 protected_models 检查）
         let quota_protection_enabled = crate::modules::config::load_app_config()
             .map(|cfg| cfg.quota_protection.enabled)
@@ -682,15 +682,15 @@ impl TokenManager {
 
             // ===== 【核心】粘性会话与智能调度逻辑 =====
             let mut target_token: Option<ProxyToken> = None;
-            
+
             // 归一化目标模型名为标准 ID，用于配额保护检查
             let normalized_target = crate::proxy::common::model_mapping::normalize_to_standard_id(target_model)
                 .unwrap_or_else(|| target_model.to_string());
-            
+
             // 模式 A: 粘性会话处理 (CacheFirst 或 Balance 且有 session_id)
             if !rotate && session_id.is_some() && scheduling.mode != SchedulingMode::PerformanceFirst {
                 let sid = session_id.unwrap();
-                
+
                 // 1. 检查会话是否已绑定账号
                 if let Some(bound_id) = self.session_accounts.get(sid).map(|v| v.clone()) {
                     // 【修复】先通过 account_id 找到对应的账号，获取其 email
@@ -745,7 +745,7 @@ impl TokenManager {
                         }
                     }
                 }
-                
+
                 // 若无锁定，则轮询选择新账号
                 if target_token.is_none() {
                     let start_idx = self.current_index.fetch_add(1, Ordering::SeqCst) % total;
@@ -770,7 +770,7 @@ impl TokenManager {
                         target_token = Some(candidate.clone());
                         // 【优化】标记需要更新，稍后统一写回
                         need_update_last_used = Some((candidate.account_id.clone(), std::time::Instant::now()));
-                        
+
                         // 如果是会话首次分配且需要粘性，在此建立绑定
                         if let Some(sid) = session_id {
                             if scheduling.mode != SchedulingMode::PerformanceFirst {
@@ -788,7 +788,7 @@ impl TokenManager {
                 for offset in 0..total {
                     let idx = (start_idx + offset) % total;
                     let candidate = &tokens_snapshot[idx];
-                    
+
                     if attempted.contains(&candidate.account_id) {
                         tracing::debug!("  [{}] {} - SKIP: already attempted", idx, candidate.email);
                         continue;
@@ -808,14 +808,14 @@ impl TokenManager {
 
                     tracing::debug!("  [{}] {} - SELECTED", idx, candidate.email);
                     target_token = Some(candidate.clone());
-                    
+
                     if rotate {
                         tracing::debug!("Force Rotation: Switched to account: {}", candidate.email);
                     }
                     break;
                 }
             }
-            
+
             let mut token = match target_token {
                 Some(t) => t,
                 None => {
@@ -825,7 +825,7 @@ impl TokenManager {
                     let min_wait = tokens_snapshot.iter()
                         .filter_map(|t| self.rate_limit_tracker.get_reset_seconds(&t.account_id))
                         .min();
-                    
+
                     // Layer 1: 如果最短等待时间 <= 2秒,执行缓冲延迟
                     if let Some(wait_sec) = min_wait {
                         if wait_sec <= 2 {
@@ -834,14 +834,14 @@ impl TokenManager {
                                 "All accounts rate-limited but shortest wait is {}s. Applying {}ms buffer for state sync...",
                                 wait_sec, wait_ms
                             );
-                            
+
                             // 缓冲延迟
                             tokio::time::sleep(tokio::time::Duration::from_millis(wait_ms)).await;
-                            
+
                             // 重新尝试选择账号
                             let retry_token = tokens_snapshot.iter()
                                 .find(|t| !attempted.contains(&t.account_id) && !self.is_rate_limited_sync(&t.account_id, None));
-                            
+
                             if let Some(t) = retry_token {
                                 tracing::info!("✅ Buffer delay successful! Found available account: {}", t.email);
                                 t.clone()
@@ -851,14 +851,14 @@ impl TokenManager {
                                     "Buffer delay failed. Executing optimistic reset for all {} accounts...",
                                     tokens_snapshot.len()
                                 );
-                                
+
                                 // 清除所有限流记录
                                 self.rate_limit_tracker.clear_all();
-                                
+
                                 // 再次尝试选择账号
                                 let final_token = tokens_snapshot.iter()
                                     .find(|t| !attempted.contains(&t.account_id));
-                                
+
                                 if let Some(t) = final_token {
                                     tracing::info!("✅ Optimistic reset successful! Using account: {}", t.email);
                                     t.clone()
@@ -875,7 +875,7 @@ impl TokenManager {
                 }
             };
 
-        
+
             // 3. 检查 token 是否过期（提前5分钟刷新）
             let now = chrono::Utc::now().timestamp();
             if now >= token.timestamp - 300 {
@@ -999,7 +999,7 @@ impl TokenManager {
 
         std::fs::write(&path, serde_json::to_string_pretty(&content).unwrap())
             .map_err(|e| format!("写入文件失败: {}", e))?;
-        
+
         // 【修复 Issue #3】从内存中移除禁用的账号，防止被60s锁定逻辑继续使用
         self.tokens.remove(account_id);
 
@@ -1011,46 +1011,46 @@ impl TokenManager {
     async fn save_project_id(&self, account_id: &str, project_id: &str) -> Result<(), String> {
         let entry = self.tokens.get(account_id)
             .ok_or("账号不存在")?;
-        
+
         let path = &entry.account_path;
-        
+
         let mut content: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?
         ).map_err(|e| format!("解析 JSON 失败: {}", e))?;
-        
+
         content["token"]["project_id"] = serde_json::Value::String(project_id.to_string());
-        
+
         std::fs::write(path, serde_json::to_string_pretty(&content).unwrap())
             .map_err(|e| format!("写入文件失败: {}", e))?;
-        
+
         tracing::debug!("已保存 project_id 到账号 {}", account_id);
         Ok(())
     }
-    
+
     /// 保存刷新后的 token 到账号文件
     async fn save_refreshed_token(&self, account_id: &str, token_response: &crate::modules::oauth::TokenResponse) -> Result<(), String> {
         let entry = self.tokens.get(account_id)
             .ok_or("账号不存在")?;
-        
+
         let path = &entry.account_path;
-        
+
         let mut content: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?
         ).map_err(|e| format!("解析 JSON 失败: {}", e))?;
-        
+
         let now = chrono::Utc::now().timestamp();
-        
+
         content["token"]["access_token"] = serde_json::Value::String(token_response.access_token.clone());
         content["token"]["expires_in"] = serde_json::Value::Number(token_response.expires_in.into());
         content["token"]["expiry_timestamp"] = serde_json::Value::Number((now + token_response.expires_in).into());
-        
+
         std::fs::write(path, serde_json::to_string_pretty(&content).unwrap())
             .map_err(|e| format!("写入文件失败: {}", e))?;
-        
+
         tracing::debug!("已保存刷新后的 token 到账号 {}", account_id);
         Ok(())
     }
-    
+
     pub fn len(&self) -> usize {
         self.tokens.len()
     }
@@ -1093,7 +1093,7 @@ impl TokenManager {
         };
 
         let project_id = project_id_opt.unwrap_or_else(|| "bamboo-precept-lgxtn".to_string());
-        
+
         // 检查是否过期 (提前5分钟)
         if now < timestamp + expires_in - 300 {
             return Ok((current_access_token, project_id, email.to_string(), 0));
@@ -1106,7 +1106,7 @@ impl TokenManager {
             Ok(token_response) => {
                 tracing::info!("[Warmup] Token refresh successful for {}", email);
                 let new_now = chrono::Utc::now().timestamp();
-                
+
                 // 更新缓存
                 if let Some(mut entry) = self.tokens.get_mut(&account_id) {
                     entry.access_token = token_response.access_token.clone();
@@ -1122,9 +1122,9 @@ impl TokenManager {
             Err(e) => Err(format!("[Warmup] Token refresh failed for {}: {}", email, e)),
         }
     }
-    
+
     // ===== 限流管理方法 =====
-    
+
     /// 标记账号限流(从外部调用,通常在 handler 中)
     /// 参数为 email，内部会自动转换为 account_id
     pub async fn mark_rate_limited(
@@ -1142,7 +1142,7 @@ impl TokenManager {
 
         // 【替代方案】转换 email -> account_id
         let key = self.email_to_account_id(email).unwrap_or_else(|| email.to_string());
-        
+
         self.rate_limit_tracker.parse_from_error(
             &key,
             status,
@@ -1152,7 +1152,7 @@ impl TokenManager {
             &config.backoff_steps, // [NEW] 传入配置
         );
     }
-    
+
 
     /// 检查账号是否在限流中 (支持模型级)
     pub async fn is_rate_limited(&self, account_id: &str, model: Option<&str>) -> bool {
@@ -1173,19 +1173,19 @@ impl TokenManager {
         }
         self.rate_limit_tracker.is_rate_limited(account_id, model)
     }
-    
+
     /// 获取距离限流重置还有多少秒
     #[allow(dead_code)]
     pub fn get_rate_limit_reset_seconds(&self, account_id: &str) -> Option<u64> {
         self.rate_limit_tracker.get_reset_seconds(account_id)
     }
-    
+
     /// 清除过期的限流记录
     #[allow(dead_code)]
     pub fn clean_expired_rate_limits(&self) {
         self.rate_limit_tracker.cleanup_expired();
     }
-    
+
     /// 【替代方案】通过 email 查找对应的 account_id
     /// 用于将 handlers 传入的 email 转换为 tracker 使用的 account_id
     fn email_to_account_id(&self, email: &str) -> Option<String> {
@@ -1193,7 +1193,7 @@ impl TokenManager {
             .find(|entry| entry.value().email == email)
             .map(|entry| entry.value().account_id.clone())
     }
-    
+
     /// 清除指定账号的限流记录
     pub fn clear_rate_limit(&self, account_id: &str) -> bool {
         self.rate_limit_tracker.clear(account_id)
@@ -1203,27 +1203,27 @@ impl TokenManager {
     pub fn clear_all_rate_limits(&self) {
         self.rate_limit_tracker.clear_all();
     }
-    
+
     /// 标记账号请求成功，重置连续失败计数
-    /// 
+    ///
     /// 在请求成功完成后调用，将该账号的失败计数归零，
     /// 下次失败时从最短的锁定时间开始（智能限流）。
     pub fn mark_account_success(&self, account_id: &str) {
         self.rate_limit_tracker.mark_success(account_id);
     }
-    
+
     /// 检查是否有可用的 Google 账号
-    /// 
+    ///
     /// 用于"仅兜底"模式的智能判断:当所有 Google 账号不可用时才使用外部提供商。
-    /// 
+    ///
     /// # 参数
     /// - `quota_group`: 配额组("claude" 或 "gemini"),暂未使用但保留用于未来扩展
     /// - `target_model`: 目标模型名称(已归一化),用于配额保护检查
-    /// 
+    ///
     /// # 返回值
     /// - `true`: 至少有一个可用账号(未限流且未被配额保护)
     /// - `false`: 所有账号都不可用(被限流或被配额保护)
-    /// 
+    ///
     /// # 示例
     /// ```ignore
     /// // 检查是否有可用账号处理 claude-sonnet 请求
@@ -1237,11 +1237,11 @@ impl TokenManager {
         let quota_protection_enabled = crate::modules::config::load_app_config()
             .map(|cfg| cfg.quota_protection.enabled)
             .unwrap_or(false);
-        
+
         // 遍历所有账号,检查是否有可用的
         for entry in self.tokens.iter() {
             let token = entry.value();
-            
+
             // 1. 检查是否被限流
             if self.is_rate_limited(&token.account_id, None).await {
                 tracing::debug!(
@@ -1250,7 +1250,7 @@ impl TokenManager {
                 );
                 continue;
             }
-            
+
             // 2. 检查是否被配额保护(如果启用)
             if quota_protection_enabled && token.protected_models.contains(target_model) {
                 tracing::debug!(
@@ -1260,7 +1260,7 @@ impl TokenManager {
                 );
                 continue;
             }
-            
+
             // 找到至少一个可用账号
             tracing::debug!(
                 "[Fallback Check] Found available account: {} for model {}",
@@ -1269,7 +1269,7 @@ impl TokenManager {
             );
             return true;
         }
-        
+
         // 所有账号都不可用
         tracing::info!(
             "[Fallback Check] No available Google accounts for model {}, fallback should be triggered",
@@ -1277,73 +1277,59 @@ impl TokenManager {
         );
         false
     }
-    
+
     /// 从账号文件获取配额刷新时间
-    /// 
+    ///
     /// 返回该账号最近的配额刷新时间字符串（ISO 8601 格式）
-    pub fn get_quota_reset_time(&self, email: &str) -> Option<String> {
-        // 尝试从账号文件读取配额信息
-        let accounts_dir = self.data_dir.join("accounts");
-        
-        // 遍历账号文件查找对应的 email
-        if let Ok(entries) = std::fs::read_dir(&accounts_dir) {
-            for entry in entries.flatten() {
-                if let Ok(content) = std::fs::read_to_string(entry.path()) {
-                    if let Ok(account) = serde_json::from_str::<serde_json::Value>(&content) {
-                        // 检查 email 是否匹配
-                        if account.get("email").and_then(|e| e.as_str()) == Some(email) {
-                            // 获取 quota.models 中最早的 reset_time
-                            if let Some(models) = account
-                                .get("quota")
-                                .and_then(|q| q.get("models"))
-                                .and_then(|m| m.as_array()) 
-                            {
-                                // 找到最早的 reset_time（最保守的锁定策略）
-                                let mut earliest_reset: Option<&str> = None;
-                                for model in models {
-                                    if let Some(reset_time) = model.get("reset_time").and_then(|r| r.as_str()) {
-                                        if !reset_time.is_empty() {
-                                            if earliest_reset.is_none() || reset_time < earliest_reset.unwrap() {
-                                                earliest_reset = Some(reset_time);
-                                            }
-                                        }
-                                    }
-                                }
-                                if let Some(reset) = earliest_reset {
-                                    return Some(reset.to_string());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        None
-    }
-    
-    /// 使用配额刷新时间精确锁定账号
-    /// 
-    /// 当 API 返回 429 但没有 quotaResetDelay 时,尝试使用账号的配额刷新时间
-    /// 
+    ///
     /// # 参数
+    /// - `account_id`: 账号 ID（用于查找账号文件）
+    pub fn get_quota_reset_time(&self, account_id: &str) -> Option<String> {
+        // 直接用 account_id 查找账号文件（文件名是 {account_id}.json）
+        let account_path = self.data_dir.join("accounts").join(format!("{}.json", account_id));
+
+        let content = std::fs::read_to_string(&account_path).ok()?;
+        let account: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+        // 获取 quota.models 中最早的 reset_time（最保守的锁定策略）
+        account
+            .get("quota")
+            .and_then(|q| q.get("models"))
+            .and_then(|m| m.as_array())
+            .and_then(|models| {
+                models.iter()
+                    .filter_map(|m| m.get("reset_time").and_then(|r| r.as_str()))
+                    .filter(|s| !s.is_empty())
+                    .min()
+                    .map(|s| s.to_string())
+            })
+    }
+
+    /// 使用配额刷新时间精确锁定账号
+    ///
+    /// 当 API 返回 429 但没有 quotaResetDelay 时,尝试使用账号的配额刷新时间
+    ///
+    /// # 参数
+    /// - `account_id`: 账号 ID
+    /// - `reason`: 限流原因（QuotaExhausted/ServerError 等）
     /// - `model`: 可选的模型名称,用于模型级别限流
-    pub fn set_precise_lockout(&self, email: &str, reason: crate::proxy::rate_limit::RateLimitReason, model: Option<String>) -> bool {
-        if let Some(reset_time_str) = self.get_quota_reset_time(email) {
-            tracing::info!("找到账号 {} 的配额刷新时间: {}", email, reset_time_str);
-            self.rate_limit_tracker.set_lockout_until_iso(email, &reset_time_str, reason, model)
+    pub fn set_precise_lockout(&self, account_id: &str, reason: crate::proxy::rate_limit::RateLimitReason, model: Option<String>) -> bool {
+        if let Some(reset_time_str) = self.get_quota_reset_time(account_id) {
+            tracing::info!("找到账号 {} 的配额刷新时间: {}", account_id, reset_time_str);
+            self.rate_limit_tracker.set_lockout_until_iso(account_id, &reset_time_str, reason, model)
         } else {
-            tracing::debug!("未找到账号 {} 的配额刷新时间,将使用默认退避策略", email);
+            tracing::debug!("未找到账号 {} 的配额刷新时间,将使用默认退避策略", account_id);
             false
         }
     }
-    
+
     /// 实时刷新配额并精确锁定账号
-    /// 
+    ///
     /// 当 429 发生时调用此方法:
     /// 1. 实时调用配额刷新 API 获取最新的 reset_time
     /// 2. 使用最新的 reset_time 精确锁定账号
     /// 3. 如果获取失败,返回 false 让调用方使用回退策略
-    /// 
+    ///
     /// # 参数
     /// - `model`: 可选的模型名称,用于模型级别限流
     pub async fn fetch_and_lock_with_realtime_quota(
@@ -1352,26 +1338,30 @@ impl TokenManager {
         reason: crate::proxy::rate_limit::RateLimitReason,
         model: Option<String>,
     ) -> bool {
-        // 1. 从 tokens 中获取该账号的 access_token
-        let access_token = {
-            let mut found_token: Option<String> = None;
+        // 1. 从 tokens 中获取该账号的 access_token 和 account_id
+        // 同时获取 account_id，确保锁定 key 与检查 key 一致
+        let (access_token, account_id) = {
+            let mut found: Option<(String, String)> = None;
             for entry in self.tokens.iter() {
                 if entry.value().email == email {
-                    found_token = Some(entry.value().access_token.clone());
+                    found = Some((
+                        entry.value().access_token.clone(),
+                        entry.value().account_id.clone(),
+                    ));
                     break;
                 }
             }
-            found_token
-        };
-        
-        let access_token = match access_token {
-            Some(t) => t,
-            None => {
+            found
+        }.unzip();
+
+        let (access_token, account_id) = match (access_token, account_id) {
+            (Some(token), Some(id)) => (token, id),
+            _ => {
                 tracing::warn!("无法找到账号 {} 的 access_token,无法实时刷新配额", email);
                 return false;
             }
         };
-        
+
         // 2. 调用配额刷新 API
         tracing::info!("账号 {} 正在实时刷新配额...", email);
         match crate::modules::quota::fetch_quota(&access_token, email).await {
@@ -1386,13 +1376,14 @@ impl TokenManager {
                         }
                     })
                     .min();
-                
+
                 if let Some(reset_time_str) = earliest_reset {
                     tracing::info!(
                         "账号 {} 实时配额刷新成功,reset_time: {}",
                         email, reset_time_str
                     );
-                    self.rate_limit_tracker.set_lockout_until_iso(email, reset_time_str, reason, model)
+                    // [FIX] 使用 account_id 作为 key，与 is_rate_limited 检查一致
+                    self.rate_limit_tracker.set_lockout_until_iso(&account_id, reset_time_str, reason, model)
                 } else {
                     tracing::warn!("账号 {} 配额刷新成功但未找到 reset_time", email);
                     false
@@ -1404,17 +1395,21 @@ impl TokenManager {
             }
         }
     }
-    
+
     /// 标记账号限流(异步版本,支持实时配额刷新)
-    /// 
+    ///
     /// 三级降级策略:
     /// 1. 优先: API 返回 quotaResetDelay → 直接使用
     /// 2. 次优: 实时刷新配额 → 获取最新 reset_time
     /// 3. 保底: 使用本地缓存配额 → 读取账号文件
     /// 4. 兜底: 指数退避策略 → 默认锁定时间
-    /// 
+    ///
     /// # 参数
-    /// - `model`: 可选的模型名称,用于模型级别限流。传入实际使用的模型可以避免不同模型配额互相影响
+    /// - `email`: 账号邮箱,用于查找账号信息
+    /// - `status`: HTTP 状态码（如 429、500 等）
+    /// - `retry_after_header`: 可选的 Retry-After 响应头
+    /// - `error_body`: 错误响应体,用于解析 quotaResetDelay
+    /// - `model`: 可选的模型名称,用于模型级别限流
     pub async fn mark_rate_limited_async(
         &self,
         email: &str,
@@ -1431,11 +1426,11 @@ impl TokenManager {
 
         // [FIX] Convert email to account_id for consistent tracking
         let account_id = self.email_to_account_id(email).unwrap_or_else(|| email.to_string());
-        
+
         // 检查 API 是否返回了精确的重试时间
-        let has_explicit_retry_time = retry_after_header.is_some() || 
+        let has_explicit_retry_time = retry_after_header.is_some() ||
             error_body.contains("quotaResetDelay");
-        
+
         if has_explicit_retry_time {
             // API 返回了精确时间(quotaResetDelay),直接使用,无需实时刷新
             if let Some(m) = model {
@@ -1453,7 +1448,7 @@ impl TokenManager {
             );
             return;
         }
-        
+
         // 确定限流原因
         let reason = if error_body.to_lowercase().contains("model_capacity") {
             crate::proxy::rate_limit::RateLimitReason::ModelCapacityExhausted
@@ -1462,25 +1457,26 @@ impl TokenManager {
         } else {
             crate::proxy::rate_limit::RateLimitReason::Unknown
         };
-        
+
         // API 未返回 quotaResetDelay,需要实时刷新配额获取精确锁定时间
         if let Some(m) = model {
             tracing::info!("账号 {} 的模型 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...", account_id, m);
         } else {
             tracing::info!("账号 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...", account_id);
         }
-        
-        if self.fetch_and_lock_with_realtime_quota(&account_id, reason, model.map(|s| s.to_string())).await {
-            tracing::info!("账号 {} 已使用实时配额精确锁定", account_id);
+
+        // [FIX] 传入 email 而不是 account_id，因为 fetch_and_lock_with_realtime_quota 期望 email
+        if self.fetch_and_lock_with_realtime_quota(email, reason, model.map(|s| s.to_string())).await {
+            tracing::info!("账号 {} 已使用实时配额精确锁定", email);
             return;
         }
-        
+
         // 实时刷新失败,尝试使用本地缓存的配额刷新时间
         if self.set_precise_lockout(&account_id, reason, model.map(|s| s.to_string())) {
             tracing::info!("账号 {} 已使用本地缓存配额锁定", account_id);
             return;
         }
-        
+
         // 都失败了,回退到指数退避策略
         tracing::warn!("账号 {} 无法获取配额刷新时间,使用指数退避策略", account_id);
         self.rate_limit_tracker.parse_from_error(
@@ -1565,7 +1561,7 @@ impl TokenManager {
         // 先获取 Access Token
         let token = crate::modules::oauth::refresh_access_token(refresh_token).await
             .map_err(|e| format!("刷新 Access Token 失败: {}", e))?;
-            
+
         crate::modules::oauth::get_user_info(&token.access_token).await
     }
 
@@ -1584,7 +1580,7 @@ impl TokenManager {
         // 3. 委托给 modules::account::add_account 处理 (包含文件写入、索引更新、锁)
         let email_clone = email.to_string();
         let refresh_token_clone = refresh_token.to_string();
-        
+
         tokio::task::spawn_blocking(move || {
             let token_data = crate::models::TokenData::new(
                 token_info.access_token,
@@ -1594,7 +1590,7 @@ impl TokenManager {
                 Some(project_id),
                 None, // session_id
             );
-            
+
             crate::modules::account::upsert_account(email_clone, None, token_data)
         }).await
         .map_err(|e| format!("Task join error: {}", e))?
@@ -1603,7 +1599,7 @@ impl TokenManager {
         // 4. 重新加载 (更新内存)
         self.reload_all_accounts().await.map(|_| ())
     }
-    
+
 /// 记录请求成功，增加健康分
     pub fn record_success(&self, account_id: &str) {
         self.health_scores.entry(account_id.to_string())


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                  
- Prevent 5xx errors from polluting 429 backoff ladder, fixing 7200s lockouts after 5xx storms                                                                                                                   
- Unify rate limit tracking to use `account_id` consistently, fixing key mismatch bugs                                                                                                                           
- Restore `X-Account-Email` header in all responses (200/429/503/etc)                                                                                                                                            
- Optimize quota file lookup from O(n) directory scan to O(1) direct access                                                                                                                                      
- Add unit tests for failure_count isolation behavior                                                                                                                                                            
                                                                                                                                                                                                                  
## Problem                                                                                                                                                                                                       
                                                                                                                                                                                                                  
The rate limiting system has two issues causing 503 account pool lockup and missing account tracking:                                                                                                            
                                                                                                                                                                                                                  
**Root Cause: failure_count pollution**                                                                                                                                                                          
                                                                                                                                                                                                                  
`failure_count` is shared across all error types. When upstream returns multiple 5xx errors:                                                                                                                     
- Each 5xx increments `failure_count` (1→2→3→...→9)                                                                                                                                                              
- Subsequent 429 QuotaExhausted inherits this inflated count                                                                                                                                                     
- Lockout jumps directly to 7200s instead of starting at 60s                                                                                                                                                     
- All accounts get locked → proxy returns 503                                                                                                                                                                    
                                                                                                                                                                                                                  
**Contributing Factor: email/account_id key mismatch**                                                                                                                                                           
                                                                                                                                                                                                                  
Rate limit operations use inconsistent keys:                                                                                                                                                                     
- `fetch_and_lock_with_realtime_quota()` stored locks under `email`                                                                                                                                              
- `is_rate_limited()` checked locks under `account_id`                                                                                                                                                           
- Result: locks never matched, realtime quota precision was ineffective                                                                                                                                          
- Fell back to polluted exponential backoff                                                                                                                                                                      
- `X-Account-Email` header missing in ALL responses (not just 429)                                                                                                                                               
                                                                                                                                                                                                                  
**Evidence from logs:**                                                                                                                                                                                          
23:06:03 账号 52c637f8... 第9次连续失败，根据配置锁定 7200 秒                                                                                                                                                    
... (大量 503，只有 Router match，没有 Using account)                                                                                                                                                            
200    POST    claude-opus-4-5-thinking    Claude    -    ← 邮箱显示为 "-"                                                                                                                                       
23:08:58 🔄 Optimistic reset: Cleared all 9 rate limit record(s)  ← 手动刷新才恢复                                                                                                                               
                                                                                                                                                                                                                  
## Solution                                                                                                                                                                                                      
                                                                                                                                                                                                                  
**failure_count isolation**: When `reason == ServerError`, use fixed `failure_count = 1` instead of accumulating. This prevents 5xx storms from polluting the 429 backoff ladder while still applying 8s soft avoidance.                                                                                                                                                                                                       
                                                                                                                                                                                                                  
**Unified account_id key**: All rate limit functions now consistently use `account_id` as the lock key, ensuring locks are stored and checked with the same key.                                                 
                                                                                                                                                                                                                  
## Changes                                                                                                                                                                                                       
                                                                                                                                                                                                                  
- **rate_limit.rs**: Add conditional branch in `parse_from_error()` - ServerError uses fixed `failure_count = 1`, other reasons continue to accumulate normally                                                  
- **rate_limit.rs**: Add 2 unit tests verifying isolation behavior                                                                                                                                               
- **token_manager.rs `fetch_and_lock_with_realtime_quota()`**: Extract `account_id` alongside `access_token`, use `account_id` as lock key in `set_lockout_until_iso()`                                          
- **token_manager.rs `get_quota_reset_time()`**: Change parameter from `email` to `account_id`, use direct file path `{account_id}.json` instead of directory scan                                               
- **token_manager.rs `set_precise_lockout()`**: Rename parameter from `email` to `account_id` for consistency                                                                                                    
- **token_manager.rs**: Replace `unwrap()` with pattern matching, use iterator chains for cleaner code                                                                                                           
                                                                                                                                                                                                                  
## Test Plan                                                                                                                                                                                                     
                                                                                                                                                                                                                  
- [x] `cargo build` passes                                                                                                                                                                                       
- [x] `cargo test rate_limit::tests` - 8 tests pass                                                                                                                                                              
- [x] `test_server_error_does_not_accumulate_failure_count` - 5x 5xx then 429 → lockout starts at 60s                                                                                                            
- [x] `test_quota_exhausted_does_accumulate_failure_count` - 4x 429 → escalates 60→300→1800→7200                                                                                                                 
- [ ] Manual: Trigger 5xx errors, verify logs show "第1次连续失败" each time (not accumulating)                                                                                                                  
- [ ] Manual: Trigger 429 after 5xx storm, verify lockout starts at 60s (not 1800s/7200s)                                                                                                                        
- [x] Manual: Check any response, verify `X-Account-Email` header shows email (not `-`)                                                                                                                          
- [ ] Manual: Verify no regression in normal 200 response flow