### PR TITLE
feat: enhance update checker with proxy and multi-layer fallback

### DIFF
--- a/src/components/UpdateNotification.tsx
+++ b/src/components/UpdateNotification.tsx
@@ -12,6 +12,7 @@ interface UpdateInfo {
   latest_version: string;
   current_version: string;
   download_url: string;
+  source?: string;
 }
 
 type UpdateState = 'checking' | 'available' | 'downloading' | 'ready' | 'none';
@@ -153,9 +154,16 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({ onClose 
                     : t('update_notification.title')}
                 </h3>
                 {updateInfo && (
-                  <p className="text-xs font-medium text-blue-600 dark:text-blue-400">
-                    v{updateInfo.latest_version}
-                  </p>
+                  <div className="flex flex-col">
+                    <p className="text-xs font-medium text-blue-600 dark:text-blue-400">
+                      v{updateInfo.latest_version}
+                    </p>
+                    {updateInfo.source && updateInfo.source !== 'GitHub API' && (
+                      <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">
+                        via {updateInfo.source}
+                      </p>
+                    )}
+                  </div>
                 )}
               </div>
             </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -81,6 +81,7 @@ function Settings() {
         latestVersion: string;
         currentVersion: string;
         downloadUrl: string;
+        source?: string;
     } | null>(null);
 
 
@@ -236,6 +237,7 @@ function Settings() {
                 latest_version: string;
                 current_version: string;
                 download_url: string;
+                source?: string;
             }>('check_for_updates');
 
             setUpdateInfo({
@@ -243,10 +245,12 @@ function Settings() {
                 latestVersion: result.latest_version,
                 currentVersion: result.current_version,
                 downloadUrl: result.download_url,
+                source: result.source,
             });
 
             if (result.has_update) {
-                showToast(t('settings.about.new_version_available', { version: result.latest_version }), 'info');
+                const sourceMsg = result.source && result.source !== 'GitHub API' ? ` (via ${result.source})` : '';
+                showToast(t('settings.about.new_version_available', { version: result.latest_version }) + sourceMsg, 'info');
             } else {
                 showToast(t('settings.about.latest_version'), 'success');
             }


### PR DESCRIPTION
## Description

Due to the frequency limit of GitHub API requests on export IPs, users often encounter the issue of "update check failed: GitHub API returned status: 403 Forbidden" when checking for updates. Additionally, Homebrew updates have a certain delay, forcing users to manually update the applications.

This PR resolves the issue of frequent update check failures in restricted environments due to GitHub 403 errors or network timeouts.

## Change

- **Proxy Support**: The update checker now respects the application's global upstream proxy configuration.
- **Multi-layer Fallback**: Implemented a robust fallback strategy:
  1. GitHub API (Preferred, has release notes)
  2. GitHub Raw (Precision check, avoids API rate limits)
  3. jsDelivr CDN (High availability backup)
- **UI Observability**: Added `source` field to update info to indicate which method detected the update (displayed in UI).
