### PR TITLE
feat: add Claude Opus 4.6 model support

### DIFF
--- a/src-tauri/src/proxy/common/model_mapping.rs
+++ b/src-tauri/src/proxy/common/model_mapping.rs
@@ -16,6 +16,12 @@ static CLAUDE_TO_GEMINI: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|
     m.insert("claude-3-5-sonnet-20240620", "claude-sonnet-4-5");
     m.insert("claude-opus-4", "claude-opus-4-5-thinking");
     m.insert("claude-opus-4-5-20251101", "claude-opus-4-5-thinking");
+
+    // Claude Opus 4.6 (new models - Feb 2026)
+    m.insert("claude-opus-4-6", "claude-opus-4-6");
+    m.insert("claude-opus-4-6-thinking", "claude-opus-4-6-thinking");
+    m.insert("claude-opus-4.6", "claude-opus-4-6");  // dot notation alias
+    m.insert("claude-opus-4.6-thinking", "claude-opus-4-6-thinking");
     m.insert("claude-haiku-4", "claude-sonnet-4-5");
     m.insert("claude-3-haiku-20240307", "claude-sonnet-4-5");
     m.insert("claude-haiku-4-5-20251001", "claude-sonnet-4-5");
@@ -252,6 +258,9 @@ pub fn normalize_to_standard_id(model_name: &str) -> Option<String> {
 
         // Claude 4.5 Sonnet Group
         "claude-sonnet-4-5" | "claude-sonnet-4-5-thinking" | "claude-opus-4-5-thinking" => Some("claude-sonnet-4-5".to_string()),
+
+        // Claude 4.6 Opus Group (new - Feb 2026)
+        "claude-opus-4-6" | "claude-opus-4-6-thinking" => Some("claude-opus-4-6".to_string()),
 
         _ => None
     }


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-6` and `claude-opus-4-6-thinking` to model mappings
- Support dot notation aliases (`claude-opus-4.6`, `claude-opus-4.6-thinking`)
- Add Opus 4.6 to quota protection normalization group

## Context
Claude Opus 4.6 has been spotted live on Google's servers (confirmed working via Antigravity proxy). This PR adds official support so the models appear in `/v1/models` endpoint.

## Test plan
- [x] Verified `claude-opus-4-6` works via proxy (returns response with reasoning_content)
- [x] Verified `claude-opus-4.6` dot notation works
- [x] `cargo check` passes
- [x] `cargo build --release` succeeds