### PR TITLE
fix: 403 账号轮换修复

### DIFF
--- a/src-tauri/src/proxy/handlers/claude.rs
+++ b/src-tauri/src/proxy/handlers/claude.rs
@@ -1094,8 +1094,33 @@ pub async fn handle_messages(
         // 5. 统一处理所有可重试错误
         // [REMOVED] 不再特殊处理 QUOTA_EXHAUSTED,允许账号轮换
         // 原逻辑会在第一个账号配额耗尽时直接返回,导致"平衡"模式无法切换账号
-        
-        
+
+        // [FIX] 403 时设置 is_forbidden 状态，避免账号被重复选中
+        if status_code == 403 {
+            // Check for VALIDATION_REQUIRED error - temporarily block account
+            if error_text.contains("VALIDATION_REQUIRED") ||
+               error_text.contains("verify your account") ||
+               error_text.contains("validation_url")
+            {
+                tracing::warn!(
+                    "[Claude] VALIDATION_REQUIRED detected on account {}, temporarily blocking",
+                    email
+                );
+                let block_minutes = 10i64;
+                let block_until = chrono::Utc::now().timestamp() + (block_minutes * 60);
+                if let Err(e) = token_manager.set_validation_block_public(&account_id, block_until, &error_text).await {
+                    tracing::error!("Failed to set validation block: {}", e);
+                }
+            }
+
+            // 设置 is_forbidden 状态
+            if let Err(e) = token_manager.set_forbidden(&account_id, &error_text).await {
+                tracing::error!("Failed to set forbidden status for {}: {}", email, e);
+            } else {
+                tracing::warn!("[Claude] Account {} marked as forbidden due to 403", email);
+            }
+        }
+
         // 确定重试策略
         let strategy = determine_retry_strategy(status_code, &error_text, retried_without_thinking);
         
@@ -1150,7 +1175,14 @@ pub async fn handle_messages(
             _ => "api_error",
         };
 
-        (last_status, headers, Json(json!({
+        // [FIX] 403 时返回 503，避免 Claude Code 客户端退出到登录页
+        let response_status = if last_status.as_u16() == 403 {
+            StatusCode::SERVICE_UNAVAILABLE
+        } else {
+            last_status
+        };
+
+        (response_status, headers, Json(json!({
             "type": "error",
             "error": {
                 "id": "err_retry_exhausted",
@@ -1166,7 +1198,7 @@ pub async fn handle_messages(
                 headers.insert("X-Mapped-Model", v);
              }
         }
-        
+
         let error_type = match last_status.as_u16() {
             400 => "invalid_request_error",
             401 => "authentication_error",
@@ -1176,7 +1208,14 @@ pub async fn handle_messages(
             _ => "api_error",
         };
 
-        (last_status, headers, Json(json!({
+        // [FIX] 403 时返回 503，避免 Claude Code 客户端退出到登录页
+        let response_status = if last_status.as_u16() == 403 {
+            StatusCode::SERVICE_UNAVAILABLE
+        } else {
+            last_status
+        };
+
+        (response_status, headers, Json(json!({
             "type": "error",
             "error": {
                 "id": "err_retry_exhausted",

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -2405,6 +2405,9 @@ impl TokenManager {
         std::fs::write(&path, json_str)
             .map_err(|e| format!("Failed to write account file: {}", e))?;
 
+        // [FIX] 从内存池中移除账号，避免重试时再次选中
+        self.remove_account(account_id);
+
         tracing::warn!(
             "🚫 Account {} marked as forbidden (403): {}",
             account_id,


### PR DESCRIPTION
## 问题描述
1. 账号返回 403 后仍被重复选中
2. 403 错误导致 Claude Code 客户端退出到登录页

## 修复内容

### claude.rs
- 403 时调用 set_forbidden 标记账号
- 403 时返回 503 状态码，避免客户端退出登录

### token_manager.rs
- set_forbidden 后调用 remove_account 从内存池移除