### PR TITLE
fix: proxy pool binding persistence & disabled account filtering

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,8 +2,9 @@ services:
   antigravity-manager:
     image: lbjlaq/antigravity-manager:latest
     container_name: antigravity-manager
-    ports:
-      - "8045:8045"
+    network_mode: host  # 使用宿主机网络，可直接访问 localhost:17771 等代理端口
+    # ports:  # host 模式不需要端口映射
+    #   - "8045:8045"
     volumes:
       - ~/.antigravity_tools:/root/.antigravity_tools
     environment:

--- a/src-tauri/src/models/account.rs
+++ b/src-tauri/src/models/account.rs
@@ -37,6 +37,15 @@ pub struct Account {
     /// 受配额保护禁用的模型列表 [NEW #621]
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub protected_models: HashSet<String>,
+    /// [NEW] 403 验证阻止状态 (VALIDATION_REQUIRED)
+    #[serde(default)]
+    pub validation_blocked: bool,
+    /// [NEW] 验证阻止截止时间戳
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation_blocked_until: Option<i64>,
+    /// [NEW] 验证阻止原因
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation_blocked_reason: Option<String>,
     pub created_at: i64,
     pub last_used: i64,
     /// 绑定的代理 ID (None = 使用全局代理池)
@@ -65,6 +74,9 @@ impl Account {
             proxy_disabled_reason: None,
             proxy_disabled_at: None,
             protected_models: HashSet::new(),
+            validation_blocked: false,
+            validation_blocked_until: None,
+            validation_blocked_reason: None,
             created_at: now,
             last_used: now,
             proxy_id: None,

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -1018,6 +1018,14 @@ pub async fn refresh_all_quotas_logic() -> Result<RefreshStats, String> {
                 ));
                 return false;
             }
