### PR TITLE
fix: improve warmup functionality and fix false-positive issues

### DIFF
--- a/src-tauri/src/modules/quota.rs
+++ b/src-tauri/src/modules/quota.rs
@@ -353,15 +353,11 @@ pub async fn warm_up_all_accounts() -> Result<String, String> {
                     for m in fresh_quota.models {
                         if m.percentage >= 100 {
                             let model_to_ping = m.name.clone();
-                            
-                            match model_to_ping.as_str() {
-                                "gemini-3-flash" | "claude-sonnet-4-5" | "gemini-3-pro-high" | "gemini-3-pro-image" => {
-                                    if !account_warmed_series.contains(&model_to_ping) {
-                                        warmup_items.push((email.clone(), model_to_ping.clone(), token.clone(), pid.clone(), m.percentage));
-                                        account_warmed_series.insert(model_to_ping);
-                                    }
-                                }
-                                _ => continue,
+
+                            // Removed hardcoded whitelist - now warms up any model at 100%
+                            if !account_warmed_series.contains(&model_to_ping) {
+                                warmup_items.push((email.clone(), model_to_ping.clone(), token.clone(), pid.clone(), m.percentage));
+                                account_warmed_series.insert(model_to_ping);
                             }
                         } else if m.percentage >= NEAR_READY_THRESHOLD {
                             has_near_ready_models = true;
@@ -383,7 +379,7 @@ pub async fn warm_up_all_accounts() -> Result<String, String> {
             if warmup_items.is_empty() {
                 let skipped = total_before;
                 crate::modules::logger::log_info(&format!("[Warmup] Returning to frontend: All models in cooldown, skipped {}", skipped));
-                return Ok(format!("All models are in 4-hour cooldown, skipped {} items", skipped));
+                return Ok(format!("All models are in cooldown, skipped {} items", skipped));
             }
             
             let total = warmup_items.len();
@@ -473,16 +469,11 @@ pub async fn warm_up_account(account_id: &str) -> Result<String, String> {
     for m in fresh_quota.models {
         if m.percentage >= 100 {
             let model_name = m.name.clone();
-            
-            // 2. Strict whitelist filtering
-            match model_name.as_str() {
-                "gemini-3-flash" | "claude-sonnet-4-5" | "gemini-3-pro-high" | "gemini-3-pro-image" => {
-                    if !warmed_series.contains(&model_name) {
-                        models_to_warm.push((model_name.clone(), m.percentage));
-                        warmed_series.insert(model_name);
-                    }
-                }
-                _ => continue,
+
+            // Removed hardcoded whitelist - now warms up any model at 100%
+            if !warmed_series.contains(&model_name) {
+                models_to_warm.push((model_name.clone(), m.percentage));
+                warmed_series.insert(model_name);
             }
         }
     }

--- a/src-tauri/src/modules/scheduler.rs
+++ b/src-tauri/src/modules/scheduler.rs
@@ -263,7 +263,6 @@ pub fn start_scheduler(app_handle: Option<tauri::AppHandle>, proxy_state: crate:
 }
 
 /// Trigger immediate smart warmup check for a single account
-#[allow(dead_code)]
 pub async fn trigger_warmup_for_account(account: &Account) {
     // Get valid token
     let Ok((token, pid)) = quota::get_valid_token_for_warmup(account).await else {
@@ -275,17 +274,29 @@ pub async fn trigger_warmup_for_account(account: &Account) {
         return;
     };
 
+    // Load config once at the beginning
+    let Ok(app_config) = config::load_app_config() else {
+        logger::log_warn("[Scheduler] Failed to load app config, skipping warmup check");
+        return;
+    };
+
     let now_ts = Utc::now().timestamp();
     let mut tasks_to_run = Vec::new();
 
     for model in fresh_quota.models {
-        let history_key = format!("{}:{}:100", account.email, model.name);
-        
+        let model_name = model.name.clone();
+        let history_key = format!("{}:{}:100", account.email, model_name);
+
         if model.percentage == 100 {
-            // Check history to avoid repeated warmup (with cooldown)
+            // First check if model is in user's monitored list
+            if !app_config.scheduled_warmup.monitored_models.contains(&model_name) {
+                continue;
+            }
+
+            // Then check cooldown history
             {
-                let mut history = WARMUP_HISTORY.lock().unwrap();
-                
+                let history = WARMUP_HISTORY.lock().unwrap();
+
                 // 4 hour cooldown (Pro account resets every 5h, 1h margin)
                 if let Some(&last_warmup_ts) = history.get(&history_key) {
                     let cooldown_seconds = 14400;
@@ -294,36 +305,38 @@ pub async fn trigger_warmup_for_account(account: &Account) {
                         continue;
                     }
                 }
-                
-                history.insert(history_key, now_ts);
-                save_warmup_history(&history);
             }
+            // Note: Don't write history here - only write after successful warmup
 
-            let model_to_ping = model.name.clone();
-
-            // Only warmup models selected by user
-            let Ok(app_config) = config::load_app_config() else {
-                continue;
-            };
-
-            if app_config.scheduled_warmup.monitored_models.contains(&model_to_ping) {
-                tasks_to_run.push((model_to_ping, model.percentage));
-            }
+            tasks_to_run.push((model_name, model.percentage, history_key));
         } else if model.percentage < 100 {
             // Quota not full, clear history, allow warmup next time it's 100%
             let mut history = WARMUP_HISTORY.lock().unwrap();
-            history.remove(&history_key);
+            if history.remove(&history_key).is_some() {
+                save_warmup_history(&history);
+            }
         }
     }
 
-    // Execute warmup
+    // Execute warmup and record history only on success
     if !tasks_to_run.is_empty() {
-        for (model, pct) in tasks_to_run {
+        logger::log_info(&format!(
+            "[Scheduler] Found {} models ready for warmup on {}",
+            tasks_to_run.len(), account.email
+        ));
+
+        for (model, pct, history_key) in tasks_to_run {
             logger::log_info(&format!(
                 "[Scheduler] 🔥 Triggering individual warmup: {} @ {} (Sync)",
                 model, account.email
             ));
-            quota::warmup_model_directly(&token, &model, &pid, &account.email, pct).await;
+
+            let success = quota::warmup_model_directly(&token, &model, &pid, &account.email, pct).await;
+
+            // Only record history if warmup was successful
+            if success {
+                record_warmup_history(&history_key, now_ts);
+            }
         }
     }
 }

--- a/src-tauri/src/proxy/handlers/warmup.rs
+++ b/src-tauri/src/proxy/handlers/warmup.rs
@@ -15,6 +15,7 @@ use serde_json::{json, Value};
 use tracing::{info, warn};
 
 use crate::proxy::mappers::gemini::wrapper::wrap_request;
+use crate::proxy::monitor::ProxyRequestLog;
 use crate::proxy::server::AppState;
 
 /// 预热请求体
@@ -44,6 +45,26 @@ pub async fn handle_warmup(
     State(state): State<AppState>,
     Json(req): Json<WarmupRequest>,
 ) -> Response {
+    let start_time = std::time::Instant::now();
+
+    // ===== 前置检查：跳过 gemini-2.5-* 家族模型 =====
+    let model_lower = req.model.to_lowercase();
+    if model_lower.contains("2.5-") || model_lower.contains("2-5-") {
+        info!(
+            "[Warmup-API] SKIP: gemini-2.5-* model not supported for warmup: {} / {}",
+            req.email, req.model
+        );
+        return (
+            StatusCode::OK,
+            Json(WarmupResponse {
+                success: true,
+                message: format!("Skipped warmup for {} (2.5 models not supported)", req.model),
+                error: None,
+            }),
+        )
+            .into_response();
+    }
+
     info!(
         "[Warmup-API] ========== START: email={}, model={} ==========",
         req.email, req.model
@@ -79,7 +100,7 @@ pub async fn handle_warmup(
 
     let body: Value = if is_claude {
         // Claude 模型：使用 transform_claude_request_in 转换
-        let session_id = format!("warmup_{}_{}", 
+        let session_id = format!("warmup_{}_{}",
             chrono::Utc::now().timestamp_millis(),
             &uuid::Uuid::new_v4().to_string()[..8]
         );
@@ -128,7 +149,7 @@ pub async fn handle_warmup(
         }
     } else {
         // Gemini 模型：使用 wrap_request
-        let session_id = format!("warmup_{}_{}", 
+        let session_id = format!("warmup_{}_{}",
             chrono::Utc::now().timestamp_millis(),
             &uuid::Uuid::new_v4().to_string()[..8]
         );
@@ -181,14 +202,39 @@ pub async fn handle_warmup(
             .await;
     }
 
-    // ===== 步骤 4: 处理响应 =====
+    let duration = start_time.elapsed().as_millis() as u64;
+
+    // ===== 步骤 4: 处理响应并记录流量日志 =====
     match result {
         Ok(response) => {
             let status = response.status();
+            let status_code = status.as_u16();
+
+            // 记录预热请求到流量日志
+            let log = ProxyRequestLog {
+                id: uuid::Uuid::new_v4().to_string(),
+                timestamp: chrono::Utc::now().timestamp_millis(),
+                method: "POST".to_string(),
+                url: format!("/internal/warmup -> {}", req.model),
+                status: status_code,
+                duration,
+                model: Some(req.model.clone()),
+                mapped_model: Some(req.model.clone()),
+                account_email: Some(req.email.clone()),
+                client_ip: Some("127.0.0.1".to_string()),
+                error: if status.is_success() { None } else { Some(format!("HTTP {}", status_code)) },
+                request_body: Some(format!("{{\"type\": \"warmup\", \"model\": \"{}\"}}", req.model)),
+                response_body: None,
+                input_tokens: Some(0),
+                output_tokens: Some(0),
+                protocol: Some("warmup".to_string()),
+            };
+            state.monitor.log_request(log).await;
+
             let mut response = if status.is_success() {
                 info!(
-                    "[Warmup-API] ========== SUCCESS: {} / {} ==========",
-                    req.email, req.model
+                    "[Warmup-API] ========== SUCCESS: {} / {} ({}ms) ==========",
+                    req.email, req.model, duration
                 );
                 (
                     StatusCode::OK,
@@ -200,7 +246,6 @@ pub async fn handle_warmup(
                 )
                     .into_response()
             } else {
-                let status_code = status.as_u16();
                 let error_text = response.text().await.unwrap_or_default();
                 (
                     StatusCode::from_u16(status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
@@ -220,15 +265,36 @@ pub async fn handle_warmup(
             if let Ok(model_val) = axum::http::HeaderValue::from_str(&req.model) {
                 response.headers_mut().insert("X-Mapped-Model", model_val);
             }
-            
+
             response
         }
         Err(e) => {
             warn!(
-                "[Warmup-API] ========== ERROR: {} / {} - {} ==========",
-                req.email, req.model, e
+                "[Warmup-API] ========== ERROR: {} / {} - {} ({}ms) ==========",
+                req.email, req.model, e, duration
             );
-            
+
+            // 记录失败的预热请求到流量日志
+            let log = ProxyRequestLog {
+                id: uuid::Uuid::new_v4().to_string(),
+                timestamp: chrono::Utc::now().timestamp_millis(),
+                method: "POST".to_string(),
+                url: format!("/internal/warmup -> {}", req.model),
+                status: 500,
+                duration,
+                model: Some(req.model.clone()),
+                mapped_model: Some(req.model.clone()),
+                account_email: Some(req.email.clone()),
+                client_ip: Some("127.0.0.1".to_string()),
+                error: Some(e.clone()),
+                request_body: Some(format!("{{\"type\": \"warmup\", \"model\": \"{}\"}}", req.model)),
+                response_body: None,
+                input_tokens: None,
+                output_tokens: None,
+                protocol: Some("warmup".to_string()),
+            };
+            state.monitor.log_request(log).await;
+
             let mut response = (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(WarmupResponse {
@@ -245,7 +311,7 @@ pub async fn handle_warmup(
             if let Ok(model_val) = axum::http::HeaderValue::from_str(&req.model) {
                 response.headers_mut().insert("X-Mapped-Model", model_val);
             }
-            
+
             response
         }
     }

--- a/src-tauri/src/proxy/middleware/monitor.rs
+++ b/src-tauri/src/proxy/middleware/monitor.rs
@@ -23,7 +23,7 @@ pub async fn monitor_middleware(
     let method = request.method().to_string();
     let uri = request.uri().to_string();
     
-    if uri.contains("event_logging") || uri.contains("/api/") {
+    if uri.contains("event_logging") || uri.contains("/api/") || uri.starts_with("/internal/") {
         return next.run(request).await;
     }
     


### PR DESCRIPTION
## Summary / 摘要

This PR fixes multiple issues with the warmup functionality, addressing false-positive warmup reports and improving the overall reliability of the warmup system.

本 PR 修复了预热功能的多个问题，解决了预热"假成功"的报告，并提升了预热系统的整体可靠性。

---

## Changes / 修改内容

### 1. Remove hardcoded model whitelist / 移除硬编码模型白名单
- **File**: `src-tauri/src/modules/quota.rs`
- Removed `match` statement that only allowed 4 specific models (`gemini-3-flash`, `claude-sonnet-4-5`, `gemini-3-pro-high`, `gemini-3-pro-image`)
- Now warms up any model at 100% quota based on account data
- 移除了仅允许 4 个特定模型的 `match` 语句，现在会根据账户数据预热所有配额为 100% 的模型

### 2. Trigger warmup immediately after quota refresh / 刷新配额后立即触发预热
- **File**: `src-tauri/src/modules/account.rs`
- Added `check_and_trigger_warmup_for_recovered_models()` function
- Called automatically after `refresh_all_quotas_logic()` completes
- No longer need to wait 10 minutes for scheduler polling
- 新增函数在配额刷新完成后自动检测并触发预热，无需等待 10 分钟调度器轮询

### 3. Fix warmup history recording logic / 修复预热历史记录逻辑
- **File**: `src-tauri/src/modules/scheduler.rs`
- Fixed critical bug: history was written BEFORE whitelist check, causing "false success"
- History now recorded only AFTER successful warmup execution
- Removed `#[allow(dead_code)]` from `trigger_warmup_for_account` as it's now used
- 修复关键 Bug：历史记录在白名单检查之前写入，导致"假成功"。现在仅在预热实际成功后写入历史

### 4. Add warmup requests to traffic logs / 预热请求显示在流量日志
- **Files**: `src-tauri/src/proxy/handlers/warmup.rs`, `src-tauri/src/proxy/middleware/monitor.rs`
- Warmup requests now appear in traffic logs with protocol type "warmup"
- Excluded `/internal/` paths from monitor middleware to avoid duplicate logging
- 预热请求现在会显示在流量日志中，协议类型为 "warmup"，便于筛选和排查

### 5. Skip gemini-2.5-* models from warmup / 跳过 gemini-2.5-* 模型预热
- **File**: `src-tauri/src/proxy/handlers/warmup.rs`
- Added early return for `gemini-2.5-*` family models
- These models return `400 INVALID_ARGUMENT` with current warmup protocol
- Returns success to avoid false error reports
- 这些模型使用当前预热协议会返回 400 错误，暂时跳过并返回成功以避免误报

### 6. Remove specific time from cooldown message / 移除冷却提示中的具体时间
- **File**: `src-tauri/src/modules/quota.rs`
- Changed "4-hour cooldown" to just "cooldown" in user-facing message
- Avoids outdated info if cooldown duration changes in the future
- 将提示信息中的 "4-hour cooldown" 改为 "cooldown"，避免冷却时间调整后信息过时

---

## Test Plan / 测试计划

- [x] Manual warmup triggers correctly for supported models
- [x] Warmup requests appear in traffic logs with "warmup" protocol
- [x] gemini-2.5-* models are skipped gracefully
- [x] Quota refresh triggers immediate warmup check
- [x] No duplicate entries in traffic logs
- [x] Backend compiles without errors (`cargo build`)