### PR TITLE
fix: Web Mode 登录验证修复 & 登出按钮

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -104,6 +104,14 @@ pub fn run() {
                     // Force LAN access in headless/docker mode so it binds to 0.0.0.0
                     config.proxy.allow_lan_access = true;
 
+                    // [FIX] Force auth mode to AllExceptHealth in headless mode if it's Off or Auto
+                    // This ensures Web UI login validation works properly
+                    if matches!(config.proxy.auth_mode, crate::proxy::ProxyAuthMode::Off | crate::proxy::ProxyAuthMode::Auto) {
+                        info!("Headless mode: Forcing auth_mode to AllExceptHealth for Web UI security");
+                        config.proxy.auth_mode = crate::proxy::ProxyAuthMode::AllExceptHealth;
+                        modified = true;
+                    }
+
                     // [NEW] 支持通过环境变量注入 API Key
                     // 优先级：ABV_API_KEY > API_KEY > 配置文件
                     let env_key = std::env::var("ABV_API_KEY")

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -474,8 +474,10 @@ pub struct DeviceProfiles {
 }
 
 pub fn get_device_profiles(account_id: &str) -> Result<DeviceProfiles, String> {
-    let storage_path = crate::modules::device::get_storage_path()?;
-    let current = crate::modules::device::read_profile(&storage_path).ok();
+    // In headless/Docker mode, storage.json may not exist - handle gracefully
+    let current = crate::modules::device::get_storage_path()
+        .ok()
+        .and_then(|path| crate::modules::device::read_profile(&path).ok());
     let account = load_account(account_id)?;
     Ok(DeviceProfiles {
         current_storage: current,

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -2486,6 +2486,7 @@ async fn admin_preview_generate_profile(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct BindDeviceProfileWrapper {
+    #[serde(default)]
     account_id: String,
     #[serde(alias = "profile")]
     profile_wrapper: DeviceProfileApiWrapper,

--- a/src/components/accounts/DeviceFingerprintDialog.tsx
+++ b/src/components/accounts/DeviceFingerprintDialog.tsx
@@ -4,6 +4,7 @@ import { Wand2, RotateCcw, FolderOpen, Trash2, X } from 'lucide-react';
 import { Account, DeviceProfile, DeviceProfileVersion } from '../../types/account';
 import * as accountService from '../../services/accountService';
 import { useTranslation } from 'react-i18next';
+import { isTauri } from '../../utils/env';
 
 interface DeviceFingerprintDialogProps {
     account: Account | null;
@@ -180,9 +181,11 @@ export default function DeviceFingerprintDialog({ account, onClose }: DeviceFing
                             <button className="btn btn-xs btn-outline btn-error" disabled={loadingDevice || actionLoading === 'restore'} onClick={handleRestoreOriginalConfirm}>
                                 <RotateCcw size={14} className="mr-1" />{t('accounts.device_fingerprint_dialog.restore_original')}
                             </button>
-                            <button className="btn btn-xs btn-outline" disabled={actionLoading === 'open-folder'} onClick={handleOpenFolder}>
-                                <FolderOpen size={14} className="mr-1" />{t('accounts.device_fingerprint_dialog.open_storage_directory')}
-                            </button>
+                            {isTauri() && (
+                                <button className="btn btn-xs btn-outline" disabled={actionLoading === 'open-folder'} onClick={handleOpenFolder}>
+                                    <FolderOpen size={14} className="mr-1" />{t('accounts.device_fingerprint_dialog.open_storage_directory')}
+                                </button>
+                            )}
                         </div>
                     </div>
                     {actionMessage && <div className="text-xs text-blue-600 dark:text-blue-300">{actionMessage}</div>}

--- a/src/components/common/AdminAuthGuard.tsx
+++ b/src/components/common/AdminAuthGuard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Lock, Key, Globe } from 'lucide-react';
+import { Lock, Key, Globe, AlertCircle, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { isTauri } from '../../utils/env';
 
@@ -13,6 +13,8 @@ export const AdminAuthGuard: React.FC<{ children: React.ReactNode }> = ({ childr
     const [isAuthenticated, setIsAuthenticated] = useState(isTauri());
     const [apiKey, setApiKey] = useState('');
     const [showLangMenu, setShowLangMenu] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState('');
 
     useEffect(() => {
         if (isTauri()) return;
@@ -46,14 +48,48 @@ export const AdminAuthGuard: React.FC<{ children: React.ReactNode }> = ({ childr
         return () => window.removeEventListener('abv-unauthorized', handleUnauthorized);
     }, []);
 
-    const handleLogin = (e: React.FormEvent) => {
+    const handleLogin = async (e: React.FormEvent) => {
         e.preventDefault();
-        if (apiKey.trim()) {
-            sessionStorage.setItem('abv_admin_api_key', apiKey.trim());
-            // 确保旧的被清理
-            localStorage.removeItem('abv_admin_api_key');
-            setIsAuthenticated(true);
-            window.location.reload();
+        const trimmedKey = apiKey.trim();
+        if (!trimmedKey) return;
+
+        setIsLoading(true);
+        setError('');
+
+        try {
+            // 先临时存储 key，用于验证请求
+            sessionStorage.setItem('abv_admin_api_key', trimmedKey);
+
+            // 调用一个需要认证的 API 来验证密码是否正确
+            const response = await fetch('/api/accounts', {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${trimmedKey}`,
+                    'x-api-key': trimmedKey
+                }
+            });
+
+            if (response.ok || response.status === 204) {
+                // 验证成功
+                localStorage.removeItem('abv_admin_api_key');
+                setIsAuthenticated(true);
+                window.location.reload();
+            } else if (response.status === 401) {
+                // 密码错误
+                sessionStorage.removeItem('abv_admin_api_key');
+                setError(t('login.error_invalid_key'));
+            } else {
+                // 其他错误，但可能密码是对的
+                setIsAuthenticated(true);
+                window.location.reload();
+            }
+        } catch (err) {
+            // 网络错误等
+            sessionStorage.removeItem('abv_admin_api_key');
+            setError(t('login.error_network'));
+        } finally {
+            setIsLoading(false);
         }
     };
 
@@ -125,17 +161,32 @@ export const AdminAuthGuard: React.FC<{ children: React.ReactNode }> = ({ childr
                             <input
                                 type="password"
                                 placeholder={t('login.placeholder')}
-                                className="w-full pl-12 pr-4 py-4 bg-slate-50 dark:bg-base-200 border-none rounded-2xl focus:ring-2 focus:ring-blue-500 transition-all outline-none text-slate-900 dark:text-white"
+                                className={`w-full pl-12 pr-4 py-4 bg-slate-50 dark:bg-base-200 border-2 rounded-2xl focus:ring-2 focus:ring-blue-500 transition-all outline-none text-slate-900 dark:text-white ${error ? 'border-red-400' : 'border-transparent'}`}
                                 value={apiKey}
-                                onChange={(e) => setApiKey(e.target.value)}
+                                onChange={(e) => { setApiKey(e.target.value); setError(''); }}
                                 autoFocus
+                                disabled={isLoading}
                             />
                         </div>
+                        {error && (
+                            <div className="flex items-center gap-2 text-red-500 text-sm">
+                                <AlertCircle className="w-4 h-4" />
+                                <span>{error}</span>
+                            </div>
+                        )}
                         <button
                             type="submit"
-                            className="w-full py-4 bg-blue-500 hover:bg-blue-600 text-white font-bold rounded-2xl shadow-lg shadow-blue-500/30 transition-all active:scale-[0.98]"
+                            disabled={isLoading || !apiKey.trim()}
+                            className="w-full py-4 bg-blue-500 hover:bg-blue-600 disabled:bg-blue-300 disabled:cursor-not-allowed text-white font-bold rounded-2xl shadow-lg shadow-blue-500/30 transition-all active:scale-[0.98] flex items-center justify-center gap-2"
                         >
-                            {t('login.btn_login')}
+                            {isLoading ? (
+                                <>
+                                    <Loader2 className="w-5 h-5 animate-spin" />
+                                    {t('login.btn_verifying')}
+                                </>
+                            ) : (
+                                t('login.btn_login')
+                            )}
                         </button>
                     </form>
 

--- a/src/components/navbar/NavDropdowns.tsx
+++ b/src/components/navbar/NavDropdowns.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { ChevronDown, MoreVertical, Sun, Moon } from 'lucide-react';
+import { ChevronDown, MoreVertical, Sun, Moon, LogOut } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { NavItem, Language } from './constants';
+import { isTauri } from '../../utils/env';
 
 // useClickOutside Hook
 export function useClickOutside(
@@ -189,6 +190,12 @@ export function MoreDropdown({
         setIsOpen(false);
     };
 
+    const handleLogout = () => {
+        sessionStorage.removeItem('abv_admin_api_key');
+        localStorage.removeItem('abv_admin_api_key');
+        window.location.reload();
+    };
+
     return (
         <div className="min-[480px]:hidden relative" ref={menuRef}>
             <button
@@ -237,6 +244,20 @@ export function MoreDropdown({
                             )}
                         </button>
                     ))}
+
+                    {/* 登出按钮 - 仅 Web 模式显示 */}
+                    {!isTauri() && (
+                        <>
+                            <div className="my-1 border-t border-gray-100 dark:border-base-100"></div>
+                            <button
+                                onClick={handleLogout}
+                                className="w-full px-4 py-2.5 text-left text-sm flex items-center gap-3 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors text-red-600 dark:text-red-400"
+                            >
+                                <LogOut className="w-4 h-4" />
+                                <span>{t('nav.logout', '登出')}</span>
+                            </button>
+                        </>
+                    )}
                 </div>
             )}
         </div>

--- a/src/components/navbar/NavSettings.tsx
+++ b/src/components/navbar/NavSettings.tsx
@@ -1,7 +1,8 @@
-import { Sun, Moon } from 'lucide-react';
+import { Sun, Moon, LogOut } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { LanguageDropdown, MoreDropdown } from './NavDropdowns';
 import { LANGUAGES } from './constants';
+import { isTauri } from '../../utils/env';
 
 interface NavSettingsProps {
     theme: 'light' | 'dark';
@@ -24,6 +25,12 @@ export function NavSettings({
     onLanguageChange
 }: NavSettingsProps) {
     const { t } = useTranslation();
+
+    const handleLogout = () => {
+        sessionStorage.removeItem('abv_admin_api_key');
+        localStorage.removeItem('abv_admin_api_key');
+        window.location.reload();
+    };
 
     return (
         <>
@@ -48,6 +55,17 @@ export function NavSettings({
                     languages={LANGUAGES}
                     onLanguageChange={onLanguageChange}
                 />
+
+                {/* 登出按钮 - 仅 Web 模式显示 */}
+                {!isTauri() && (
+                    <button
+                        onClick={handleLogout}
+                        className="w-10 h-10 rounded-full bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 flex items-center justify-center transition-colors"
+                        title={t('nav.logout', '登出')}
+                    >
+                        <LogOut className="w-5 h-5 text-red-600 dark:text-red-400" />
+                    </button>
+                )}
             </div>
 
             {/* 更多菜单 (< 480px) */}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -78,7 +78,8 @@
         "switch_to_spanish": "Switch to Spanish",
         "switch_to_spanish_short": "ES",
         "switch_to_malay": "Switch to Malay",
-        "switch_to_malay_short": "MY"
+        "switch_to_malay_short": "MY",
+        "logout": "Logout"
     },
     "dashboard": {
         "hello": "Hello, User 👋",
@@ -1054,6 +1055,9 @@
         "desc": "Running in Web mode. Please enter management password or API Key to access.",
         "placeholder": "Enter management password or API Key",
         "btn_login": "Verify and Enter",
+        "btn_verifying": "Verifying...",
+        "error_invalid_key": "Invalid password or API Key, please try again",
+        "error_network": "Network connection failed, please check if the service is running",
         "note": "Note: If a separate management password is set, please enter it; otherwise, enter API_KEY.",
         "lookup_hint": "If forgotten, run docker logs antigravity-manager to find Current API Key or Web UI Password",
         "config_hint": "Or run grep -E '\"api_key\"|\"admin_password\"' ~/.antigravity_tools/gui_config.json to view."

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1067,6 +1067,9 @@
         "desc": "現在 Web モードで実行されています。管理パスワードまたは API キーを入力してアクセスしてください。",
         "placeholder": "管理パスワードまたは API キーを入力してください",
         "btn_login": "認証してアクセス",
+        "btn_verifying": "認証中...",
+        "error_invalid_key": "パスワードまたは API キーが無効です。再試行してください",
+        "error_network": "ネットワーク接続に失敗しました。サービスが実行中か確認してください",
         "note": "注意：独立した管理パスワードが設定されている場合は管理パスワードを入力してください。そうでない場合は API_KEY を入力してください。",
         "lookup_hint": "お忘れの場合は、docker logs antigravity-manager を実行して Current API Key または Web UI Password を探してください",
         "config_hint": "または grep -E '\"api_key\"|\"admin_password\"' ~/.antigravity_tools/gui_config.json を実行して確認してください。"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1004,6 +1004,9 @@
         "desc": "현재 Web 모드에서 실행 중입니다. 관리 비밀번호 또는 API 키를 입력하여 액세스하십시오.",
         "placeholder": "관리 비밀번호 또는 API 키를 입력하십시오",
         "btn_login": "인증 및 입장",
+        "btn_verifying": "인증 중...",
+        "error_invalid_key": "비밀번호 또는 API 키가 잘못되었습니다. 다시 시도하십시오",
+        "error_network": "네트워크 연결에 실패했습니다. 서비스가 실행 중인지 확인하십시오",
         "note": "참고: 별도의 관리 비밀번호가 설정된 경우 관리 비밀번호를 입력하십시오. 그렇지 않으면 API_KEY를 입력하십시오.",
         "lookup_hint": "잊으신 경우 docker logs antigravity-manager를 실행하여 Current API Key 또는 Web UI Password를 찾으십시오.",
         "config_hint": "또는 grep -E '\"api_key\"|\"admin_password\"' ~/.antigravity_tools/gui_config.json을 실행하여 확인하십시오."

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -1000,6 +1000,9 @@
         "desc": "當前運行在 Web 模式下，請輸入管理密碼或 API Key 以進入後台。",
         "placeholder": "請輸入管理密碼或 API Key",
         "btn_login": "驗證並進入",
+        "btn_verifying": "驗證中...",
+        "error_invalid_key": "密碼或 API Key 錯誤，請重試",
+        "error_network": "網路連線失敗，請檢查服務是否正常運行",
         "note": "注意：如果設置了獨立的管理密碼，請輸入管理密碼；否則請輸入 API_KEY。",
         "lookup_hint": "如果您忘記了，請運行 docker logs antigravity-manager 尋找 Current API Key 或 Web UI Password",
         "config_hint": "或執行 grep -E '\"api_key\"|\"admin_password\"' ~/.antigravity_tools/gui_config.json 查看。"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -75,7 +75,8 @@
         "switch_to_spanish": "切换到西班牙语",
         "switch_to_spanish_short": "ES",
         "switch_to_malay": "切换到马来语",
-        "switch_to_malay_short": "MY"
+        "switch_to_malay_short": "MY",
+        "logout": "登出"
     },
     "dashboard": {
         "hello": "你好, 用户 👋",
@@ -1017,6 +1018,9 @@
         "desc": "当前运行在 Web 模式下，请输入管理密码或 API Key 以进入后台。",
         "placeholder": "请输入管理密码或 API Key",
         "btn_login": "验证并进入",
+        "btn_verifying": "验证中...",
+        "error_invalid_key": "密码或 API Key 错误，请重试",
+        "error_network": "网络连接失败，请检查服务是否正常运行",
         "note": "注意：如果设置了独立的管理密码，请输入管理密码；否则请输入 API_KEY。",
         "lookup_hint": "如果您忘记了，请运行 docker logs antigravity-manager 寻找 Current API Key 或 Web UI Password",
         "config_hint": "或执行 grep -E '\"api_key\"|\"admin_password\"' ~/.antigravity_tools/gui_config.json 查看。"


### PR DESCRIPTION
## 概述

本次修复主要解决 Docker/Web 模式下的登录验证问题和用户体验优化，包括登录密码后端验证、强制鉴权模式、登出按钮、以及隐藏不支持的功能按钮。

---

## 主要修复

### 1. Web 登录验证修复 (Issue: 任意密码可进入)

**问题**: Web 模式下输入任意密码都可以进入管理界面，没有真正验证密码

**修复**:
- `AdminAuthGuard.tsx` 添加后端密码验证逻辑
- 登录时调用 `/api/accounts` API 验证密码是否正确
- 添加加载状态和错误提示

---

### 2. Headless 模式强制鉴权 (Issue: auth_mode=Off 时无需密码)

**问题**: 当 `auth_mode` 设置为 `Off` 或 `Auto` 时，Web UI 不需要密码即可访问

**修复**:
- `lib.rs` 在 headless 模式下强制 `auth_mode = AllExceptHealth`
- 确保 Web UI 始终需要密码验证

---

### 3. Web 模式登出按钮

**问题**: Web 模式下没有登出功能，用户无法切换账号

**修复**:
- `NavSettings.tsx` 添加登出按钮（桌面视图）
- `NavDropdowns.tsx` 添加登出选项（移动端下拉菜单）
- 仅在 Web 模式下显示（`!isTauri()`）

---

### 4. 隐藏不支持的功能

**问题**: Web/Docker 模式下"打开文件夹"按钮会报 500 错误

**修复**:
- `DeviceFingerprintDialog.tsx` 添加 `isTauri()` 检查
- Web 模式下隐藏"打开存储目录"按钮

---

### 5. 设备指纹绑定修复

**问题**: Docker 模式下设备指纹绑定返回 422 错误

**修复**:
- `server.rs` 修复 `bind_device_profile` 参数解析
- `account.rs` 修复 `get_device_profiles` Docker 兼容性

---

## 修改文件

| 文件 | 改动 |
|------|------|
| `src-tauri/src/lib.rs` | Headless 模式强制鉴权 |
| `src-tauri/src/modules/account.rs` | Docker 模式设备指纹修复 |
| `src-tauri/src/proxy/server.rs` | 绑定设备指纹参数修复 |
| `src/components/common/AdminAuthGuard.tsx` | 后端密码验证 |
| `src/components/navbar/NavSettings.tsx` | 登出按钮（桌面） |
| `src/components/navbar/NavDropdowns.tsx` | 登出按钮（移动端） |
| `src/components/accounts/DeviceFingerprintDialog.tsx` | 隐藏不支持功能 |
| `src/locales/*.json` | 添加翻译 |

---

## 测试建议

- [ ] Docker 构建并运行
- [ ] Web 模式登录验证（正确/错误密码）
- [ ] Web 模式登出功能
- [ ] 设备指纹绑定功能
- [ ] 桌面端功能验证