+            // [FIX] 检查 proxy_disabled 状态
+            if account.proxy_disabled {
+                crate::modules::logger::log_info(&format!(
+                    "  - Skipping {} (Proxy Disabled)",
+                    account.email
+                ));
+                return false;
+            }
             if let Some(ref q) = account.quota {
                 if q.is_forbidden {
                     crate::modules::logger::log_info(&format!(

--- a/src-tauri/src/modules/quota.rs
+++ b/src-tauri/src/modules/quota.rs
@@ -330,9 +330,15 @@ pub async fn warmup_model_directly(
 /// Smart warmup for all accounts
 pub async fn warm_up_all_accounts() -> Result<String, String> {
     let mut retry_count = 0;
-    
+
     loop {
-        let target_accounts = crate::modules::account::list_accounts().unwrap_or_default();
+        let all_accounts = crate::modules::account::list_accounts().unwrap_or_default();
+
+        // [FIX] 过滤掉禁用反代的账号
+        let target_accounts: Vec<_> = all_accounts
+            .into_iter()
+            .filter(|acc| !acc.disabled && !acc.proxy_disabled)
+            .collect();
 
         if target_accounts.is_empty() {
             return Ok("No accounts available".to_string());

--- a/src-tauri/src/proxy/config.rs
+++ b/src-tauri/src/proxy/config.rs
@@ -544,6 +544,9 @@ pub struct ProxyPoolConfig {
     pub health_check_interval: u64,    // 健康检查间隔 (秒)
     pub auto_failover: bool,           // 自动故障转移
     pub strategy: ProxySelectionStrategy, // 代理选择策略
+    /// 账号到代理的绑定关系 (account_id -> proxy_id)，持久化存储
+    #[serde(default)]
+    pub account_bindings: HashMap<String, String>,
 }
 
 impl Default for ProxyPoolConfig {
@@ -555,6 +558,7 @@ impl Default for ProxyPoolConfig {
             health_check_interval: 300,
             auto_failover: true,
             strategy: ProxySelectionStrategy::Priority,
+            account_bindings: HashMap::new(),
         }
     }
 }

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -39,6 +39,7 @@ pub use security::ProxySecurityConfig;
 pub use server::AxumServer;
 pub use signature_cache::SignatureCache;
 pub use token_manager::TokenManager;
+pub use proxy_pool::{ProxyPoolManager, get_global_proxy_pool, init_global_proxy_pool};
 
 #[cfg(test)]
 pub mod tests;

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -167,7 +167,14 @@ impl TokenManager {
                 self.clear_rate_limit(account_id);
                 Ok(())
             }
-            Ok(None) => Err("账号加载失败".to_string()),
+            Ok(None) => {
+                // [FIX] 账号被禁用或不可用时，从 token 池中移除
+                if self.tokens.remove(account_id).is_some() {
+                    tracing::info!("[TokenManager] Removed disabled account from pool: {}", account_id);
+                    self.clear_rate_limit(account_id);
+                }
+                Ok(()) // 返回 Ok 表示操作成功（账号已被正确处理）
+            }
             Err(e) => Err(format!("同步账号失败: {}", e)),
         }
     }

--- a/src-tauri/src/proxy/upstream/client.rs
+++ b/src-tauri/src/proxy/upstream/client.rs
@@ -66,8 +66,8 @@ impl UpstreamClient {
         builder.build()
     }
     
-    /// Build a client with a specific ProxyConfig (from ProxyPool)
-    fn build_client_with_proxy(&self, proxy_config: crate::proxy::proxy_pool::ProxyConfig) -> Result<Client, reqwest::Error> {
+    /// Build a client with a specific PoolProxyConfig (from ProxyPool)
+    fn build_client_with_proxy(&self, proxy_config: crate::proxy::proxy_pool::PoolProxyConfig) -> Result<Client, reqwest::Error> {
         // Reuse base settings similar to default client but with specific proxy
         Client::builder()
             .connect_timeout(Duration::from_secs(20))

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -143,6 +143,13 @@ const COMMAND_MAPPING: Record<string, { url: string; method: 'GET' | 'POST' | 'D
   'renew_user_token': { url: '/api/user-tokens/:id/renew', method: 'POST' },
   'delete_user_token': { url: '/api/user-tokens/:id', method: 'DELETE' },
   'update_user_token': { url: '/api/user-tokens/:id', method: 'PATCH' },
+
+  // Proxy Pool (Web Mode Fix)
+  'get_proxy_pool_config': { url: '/api/proxy/pool/config', method: 'GET' },
+  'get_all_account_bindings': { url: '/api/proxy/pool/bindings', method: 'GET' },
+  'bind_account_proxy': { url: '/api/proxy/pool/bind', method: 'POST' },
+  'unbind_account_proxy': { url: '/api/proxy/pool/unbind', method: 'POST' },
+  'get_account_proxy_binding': { url: '/api/proxy/pool/binding/:accountId', method: 'GET' },
 };
 
 export async function request<T>(cmd: string, args?: any): Promise<T> {


### PR DESCRIPTION
## Changes

### Proxy Pool Binding Persistence
- Add `account_bindings` field to `ProxyPoolConfig` for persistence
- Load bindings from config on `ProxyPoolManager::new()`
- Auto-save bindings on bind/unbind operations

### Disabled Account Filtering
- Skip `proxy_disabled` accounts in `refresh_all_quotas_logic()`
- Skip `disabled` and `proxy_disabled` accounts in `warm_up_all_accounts()`
- Remove disabled accounts from token pool in `reload_account()`

### 403 Validation Block Status
- Add `validation_blocked`, `validation_blocked_until`, `validation_blocked_reason` fields to Account model
- Expose these fields in `AccountResponse` API

### Web Mode API
- Add proxy pool management endpoints:
  - GET /proxy/pool/config
  - GET /proxy/pool/bindings
  - POST /proxy/pool/bind
  - POST /proxy/pool/unbind
  - GET /proxy/pool/binding/:accountId
  - POST /proxy/health-check/trigger
- Add frontend command mappings in request.ts

### Docker
- Switch to `network_mode: host` for direct localhost proxy access

### Code Fixes
- Rename `ProxyConfig` to `PoolProxyConfig` in proxy_pool.rs to avoid naming conflict
- Export `ProxyPoolManager`, `get_global_proxy_pool`, `init_global_proxy_pool` from proxy module