### PR TITLE
fix: resolve Docker warmup 401/502 errors

### DIFF
--- a/src-tauri/src/modules/quota.rs
+++ b/src-tauri/src/modules/quota.rs
@@ -287,7 +287,14 @@ pub async fn warmup_model_directly(
         "project_id": project_id
     });
 
-    let client = create_warmup_client();
+    // Use a no-proxy client for local loopback requests
+    // This prevents Docker environments from routing localhost through external proxies
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .no_proxy()
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+
     let resp = client
         .post(&warmup_url)
         .header("Content-Type", "application/json")


### PR DESCRIPTION
## 问题描述 / Problem Description

在 Docker 环境中运行时，warmup 功能出现以下错误：
When running in Docker environment, the warmup feature encountered the following errors:

### 错误日志 / Error Logs
```
auth: Request: POST /internal/warmup
[Warmup] ✗ gemini-3-pro-high: HTTP 401 Unauthorized
```

### 根因分析 / Root Cause Analysis

| 问题 / Issue | 根因 / Root Cause |
|------|------|
| 502 Bad Gateway | Docker 网络中 HTTP_PROXY 环境变量导致 localhost 请求被路由到外部代理 / HTTP_PROXY env var in Docker network caused localhost requests to be routed through external proxy |
| 401 Unauthorized | 配置了 `ABV_API_KEY` 后启用鉴权，但 warmup 请求无 Authorization 头 / Auth enabled when `ABV_API_KEY` is configured, but warmup requests lack Authorization header |

## 修复方案 / Solution

### 1. `src-tauri/src/modules/quota.rs`
使用 `no_proxy()` 客户端进行本地回环请求，避免被外部代理拦截：
Use `no_proxy()` client for local loopback requests to avoid external proxy interception:

```rust
let client = reqwest::Client::builder()
    .timeout(std::time::Duration::from_secs(60))
    .no_proxy()
    .build()
    .unwrap_or_else(|_| reqwest::Client::new());
```

### 2. `src-tauri/src/proxy/middleware/auth.rs`
豁免 `/internal/*` 端点的鉴权检查：
Exempt `/internal/*` endpoints from authentication checks:

```rust
let is_internal_endpoint = path.starts_with("/internal/");
// ...
if is_internal_endpoint {
    tracing::debug!("Internal endpoint bypassed auth: {}", path);
    return Ok(next.run(request).await);
}
```

## 测试验证 / Testing

```bash
docker build -t antigravity-manager:dev -f docker/Dockerfile .
docker run -it --rm -p 8045:8045 -e RUST_LOG=debug -e ABV_API_KEY=test antigravity-manager:dev
```

**测试效果 / Tested Result:**
<img width="1232" height="140" alt="图片" src="https://github.com/user-attachments/assets/ed3ca5f7-1f0e-41c1-9e07-f5de351feb17" />

✅ 已在 Docker 环境测试通过 / Tested and verified in Docker environment