### PR TITLE
fix(#1512): prevent routing requests to disabled accounts

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -763,8 +763,32 @@ pub async fn toggle_proxy_status(
         if enable { "已启用" } else { "已禁用" }
     ));
 
-    // 4. 如果反代服务正在运行,重新加载账号池
-    let _ = crate::commands::proxy::reload_proxy_accounts(proxy_state).await;
+    // 4. 如果反代服务正在运行,立刻同步到内存池（避免禁用后仍被选中）
+    {
+        let instance_lock = proxy_state.instance.read().await;
+        if let Some(instance) = instance_lock.as_ref() {
+            // 如果禁用的是当前固定账号，则自动关闭固定模式（内存 + 配置持久化）
+            if !enable {
+                let pref_id = instance.token_manager.get_preferred_account().await;
+                if pref_id.as_deref() == Some(&account_id) {
+                    instance.token_manager.set_preferred_account(None).await;
+
+                    if let Ok(mut cfg) = crate::modules::config::load_app_config() {
+                        if cfg.proxy.preferred_account_id.as_deref() == Some(&account_id) {
+                            cfg.proxy.preferred_account_id = None;
+                            let _ = crate::modules::config::save_app_config(&cfg);
+                        }
+                    }
+                }
+            }
+
+            instance
+                .token_manager
+                .reload_account(&account_id)
+                .await
+                .map_err(|e| format!("同步账号失败: {}", e))?;
+        }
+    }
 
     // 5. 更新托盘菜单
     crate::modules::tray::update_tray_menus(&app);

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -815,6 +815,7 @@ pub async fn fetch_quota_with_retry(account: &mut Account) -> crate::error::AppR
                 account.disabled_at = Some(chrono::Utc::now().timestamp());
                 account.disabled_reason = Some(format!("invalid_grant: {}", e));
                 let _ = save_account(account);
+                crate::proxy::server::trigger_account_reload(&account.id);
             }
             return Err(AppError::OAuth(e));
         }
@@ -914,6 +915,7 @@ pub async fn fetch_quota_with_retry(account: &mut Account) -> crate::error::AppR
                             account.disabled_at = Some(chrono::Utc::now().timestamp());
                             account.disabled_reason = Some(format!("invalid_grant: {}", e));
                             let _ = save_account(account);
+                            crate::proxy::server::trigger_account_reload(&account.id);
                         }
                         return Err(AppError::OAuth(e));
                     }

