### PR TITLE
feat(account): add model logo and fixed sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@lobehub/icons": "^4.2.0",
     "@tanstack/react-virtual": "^3.13.18",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../utils/cn';
 import { useTranslation } from 'react-i18next';
 import { useConfigStore } from '../../stores/useConfigStore';
 import { QuotaItem } from './QuotaItem';
+import { MODEL_CONFIG, sortModels } from '../../config/modelConfig';
 
 interface AccountCardProps {
     account: Account;
@@ -23,12 +24,13 @@ interface AccountCardProps {
     onWarmup?: () => void;
 }
 
-const DEFAULT_MODELS = [
-    { id: 'gemini-3-pro-high', label: 'G3 Pro', protectedKey: 'gemini-pro' },
-    { id: 'gemini-3-flash', label: 'G3 Flash', protectedKey: 'gemini-flash' },
-    { id: 'gemini-3-pro-image', label: 'G3 Image', protectedKey: 'gemini-image' },
-    { id: 'claude-sonnet-4-5-thinking', label: 'Claude 4.5', protectedKey: 'claude' }
-];
+// 使用统一的模型配置
+const DEFAULT_MODELS = Object.entries(MODEL_CONFIG).map(([id, config]) => ({
+    id,
+    label: config.label,
+    protectedKey: config.protectedKey,
+    Icon: config.Icon
+}));
 
 function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, isRefreshing, isSwitching = false, onSwitch, onRefresh, onViewDetails, onExport, onDelete, onToggleProxy, onViewDevice, onWarmup }: AccountCardProps) {
     const { t } = useTranslation();
@@ -39,27 +41,41 @@ function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, is
     const isCurrent = propIsCurrent;
 
     const displayModels = useMemo(() => {
-        // Build map of friendly labels from DEFAULT_MODELS
-        const labelMap = new Map(DEFAULT_MODELS.map(m => [m.id, m.label]));
+        // Build map of friendly labels and icons from DEFAULT_MODELS
+        const iconMap = new Map(DEFAULT_MODELS.map(m => [m.id, m.Icon]));
 
         // Get all models from account (source of truth)
-        const accountModels = account.quota?.models?.map(m => ({
-            id: m.name,
-            label: labelMap.get(m.name) || m.name,
-            protectedKey: DEFAULT_MODELS.find(d => d.id === m.name)?.protectedKey,
-            data: m
-        })) || [];
+        const accountModels = account.quota?.models?.map(m => {
+            // 注意：DEFAULT_MODELS 现在应该包含 shortLabel，我们需要确保它被正确映射
+            // 但 DEFAULT_MODELS 是从 MODEL_CONFIG 生成的，我们需要确保它包含 shortLabel
+            // 这里为了安全，直接从 MODEL_CONFIG 获取
+            const fullConfig = MODEL_CONFIG[m.name.toLowerCase()];
+            return {
+                id: m.name,
+                label: fullConfig?.shortLabel || fullConfig?.label || m.name,
+                protectedKey: fullConfig?.protectedKey,
+                Icon: iconMap.get(m.name),
+                data: m
+            };
+        }) || [];
 
-        if (showAllQuotas) return accountModels;
+        let models: typeof accountModels;
 
-        // Filter for pinned or defaults
-        const pinned = config?.pinned_quota_models?.models;
-        if (pinned && pinned.length > 0) {
-            return accountModels.filter(m => pinned.includes(m.id));
+        if (showAllQuotas) {
+            models = accountModels;
+        } else {
+            // Filter for pinned or defaults
+            const pinned = config?.pinned_quota_models?.models;
+            if (pinned && pinned.length > 0) {
+                models = accountModels.filter(m => pinned.includes(m.id));
+            } else {
+                // Default fallback: show known default models
+                models = accountModels.filter(m => DEFAULT_MODELS.some(d => d.id === m.id));
+            }
         }
 
-        // Default fallback: show known default models
-        return accountModels.filter(m => DEFAULT_MODELS.some(d => d.id === m.id));
+        // 应用排序
+        return sortModels(models);
     }, [config, account, showAllQuotas]);
 
     const isModelProtected = (key?: string) => {
@@ -173,6 +189,7 @@ function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, is
                                 percentage={model.data?.percentage || 0}
                                 resetTime={model.data?.reset_time}
                                 isProtected={isModelProtected(model.protectedKey)}
+                                Icon={model.Icon}
                             />
                         ))}
                     </div>

