### PR TITLE
fix!: replace current_index round-robin with P2C algorithm

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "antigravity_tools"
-version = "4.0.11"
+version = "4.0.12"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -96,6 +96,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml 0.8.23",
  "toml_edit 0.22.27",
  "tower 0.4.13",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,6 +69,7 @@ toml = "0.8"
 toml_edit = "0.22"
 tauri-plugin-window-state = "2"
 parking_lot = "0.12.5"
+tokio-util = "0.7.18"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,10 +19,10 @@ fn increase_nofile_limit() {
             rlim_cur: 0,
             rlim_max: 0,
         };
-        
+
         if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rl) == 0 {
             info!("Current open file limit: soft={}, hard={}", rl.rlim_cur, rl.rlim_max);
-            
+
             // Attempt to increase to 4096 or maximum hard limit
             let target = 4096.min(rl.rlim_max);
             if rl.rlim_cur < target {
@@ -66,10 +66,10 @@ pub fn run() {
         error!("Failed to initialize security database: {}", e);
     }
 
-    
+
     if is_headless {
         info!("Starting in HEADLESS mode...");
-        
+
         let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
         rt.block_on(async {
             // Initialize states manually
@@ -100,7 +100,7 @@ pub fn run() {
                     let env_web_password = std::env::var("ABV_WEB_PASSWORD")
                         .or_else(|_| std::env::var("WEB_PASSWORD"))
                         .ok();
-                    
+
                     if let Some(pwd) = env_web_password {
                         if !pwd.trim().is_empty() {
                             info!("Using Web UI Password from environment variable");
@@ -113,7 +113,7 @@ pub fn run() {
                     let env_auth_mode = std::env::var("ABV_AUTH_MODE")
                         .or_else(|_| std::env::var("AUTH_MODE"))
                         .ok();
-                    
+
                     if let Some(mode_str) = env_auth_mode {
                         let mode = match mode_str.to_lowercase().as_str() {
                             "off" => Some(crate::proxy::ProxyAuthMode::Off),
@@ -143,7 +143,7 @@ pub fn run() {
                     info!("💡 Tips: You can use these keys to login to Web UI and access AI APIs.");
                     info!("💡 Search docker logs or grep gui_config.json to find them.");
                     info!("--------------------------------------------------");
-                    
+
                     // Start proxy service
                     if let Err(e) = commands::proxy::internal_start_proxy_service(
                         config.proxy,
@@ -154,9 +154,9 @@ pub fn run() {
                         error!("Failed to start proxy service in headless mode: {}", e);
                         std::process::exit(1);
                     }
-                    
+
                     info!("Headless proxy service is running.");
-                    
+
                     // Start smart scheduler
                     modules::scheduler::start_scheduler(None, proxy_state.clone());
                     info!("Smart scheduler started in headless mode.");
@@ -166,7 +166,7 @@ pub fn run() {
                     std::process::exit(1);
                 }
             }
-            
+
             // Wait for Ctrl-C
             tokio::signal::ctrl_c().await.ok();
             info!("Headless mode shutting down");
@@ -226,7 +226,7 @@ pub fn run() {
 
             modules::tray::create_tray(app.handle())?;
             info!("Tray created");
-            
+
             // 立即启动管理服务器 (8045)，以便 Web 端能访问
             let handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
@@ -235,7 +235,7 @@ pub fn run() {
                     let state = handle.state::<commands::proxy::ProxyServiceState>();
                     let cf_state = handle.state::<commands::cloudflared::CloudflaredState>();
                     let integration = crate::modules::integration::SystemManager::Desktop(handle.clone());
-                    
+
                     // 1. 确保管理后台开启
                     if let Err(e) = commands::proxy::ensure_admin_server(
                         config.proxy.clone(),
@@ -263,14 +263,14 @@ pub fn run() {
                     }
                 }
             });
-            
+
             // Start smart scheduler
             let scheduler_state = app.handle().state::<commands::proxy::ProxyServiceState>();
             modules::scheduler::start_scheduler(Some(app.handle().clone()), scheduler_state.inner().clone());
-            
+
             // [PHASE 1] 已整合至 Axum 端口 (8045)，不再单独启动 19527 端口
             info!("Management API integrated into main proxy server (port 8045)");
-            
+
             Ok(())
         })
         .on_window_event(|window, event| {
@@ -315,7 +315,6 @@ pub fn run() {
             // Additional commands
             commands::prepare_oauth_url,
             commands::start_oauth_login,
-            commands::complete_oauth_login,
             commands::complete_oauth_login,
             commands::cancel_oauth_login,
             commands::submit_oauth_code,
@@ -423,18 +422,43 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app_handle, event| {
-            // Handle macOS dock icon click to reopen window
-            #[cfg(target_os = "macos")]
-            if let tauri::RunEvent::Reopen { .. } = event {
-                if let Some(window) = app_handle.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.unminimize();
-                    let _ = window.set_focus();
-                    app_handle.set_activation_policy(tauri::ActivationPolicy::Regular).unwrap_or(());
+            match event {
+                // Handle app exit - cleanup background tasks
+                tauri::RunEvent::Exit => {
+                    tracing::info!("Application exiting, cleaning up background tasks...");
+                    if let Some(state) = app_handle.try_state::<crate::commands::proxy::ProxyServiceState>() {
+                        tauri::async_runtime::block_on(async {
+                            // Use timeout-based read() instead of try_read() to handle lock contention
+                            match tokio::time::timeout(
+                                std::time::Duration::from_secs(3),
+                                state.instance.read()
+                            ).await {
+                                Ok(guard) => {
+                                    if let Some(instance) = guard.as_ref() {
+                                        // Use graceful_shutdown with 2s timeout for task cleanup
+                                        instance.token_manager
+                                            .graceful_shutdown(std::time::Duration::from_secs(2))
+                                            .await;
+                                    }
+                                }
+                                Err(_) => {
+                                    tracing::warn!("Lock acquisition timed out after 3s, forcing exit");
+                                }
+                            }
+                        });
+                    }
                 }
+                // Handle macOS dock icon click to reopen window
+                #[cfg(target_os = "macos")]
+                tauri::RunEvent::Reopen { .. } => {
+                    if let Some(window) = app_handle.get_webview_window("main") {
+                        let _ = window.show();
+                        let _ = window.unminimize();
+                        let _ = window.set_focus();
+                        app_handle.set_activation_policy(tauri::ActivationPolicy::Regular).unwrap_or(());
+                    }
+                }
+                _ => {}
             }
-            // Suppress unused variable warnings on non-macOS platforms
-            #[cfg(not(target_os = "macos"))]
-            let _ = (app_handle, event);
         });
 }


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                     
                                                                                                                                                                                                            
- Replace broken current_index round-robin with P2C (Power of 2 Choices) algorithm                                                                                                                          
- Fix quota sorting to use target model instead of max(all models)                                                                                                                                          
- Change priority from tier-first to quota-first                                                                                                                                                            
- Add graceful shutdown for background tasks                                                                                                                                                                
                                                                                                                                                                                                            
**Problem**                                                                                                                                                                                                     
                                                                                                                                                                                                            
The account rotation algorithm sorts tokens by priority but selects starting from current_index, bypassing the sorted order entirely.                                                                       
                                                                                                                                                                                                            
**Additional issues**:                                                                                                                                                                                          
- Tier-first sorting exhausts PRO/ULTRA first, losing 5h reset advantage                                                                                                                                    
- Quota uses max(all models) instead of target model:                                                                                                                                                       
                                                                                                                                                                                                            
 | Account | max(all) | sonnet | Sorting value |                                                                                                                                                             
  |---------|----------|--------|---------------|                                                                                                                                                             
  | acc1 | 100 | 40 | 100 ❌ |                                                                                                                                                                     
  | acc2 | 100 | 100 | 100 ✓ |  
                                                                                                                                              
- Round-robin causes concurrent request hotspots                                                                                                                                                            
- Background cleanup task leaks on app exit                                                                                                                                                                 
                                                                                                                                                                                                            
**Solution**                                                                                                                                                                                                    
                                                                                                                                                                                                            
- P2C: Pick 2 from top 5 sorted candidates, select higher quota                                                                                                                                             
- Quota-first sorting: quota > health > tier > reset_time                                                                                                                                                   
- Target model quota: get_model_quota_from_json() reads from disk                                                                                                                                           
- Graceful shutdown: CancellationToken for background tasks                                                                                                                                                 
                                                                                                                                                                                                            
**Changes**                                                                                                                                                                                                     
                                                                                                                                                                                                            
- token_manager.rs: Remove current_index, add select_with_p2c(), get_model_quota_from_json()                                                                                                                
- token_manager.rs: Add graceful_shutdown(), abort_background_tasks()                                                                                                                                       
- lib.rs: Handle RunEvent::Exit with cleanup                                                                                                                                                                
- proxy.rs: Call abort_background_tasks() on stop                                                                                                                                                           
- Cargo.toml: Add tokio-util                                                                                                                                                                                
- quota_protection.rs: Add 3 unit tests                                                                                                                                                                     
                                                                                                                                                                                                            
**Impact**                                                                                                                                                                                                      
                                                                                                                                                                                                            
**BREAKING CHANGE**:                                                                                                                                                                                         
- Account selection changed from round-robin to P2C                                                                                                                                                         
- Sorting priority changed from tier-first to quota-first                                                                                                                                                   
- May affect which accounts are selected under load                   

**Performance Mode Tip**: When using "Performance Priority" scheduling mode, consider setting "Background Auto-Refresh Interval" to 1-5 minutes. More frequent quota refreshes provide P2C algorithm with more accurate account status for better account selection.                                                                                                                                           
                                                                                                                                                                                                              
**Risk Warning**: Shorter refresh intervals increase API calls to upstream services, which may trigger rate limiting or account flagging.                                                                                                                                              

                                                                                                                                                                                                            
**Test Plan**                                                                                                                                                                                                   
                                                                                                                                                                                                            
- [x] `cargo build` passes                                                                                                                                                                                        
- [x] `cargo test` - all tests pass                                                                                                                                        
- [x] Manual: Verify high-quota accounts selected first                                                                                                                                                         