--- a/src-tauri/src/modules/quota.rs
+++ b/src-tauri/src/modules/quota.rs
@@ -332,7 +332,11 @@ pub async fn warm_up_all_accounts() -> Result<String, String> {
     let mut retry_count = 0;
     
     loop {
-        let target_accounts = crate::modules::account::list_accounts().unwrap_or_default();
+        let all_accounts = crate::modules::account::list_accounts().unwrap_or_default();
+        let target_accounts: Vec<_> = all_accounts
+            .into_iter()
+            .filter(|a| !a.disabled && !a.proxy_disabled)
+            .collect();
 
         if target_accounts.is_empty() {
             return Ok("No accounts available".to_string());
@@ -472,6 +476,10 @@ pub async fn warm_up_all_accounts() -> Result<String, String> {
 pub async fn warm_up_account(account_id: &str) -> Result<String, String> {
     let accounts = crate::modules::account::list_accounts().unwrap_or_default();
     let account_owned = accounts.iter().find(|a| a.id == account_id).cloned().ok_or_else(|| "Account not found".to_string())?;
+
+    if account_owned.disabled || account_owned.proxy_disabled {
+        return Err("Account is disabled".to_string());
+    }
     
     let email = account_owned.email.clone();
     let (token, pid) = get_valid_token_for_warmup(&account_owned).await?;

--- a/src-tauri/src/modules/scheduler.rs
+++ b/src-tauri/src/modules/scheduler.rs
@@ -90,7 +90,7 @@ pub fn start_scheduler(app_handle: Option<tauri::AppHandle>, proxy_state: crate:
             // Scan each model for each account
             for account in &accounts {
                 // Skip disabled accounts
-                if account.proxy_disabled {
+                if account.disabled || account.proxy_disabled {
                     continue;
                 }
 
@@ -266,6 +266,10 @@ pub fn start_scheduler(app_handle: Option<tauri::AppHandle>, proxy_state: crate:
 
 /// Trigger immediate smart warmup check for a single account
 pub async fn trigger_warmup_for_account(account: &Account) {
+    if account.disabled || account.proxy_disabled {
+        return;
+    }
+
     // Get valid token
     let Ok((token, pid)) = quota::get_valid_token_for_warmup(account).await else {
         return;

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -9,6 +9,13 @@ use tokio_util::sync::CancellationToken;
 use crate::proxy::rate_limit::RateLimitTracker;
 use crate::proxy::sticky_config::StickySessionConfig;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OnDiskAccountState {
+    Enabled,
+    Disabled,
+    Unknown,
+}
+
 #[derive(Debug, Clone)]
 pub struct ProxyToken {
     pub account_id: String,
@@ -167,7 +174,20 @@ impl TokenManager {
                 self.clear_rate_limit(account_id);
                 Ok(())
             }
-            Ok(None) => Err("账号加载失败".to_string()),
+            Ok(None) => {
+                // load_single_account returning None means the account should be skipped in its
+                // current state (disabled / proxy_disabled / quota_protection / validation_blocked...).
+                // Purge any existing in-memory cache to avoid selecting a disabled account.
+                self.remove_account(account_id);
+                // Ensure preferred account flag is cleared even under contention.
+                {
+                    let mut preferred = self.preferred_account_id.write().await;
+                    if preferred.as_deref() == Some(account_id) {
+                        *preferred = None;
+                    }
+                }
+                Ok(())
+            }
             Err(e) => Err(format!("同步账号失败: {}", e)),
         }
     }
@@ -203,6 +223,74 @@ impl TokenManager {
                 tracing::info!("[Proxy] Cleared preferred account status for {}", account_id);
             }
         }
+    }
+
+    /// Check if an account has been disabled on disk.
+    ///
+    /// Safety net: avoids selecting a disabled account when the in-memory pool hasn't been
+    /// reloaded yet (e.g. fixed account mode / sticky session).
+    ///
+    /// Note: this is intentionally tolerant to transient read/parse failures (e.g. concurrent
+    /// writes). Failures are reported as `Unknown` so callers can skip without purging the in-memory
+    /// token pool.
+    async fn get_account_state_on_disk(account_path: &PathBuf) -> OnDiskAccountState {
+        const MAX_RETRIES: usize = 2;
+        const RETRY_DELAY_MS: u64 = 5;
+
+        for attempt in 0..=MAX_RETRIES {
+            let content = match tokio::fs::read_to_string(account_path).await {
+                Ok(c) => c,
+                Err(e) => {
+                    // If the file is gone, the in-memory token is definitely stale.
+                    if e.kind() == std::io::ErrorKind::NotFound {
+                        return OnDiskAccountState::Disabled;
+                    }
+                    if attempt < MAX_RETRIES {
+                        tokio::time::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS)).await;
+                        continue;
+                    }
+                    tracing::debug!(
+                        "Failed to read account file on disk {:?}: {}",
+                        account_path,
+                        e
+                    );
+                    return OnDiskAccountState::Unknown;
+                }
+            };
+
+            let account = match serde_json::from_str::<serde_json::Value>(&content) {
+                Ok(v) => v,
+                Err(e) => {
+                    if attempt < MAX_RETRIES {
+                        tokio::time::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS)).await;
+                        continue;
+                    }
+                    tracing::debug!(
+                        "Failed to parse account JSON on disk {:?}: {}",
+                        account_path,
+                        e
+                    );
+                    return OnDiskAccountState::Unknown;
+                }
+            };
+
+            let disabled = account
+                .get("disabled")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+                || account
+                    .get("proxy_disabled")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+            return if disabled {
+                OnDiskAccountState::Disabled
+            } else {
+                OnDiskAccountState::Enabled
+            };
+        }
+
+        OnDiskAccountState::Unknown
     }
 
     /// 加载单个账号
@@ -883,7 +971,7 @@ impl TokenManager {
     ) -> Result<(String, String, String, String, u64), String> {
         let mut tokens_snapshot: Vec<ProxyToken> =
             self.tokens.iter().map(|e| e.value().clone()).collect();
-        let total = tokens_snapshot.len();
+        let mut total = tokens_snapshot.len();
         if total == 0 {
             return Err("Token pool is empty".to_string());
         }
@@ -974,9 +1062,46 @@ impl TokenManager {
         let preferred_id = self.preferred_account_id.read().await.clone();
         if let Some(ref pref_id) = preferred_id {
             // 查找优先账号
-            if let Some(preferred_token) = tokens_snapshot.iter().find(|t| &t.account_id == pref_id)
+            if let Some(preferred_token) = tokens_snapshot
+                .iter()
+                .find(|t| &t.account_id == pref_id)
+                .cloned()
             {
                 // 检查账号是否可用（未限流、未被配额保护）
+                match Self::get_account_state_on_disk(&preferred_token.account_path).await {
+                    OnDiskAccountState::Disabled => {
+                        tracing::warn!(
+                            "🔒 [FIX #820] Preferred account {} is disabled on disk, purging and falling back",
+                            preferred_token.email
+                        );
+                        self.remove_account(&preferred_token.account_id);
+                        tokens_snapshot.retain(|t| t.account_id != preferred_token.account_id);
+                        total = tokens_snapshot.len();
+
+                        {
+                            let mut preferred = self.preferred_account_id.write().await;
+                            if preferred.as_deref() == Some(pref_id.as_str()) {
+                                *preferred = None;
+                            }
+                        }
+
+                        if total == 0 {
+                            return Err("Token pool is empty".to_string());
+                        }
+                    }
+                    OnDiskAccountState::Unknown => {
+                        tracing::warn!(
+                            "🔒 [FIX #820] Preferred account {} state on disk is unavailable, falling back",
+                            preferred_token.email
+                        );
+                        // Don't purge on transient read/parse failures; just skip this token for this request.
+                        tokens_snapshot.retain(|t| t.account_id != preferred_token.account_id);
+                        total = tokens_snapshot.len();
+                        if total == 0 {
+                            return Err("Token pool is empty".to_string());
+                        }
+                    }
+                    OnDiskAccountState::Enabled => {
                 let normalized_target =
                     crate::proxy::common::model_mapping::normalize_to_standard_id(target_model)
                         .unwrap_or_else(|| target_model.to_string());
@@ -1050,6 +1175,8 @@ impl TokenManager {
                         tracing::warn!("🔒 [FIX #820] Preferred account {} is rate-limited, falling back to round-robin", preferred_token.email);
                     } else {
                         tracing::warn!("🔒 [FIX #820] Preferred account {} is quota-protected for {}, falling back to round-robin", preferred_token.email, target_model);
+                    }
+                }
                     }
                 }
             } else {
@@ -1300,6 +1427,29 @@ impl TokenManager {
                     }
                 }
             };
+
+            // Safety net: avoid selecting an account that has been disabled on disk but still
+            // exists in the in-memory snapshot (e.g. stale cache + sticky session binding).
+            match Self::get_account_state_on_disk(&token.account_path).await {
+                OnDiskAccountState::Disabled => {
+                    tracing::warn!(
+                        "Selected account {} is disabled on disk, purging and retrying",
+                        token.email
+                    );
+                    attempted.insert(token.account_id.clone());
+                    self.remove_account(&token.account_id);
+                    continue;
+                }
+                OnDiskAccountState::Unknown => {
+                    tracing::warn!(
+                        "Selected account {} state on disk is unavailable, skipping",
+                        token.email
+                    );
+                    attempted.insert(token.account_id.clone());
+                    continue;
+                }
+                OnDiskAccountState::Enabled => {}
+            }
 
             // 3. 检查 token 是否过期（提前5分钟刷新）
             let now = chrono::Utc::now().timestamp();
@@ -2225,6 +2375,199 @@ fn truncate_reason(reason: &str, max_len: usize) -> String {
 mod tests {
     use super::*;
     use std::cmp::Ordering;
+
+    #[tokio::test]
+    async fn test_reload_account_purges_cache_when_account_becomes_proxy_disabled() {
+        let tmp_root = std::env::temp_dir().join(format!(
+            "antigravity-token-manager-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let accounts_dir = tmp_root.join("accounts");
+        std::fs::create_dir_all(&accounts_dir).unwrap();
+
+        let account_id = "acc1";
+        let email = "a@test.com";
+        let now = chrono::Utc::now().timestamp();
+        let account_path = accounts_dir.join(format!("{}.json", account_id));
+
+        let account_json = serde_json::json!({
+            "id": account_id,
+            "email": email,
+            "token": {
+                "access_token": "atk",
+                "refresh_token": "rtk",
+                "expires_in": 3600,
+                "expiry_timestamp": now + 3600
+            },
+            "disabled": false,
+            "proxy_disabled": false,
+            "created_at": now,
+            "last_used": now
+        });
+        std::fs::write(&account_path, serde_json::to_string_pretty(&account_json).unwrap()).unwrap();
+
+        let manager = TokenManager::new(tmp_root.clone());
+        manager.load_accounts().await.unwrap();
+        assert!(manager.tokens.get(account_id).is_some());
+
+        // Prime extra caches to ensure remove_account() is really called.
+        manager
+            .session_accounts
+            .insert("sid1".to_string(), account_id.to_string());
+        {
+            let mut preferred = manager.preferred_account_id.write().await;
+            *preferred = Some(account_id.to_string());
+        }
+
+        // Mark account as proxy-disabled on disk (manual disable).
+        let mut disabled_json = account_json.clone();
+        disabled_json["proxy_disabled"] = serde_json::Value::Bool(true);
+        disabled_json["proxy_disabled_reason"] = serde_json::Value::String("manual".to_string());
+        disabled_json["proxy_disabled_at"] = serde_json::Value::Number(now.into());
+        std::fs::write(&account_path, serde_json::to_string_pretty(&disabled_json).unwrap()).unwrap();
+
+        manager.reload_account(account_id).await.unwrap();
+
+        assert!(manager.tokens.get(account_id).is_none());
+        assert!(manager.session_accounts.get("sid1").is_none());
+        assert!(manager.preferred_account_id.read().await.is_none());
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
+    }
+
+    #[tokio::test]
+    async fn test_fixed_account_mode_skips_preferred_when_disabled_on_disk_without_reload() {
+        let tmp_root = std::env::temp_dir().join(format!(
+            "antigravity-token-manager-test-fixed-mode-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let accounts_dir = tmp_root.join("accounts");
+        std::fs::create_dir_all(&accounts_dir).unwrap();
+
+        let now = chrono::Utc::now().timestamp();
+
+        let write_account = |id: &str, email: &str, proxy_disabled: bool| {
+            let account_path = accounts_dir.join(format!("{}.json", id));
+            let json = serde_json::json!({
+                "id": id,
+                "email": email,
+                "token": {
+                    "access_token": format!("atk-{}", id),
+                    "refresh_token": format!("rtk-{}", id),
+                    "expires_in": 3600,
+                    "expiry_timestamp": now + 3600,
+                    "project_id": format!("pid-{}", id)
+                },
+                "disabled": false,
+                "proxy_disabled": proxy_disabled,
+                "proxy_disabled_reason": if proxy_disabled { "manual" } else { "" },
+                "created_at": now,
+                "last_used": now
+            });
+            std::fs::write(&account_path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+        };
+
+        // Two accounts in pool.
+        write_account("acc1", "a@test.com", false);
+        write_account("acc2", "b@test.com", false);
+
+        let manager = TokenManager::new(tmp_root.clone());
+        manager.load_accounts().await.unwrap();
+
+        // Enable fixed account mode for acc1.
+        manager.set_preferred_account(Some("acc1".to_string())).await;
+
+        // Disable acc1 on disk WITHOUT reloading the in-memory pool (simulates stale cache).
+        write_account("acc1", "a@test.com", true);
+
+        let (_token, _project_id, email, account_id, _wait_ms) = manager
+            .get_token("gemini", false, Some("sid1"), "gemini-3-flash")
+            .await
+            .unwrap();
+
+        // Should fall back to another account instead of using the disabled preferred one.
+        assert_eq!(account_id, "acc2");
+        assert_eq!(email, "b@test.com");
+        assert!(manager.tokens.get("acc1").is_none());
+        assert!(manager.get_preferred_account().await.is_none());
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
+    }
+
+    #[tokio::test]
+    async fn test_sticky_session_skips_bound_account_when_disabled_on_disk_without_reload() {
+        let tmp_root = std::env::temp_dir().join(format!(
+            "antigravity-token-manager-test-sticky-disabled-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let accounts_dir = tmp_root.join("accounts");
+        std::fs::create_dir_all(&accounts_dir).unwrap();
+
+        let now = chrono::Utc::now().timestamp();
+
+        let write_account = |id: &str, email: &str, percentage: i64, proxy_disabled: bool| {
+            let account_path = accounts_dir.join(format!("{}.json", id));
+            let json = serde_json::json!({
+                "id": id,
+                "email": email,
+                "token": {
+                    "access_token": format!("atk-{}", id),
+                    "refresh_token": format!("rtk-{}", id),
+                    "expires_in": 3600,
+                    "expiry_timestamp": now + 3600,
+                    "project_id": format!("pid-{}", id)
+                },
+                "quota": {
+                    "models": [
+                        { "name": "gemini-3-flash", "percentage": percentage }
+                    ]
+                },
+                "disabled": false,
+                "proxy_disabled": proxy_disabled,
+                "proxy_disabled_reason": if proxy_disabled { "manual" } else { "" },
+                "created_at": now,
+                "last_used": now
+            });
+            std::fs::write(&account_path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+        };
+
+        // Two accounts in pool. acc1 has higher quota -> should be selected and bound first.
+        write_account("acc1", "a@test.com", 90, false);
+        write_account("acc2", "b@test.com", 10, false);
+
+        let manager = TokenManager::new(tmp_root.clone());
+        manager.load_accounts().await.unwrap();
+
+        // Prime: first request should bind the session to acc1.
+        let (_token, _project_id, _email, account_id, _wait_ms) = manager
+            .get_token("gemini", false, Some("sid1"), "gemini-3-flash")
+            .await
+            .unwrap();
+        assert_eq!(account_id, "acc1");
+        assert_eq!(
+            manager.session_accounts.get("sid1").map(|v| v.clone()),
+            Some("acc1".to_string())
+        );
+
+        // Disable acc1 on disk WITHOUT reloading the in-memory pool (simulates stale cache).
+        write_account("acc1", "a@test.com", 90, true);
+
+        let (_token, _project_id, email, account_id, _wait_ms) = manager
+            .get_token("gemini", false, Some("sid1"), "gemini-3-flash")
+            .await
+            .unwrap();
+
+        // Should fall back to another account instead of reusing the disabled bound one.
+        assert_eq!(account_id, "acc2");
+        assert_eq!(email, "b@test.com");
+        assert!(manager.tokens.get("acc1").is_none());
+        assert_ne!(
+            manager.session_accounts.get("sid1").map(|v| v.clone()),
+            Some("acc1".to_string())
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
+    }
 
     /// 创建测试用的 ProxyToken
     fn create_test_token(


### PR DESCRIPTION
﻿Fixes #1512

## Problem
Users reported that after disabling an account (`disabled` / `proxy_disabled`), the proxy may still route some requests to that account. This is most likely caused by stale in-memory state (token pool / cached bindings) not being refreshed immediately after the on-disk account flags change.

> Note: I did not reproduce this locally. This PR focuses on removing stale selections by adding immediate sync + selection-time safety checks, and includes regression tests for the relevant scenarios.

## What changed

### Immediate sync on disable/enable
- When toggling an account’s proxy status and the proxy is running, immediately sync the change into the in-memory pool by calling `TokenManager.reload_account(account_id)`.
- If disabling the currently preferred (fixed) account, clear preferred mode (in-memory + persisted config) to prevent it from being selected again.

### Token selection safety net
- In `TokenManager`, add an on-disk state check to avoid selecting an account that has already been disabled on disk but is still present in the in-memory snapshot (stale cache).
- Tolerate transient read/parse failures (e.g. concurrent writes): treat as “unknown” and skip for the current request (avoid destructive purges on flaky reads).

### Background tasks
- Ensure warmup/scheduler paths skip `disabled || proxy_disabled` accounts.

## Impact / Risk
- Impact: Disabling an account takes effect immediately for subsequent routing decisions.
- Risk: Adds small per-request disk I/O to guard against stale in-memory selection; transient read/parse errors fall back to other accounts.
- Limitation: Does not cancel in-flight requests that already selected an account before the disable action.

## Files / Areas touched
- `src-tauri/src/commands/mod.rs`: sync toggle to TokenManager + clear preferred when disabling
- `src-tauri/src/proxy/token_manager.rs`: purge-on-reload, on-disk safety checks, regression tests
- `src-tauri/src/modules/account.rs`: trigger TokenManager reload when an account becomes `disabled` due to `invalid_grant`
- `src-tauri/src/modules/quota.rs`, `src-tauri/src/modules/scheduler.rs`: skip disabled accounts for warmup/scheduling

## Tests
- Add tokio tests covering:
  - preferred/fixed mode falls back when the preferred account becomes disabled on disk without an in-memory reload
  - sticky session falls back when the bound account becomes disabled on disk without an in-memory reload
  - `reload_account` purges caches when an account becomes `proxy_disabled`