--- a/src/components/accounts/AccountDetailsDialog.tsx
+++ b/src/components/accounts/AccountDetailsDialog.tsx
@@ -1,8 +1,9 @@
 import { X, Clock, AlertCircle } from 'lucide-react';
 import { createPortal } from 'react-dom';
-import { Account, ModelQuota } from '../../types/account';
+import { Account } from '../../types/account';
 import { formatDate } from '../../utils/format';
 import { useTranslation } from 'react-i18next';
+import { MODEL_CONFIG, sortModels } from '../../config/modelConfig';
 
 interface AccountDetailsDialogProps {
     account: Account | null;
@@ -28,7 +29,7 @@ export default function AccountDetailsDialog({ account, onClose }: AccountDetail
                         </div>
                         {account.quota?.subscription_tier && (
                             <div className={`px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider ${account.quota.subscription_tier === 'ultra' ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400' :
-                                    account.quota.subscription_tier === 'pro' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-gray-100 text-gray-600 dark:bg-base-300 dark:text-gray-400'
+                                account.quota.subscription_tier === 'pro' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-gray-100 text-gray-600 dark:bg-base-300 dark:text-gray-400'
                                 }`}>
                                 {account.quota.subscription_tier}
                             </div>
@@ -83,12 +84,23 @@ export default function AccountDetailsDialog({ account, onClose }: AccountDetail
 
                     <h4 className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-widest mb-3">{t('accounts.details.model_quota')}</h4>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        {account.quota?.models?.map((model: ModelQuota) => (
+                        {sortModels(
+                            (account.quota?.models || []).map(model => ({
+                                id: model.name.toLowerCase(),
+                                model
+                            }))
+                        ).map(({ model }) => (
                             <div key={model.name} className="p-4 rounded-xl border border-gray-100 dark:border-base-200 bg-white dark:bg-base-100 hover:border-blue-100 dark:hover:border-blue-900 hover:shadow-sm transition-all group">
                                 <div className="flex justify-between items-start mb-3">
-                                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300 group-hover:text-blue-700 dark:group-hover:text-blue-400 transition-colors">
-                                        {model.name}
-                                    </span>
+                                    <div className="flex items-center gap-2">
+                                        {(() => {
+                                            const Icon = MODEL_CONFIG[model.name.toLowerCase()]?.Icon;
+                                            return Icon ? <Icon size={16} className="shrink-0" /> : null;
+                                        })()}
+                                        <span className="text-sm font-medium font-mono text-gray-700 dark:text-gray-300 group-hover:text-blue-700 dark:group-hover:text-blue-400 transition-colors">
+                                            {MODEL_CONFIG[model.name.toLowerCase()]?.label || model.name}
+                                        </span>
+                                    </div>
                                     <span
                                         className={`text-xs font-bold px-2 py-0.5 rounded-md ${model.percentage >= 50 ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400' :
                                             model.percentage >= 20 ? 'bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400' :

--- a/src/components/accounts/QuotaItem.tsx
+++ b/src/components/accounts/QuotaItem.tsx
@@ -10,9 +10,10 @@ interface QuotaItemProps {
     resetTime?: string;
     isProtected?: boolean;
     className?: string;
+    Icon?: React.ComponentType<{ size?: number; className?: string }>;
 }
 
-export function QuotaItem({ label, percentage, resetTime, isProtected, className }: QuotaItemProps) {
+export function QuotaItem({ label, percentage, resetTime, isProtected, className, Icon }: QuotaItemProps) {
     const { t } = useTranslation();
     const getBgColorClass = (p: number) => {
         const color = getQuotaColor(p);
@@ -61,7 +62,8 @@ export function QuotaItem({ label, percentage, resetTime, isProtected, className
             {/* Content */}
             <div className="relative z-10 w-full flex items-center text-[10px] font-mono leading-none gap-1.5">
                 {/* Model Name */}
-                <span className="flex-1 min-w-0 text-gray-500 dark:text-gray-400 font-bold truncate text-left" title={label}>
+                <span className="flex-1 min-w-0 text-gray-500 dark:text-gray-400 font-bold truncate text-left flex items-center gap-1" title={label}>
+                    {Icon && <Icon size={12} className="shrink-0" />}
                     {label}
                 </span>
 

--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -1,0 +1,200 @@
+import { Gemini, Claude } from '@lobehub/icons';
+
+/**
+ * 模型配置接口
+ */
+export interface ModelConfig {
+    /** 模型完整显示名称 (用于详情) */
+    label: string;
+    /** 模型简短标签 (用于列表/卡片) */
+    shortLabel: string;
+    /** 保护模型的键名 */
+    protectedKey: string;
+    /** 模型图标组件 */
+    Icon: React.ComponentType<{ size?: number; className?: string }>;
+}
+
+/**
+ * 模型配置映射
+ * 键为模型 ID，值为模型配置
+ */
+export const MODEL_CONFIG: Record<string, ModelConfig> = {
+    // Gemini 3.x 系列
+    'gemini-3-pro-high': {
+        label: 'Gemini 3 Pro High',
+        shortLabel: 'G3 Pro',
+        protectedKey: 'gemini-pro',
+        Icon: Gemini.Color,
+    },
+    'gemini-3-flash': {
+        label: 'Gemini 3 Flash',
+        shortLabel: 'G3 Flash',
+        protectedKey: 'gemini-flash',
+        Icon: Gemini.Color,
+    },
+    'gemini-3-pro-image': {
+        label: 'Gemini 3 Image',
+        shortLabel: 'G3 Image',
+        protectedKey: 'gemini-pro-image',
+        Icon: Gemini.Color,
+    },
+    'gemini-3-pro-low': {
+        label: 'Gemini 3 Pro Low',
+        shortLabel: 'G3 Low',
+        protectedKey: 'gemini-pro',
+        Icon: Gemini.Color,
+    },
+
+    // Gemini 2.5 系列
+    'gemini-2.5-flash': {
+        label: 'Gemini 2.5 Flash',
+        shortLabel: 'G2.5 Flash',
+        protectedKey: 'gemini-flash',
+        Icon: Gemini.Color,
+    },
+    'gemini-2.5-flash-lite': {
+        label: 'Gemini 2.5 Flash Lite',
+        shortLabel: 'G2.5 Lite',
+        protectedKey: 'gemini-flash',
+        Icon: Gemini.Color,
+    },
+    'gemini-2.5-flash-thinking': {
+        label: 'Gemini 2.5 Flash Think',
+        shortLabel: 'G2.5 Think',
+        protectedKey: 'gemini-flash',
+        Icon: Gemini.Color,
+    },
+    'gemini-2.5-pro': {
+        label: 'Gemini 2.5 Pro',
+        shortLabel: 'G2.5 Pro',
+        protectedKey: 'gemini-pro',
+        Icon: Gemini.Color,
+    },
+
+    // Claude 系列
+    'claude-sonnet-4-5': {
+        label: 'Claude 4.5 Sonnet',
+        shortLabel: 'Claude 4.5',
+        protectedKey: 'claude-sonnet',
+        Icon: Claude.Color,
+    },
+    'claude-sonnet-4-5-thinking': {
+        label: 'Claude 4.5 Sonnet Think',
+        shortLabel: 'Claude 4.5 Tk',
+        protectedKey: 'claude-sonnet',
+        Icon: Claude.Color,
+    },
+    'claude-opus-4-5-thinking': {
+        label: 'Claude 4.5 Opus Think',
+        shortLabel: 'Claude 4.5 Op',
+        protectedKey: 'claude-opus',
+        Icon: Claude.Color,
+    },
+};
+
+/**
+ * 获取所有模型 ID 列表
+ */
+export const getAllModelIds = (): string[] => Object.keys(MODEL_CONFIG);
+
+/**
+ * 根据模型 ID 获取配置
+ */
+export const getModelConfig = (modelId: string): ModelConfig | undefined => {
+    return MODEL_CONFIG[modelId.toLowerCase()];
+};
+
+/**
+ * 模型排序权重配置
+ * 数字越小，优先级越高
+ */
+const MODEL_SORT_WEIGHTS = {
+    // 系列权重 (第一优先级)
+    series: {
+        'gemini-3': 100,
+        'gemini-2.5': 200,
+        'gemini-2': 300,
+        'claude': 400,
+    },
+    // 性能级别权重 (第二优先级)
+    tier: {
+        'pro': 10,
+        'flash': 20,
+        'lite': 30,
+        'opus': 5,
+        'sonnet': 10,
+    },
+    // 特殊后缀权重 (第三优先级)
+    suffix: {
+        'thinking': 1,
+        'image': 2,
+        'high': 0,
+        'low': 3,
+    }
+};
+
+/**
+ * 获取模型的排序权重
+ */
+function getModelSortWeight(modelId: string): number {
+    const id = modelId.toLowerCase();
+    let weight = 0;
+
+    // 1. 系列权重 (x1000)
+    if (id.startsWith('gemini-3')) {
+        weight += MODEL_SORT_WEIGHTS.series['gemini-3'] * 1000;
+    } else if (id.startsWith('gemini-2.5')) {
+        weight += MODEL_SORT_WEIGHTS.series['gemini-2.5'] * 1000;
+    } else if (id.startsWith('gemini-2')) {
+        weight += MODEL_SORT_WEIGHTS.series['gemini-2'] * 1000;
+    } else if (id.startsWith('claude')) {
+        weight += MODEL_SORT_WEIGHTS.series['claude'] * 1000;
+    }
+
+    // 2. 性能级别权重 (x100)
+    if (id.includes('pro')) {
+        weight += MODEL_SORT_WEIGHTS.tier['pro'] * 100;
+    } else if (id.includes('flash')) {
+        weight += MODEL_SORT_WEIGHTS.tier['flash'] * 100;
+    } else if (id.includes('lite')) {
+        weight += MODEL_SORT_WEIGHTS.tier['lite'] * 100;
+    } else if (id.includes('opus')) {
+        weight += MODEL_SORT_WEIGHTS.tier['opus'] * 100;
+    } else if (id.includes('sonnet')) {
+        weight += MODEL_SORT_WEIGHTS.tier['sonnet'] * 100;
+    }
+
+    // 3. 特殊后缀权重 (x10)
+    if (id.includes('thinking')) {
+        weight += MODEL_SORT_WEIGHTS.suffix['thinking'] * 10;
+    } else if (id.includes('image')) {
+        weight += MODEL_SORT_WEIGHTS.suffix['image'] * 10;
+    } else if (id.includes('high')) {
+        weight += MODEL_SORT_WEIGHTS.suffix['high'] * 10;
+    } else if (id.includes('low')) {
+        weight += MODEL_SORT_WEIGHTS.suffix['low'] * 10;
+    }
+
+    return weight;
+}
+
+/**
+ * 对模型列表进行排序
+ * @param models 模型列表
+ * @returns 排序后的模型列表
+ */
+export function sortModels<T extends { id: string }>(models: T[]): T[] {
+    return [...models].sort((a, b) => {
+        const weightA = getModelSortWeight(a.id);
+        const weightB = getModelSortWeight(b.id);
+
+        // 按权重升序排序
+        if (weightA !== weightB) {
+            return weightA - weightB;
+        }
+
+        // 权重相同时，按字母顺序排序
+        return a.id.localeCompare(b.id);
+    });
+}
+

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -194,7 +194,9 @@
         "warmup_batch_triggered": "تم إطلاق مهام التنشيط لـ {{count}} حساب",
         "quota_protected": "محمي",
         "details": {
-            "title": "تفاصيل الحصة"
+            "title": "تفاصيل الحصة",
+            "model_quota": "حصة النموذج",
+            "protected_models": "النماذج المحمية"
         },
         "toast": {
             "proxy_enabled": "تم تفعيل الوكيل لـ {{count}} حساب",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -198,7 +198,9 @@
         "warmup_batch_triggered": "Warmup tasks triggered for {{count}} accounts",
         "quota_protected": "Protected",
         "details": {
-            "title": "Quota Details"
+            "title": "Quota Details",
+            "model_quota": "Model Quota",
+            "protected_models": "Protected Models"
         },
         "toast": {
             "proxy_enabled": "Enabled proxy for {{count}} accounts",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -192,7 +192,9 @@
         "warmup_batch_triggered": "Tareas de calentamiento activadas para {{count}} cuentas",
         "quota_protected": "Protegida",
         "details": {
-            "title": "Detalles de Cuota"
+            "title": "Detalles de Cuota",
+            "model_quota": "Cuota de Modelo",
+            "protected_models": "Modelos Protegidos"
         },
         "toast": {
             "proxy_enabled": "Proxy habilitado para {{count}} cuentas",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -193,7 +193,9 @@
         },
         "quota_protected": "保護中",
         "details": {
-            "title": "クォータ詳細"
+            "title": "クォータ詳細",
+            "model_quota": "モデルクォータ",
+            "protected_models": "保護されたモデル"
         },
         "toast": {
             "proxy_enabled": "{{count}} 個のアカウントのプロキシを有効にしました",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -195,7 +195,9 @@
         "warmup_batch_triggered": "{{count}}개 계정에 대해 웜업 작업이 트리거되었습니다",
         "quota_protected": "보호됨",
         "details": {
-            "title": "할당량 상세"
+            "title": "할당량 상세",
+            "model_quota": "모델 할당량",
+            "protected_models": "보호된 모델"
         },
         "toast": {
             "proxy_enabled": "{{count}}개 계정의 프록시를 활성화했습니다",

--- a/src/locales/my.json
+++ b/src/locales/my.json
@@ -192,7 +192,9 @@
         "warmup_batch_triggered": "Tugas pemanasan dicetuskan untuk {{count}} akaun",
         "quota_protected": "Dilindungi",
         "details": {
-            "title": "Butiran Kuota"
+            "title": "Butiran Kuota",
+            "model_quota": "Kuota Model",
+            "protected_models": "Model Dilindungi"
         },
         "toast": {
             "proxy_enabled": "Proksi diaktifkan untuk {{count}} akaun",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -188,7 +188,9 @@
         "warmup_batch_triggered": "Tarefas de aquecimento acionadas para {{count}} contas",
         "quota_protected": "Protegido",
         "details": {
-            "title": "Detalhes da Cota"
+            "title": "Detalhes da Cota",
+            "model_quota": "Cota do Modelo",
+            "protected_models": "Modelos Protegidos"
         },
         "toast": {
             "proxy_enabled": "Proxy habilitado para {{count}} contas",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -191,7 +191,9 @@
         "warmup_batch_triggered": "Задачи разогрева запущены для {{count}} аккаунтов",
         "quota_protected": "Защищено",
         "details": {
-            "title": "Детали квоты"
+            "title": "Детали квоты",
+            "model_quota": "Квота модели",
+            "protected_models": "Защищенные модели"
         },
         "toast": {
             "proxy_enabled": "Включен прокси для {{count}} аккаунтов",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -184,7 +184,9 @@
         },
         "quota_protected": "Korumalı",
         "details": {
-            "title": "Kota Detayları"
+            "title": "Kota Detayları",
+            "model_quota": "Model Kotası",
+            "protected_models": "Korumalı Modeller"
         },
         "toast": {
             "proxy_enabled": "{{count}} hesap için proxy etkinleştirildi",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -191,7 +191,9 @@
         "warmup_batch_triggered": "Đã kích hoạt làm nóng cho {{count}} tài khoản",
         "quota_protected": "Được bảo vệ",
         "details": {
-            "title": "Chi tiết Hạn mức"
+            "title": "Chi tiết Hạn mức",
+            "model_quota": "Hạn mức Mô hình",
+            "protected_models": "Mô hình Được Bảo vệ"
         },
         "toast": {
             "proxy_enabled": "Đã bật proxy cho {{count}} tài khoản",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -192,7 +192,9 @@
         "warmup_batch_triggered": "已成功為 {{count}} 個帳號觸發預熱任務",
         "quota_protected": "受保護",
         "details": {
-            "title": "配額詳情"
+            "title": "配額詳情",
+            "model_quota": "模型配額",
+            "protected_models": "受保護模型"
         },
         "toast": {
             "proxy_enabled": "成功啟用 {{count}} 個帳號的反向代理功能",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -195,7 +195,9 @@
         "warmup_batch_triggered": "已成功为 {{count}} 个账号触发预热任务",
         "quota_protected": "受保护",
         "details": {
-            "title": "配额详情"
+            "title": "配额详情",
+            "model_quota": "模型配额",
+            "protected_models": "受保护模型"
         },
         "toast": {
             "proxy_enabled": "成功启用 {{count}} 个账号的反代功能",


### PR DESCRIPTION
## Description

- Provide logo display for the model while supporting fixed model sorting
- Supporting display of short names (account list and cards) and full names (account details)
- Fix the missing i18n information in the model details.

## Example

<img width="1300" height="759" alt="Google Chrome 2026-02-04 23 37 54" src="https://github.com/user-attachments/assets/b24cc769-d282-490a-9c10-7304f5ba6a73" />


<img width="1137" height="824" alt="Google Chrome 2026-02-04 23 38 12" src="https://github.com/user-attachments/assets/997d0556-df2c-435e-b1d7-55b75d5a639b" />
