### PR TITLE
feat(accounts): add custom label support for accounts

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -784,7 +784,9 @@ pub async fn toggle_proxy_status(
     }
 
     // 3. 保存到磁盘
-    std::fs::write(&account_path, serde_json::to_string_pretty(&account_json).unwrap())
+    let json_str = serde_json::to_string_pretty(&account_json)
+        .map_err(|e| format!("序列化账号数据失败: {}", e))?;
+    std::fs::write(&account_path, json_str)
         .map_err(|e| format!("写入账号文件失败: {}", e))?;
 
     modules::logger::log_info(&format!(
@@ -844,6 +846,11 @@ pub async fn update_account_label(
     account_id: String,
     label: String,
 ) -> Result<(), String> {
+    // 验证标签长度（按字符数计算，支持中文）
+    if label.chars().count() > 15 {
+        return Err("标签长度不能超过15个字符".to_string());
+    }
+
     modules::logger::log_info(&format!(
         "更新账号标签: {} -> {:?}",
         account_id,
@@ -872,7 +879,9 @@ pub async fn update_account_label(
     }
 
     // 3. 保存到磁盘
-    std::fs::write(&account_path, serde_json::to_string_pretty(&account_json).unwrap())
+    let json_str = serde_json::to_string_pretty(&account_json)
+        .map_err(|e| format!("序列化账号数据失败: {}", e))?;
+    std::fs::write(&account_path, json_str)
         .map_err(|e| format!("写入账号文件失败: {}", e))?;
 
     modules::logger::log_info(&format!(

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -242,7 +242,7 @@ function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, is
                                 onChange={(e) => setLabelInput(e.target.value)}
                                 onKeyDown={handleKeyDown}
                                 autoFocus
-                                maxLength={20}
+                                maxLength={15}
                             />
                             <button
                                 className="p-1.5 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/30 rounded-lg transition-all"

--- a/src/components/accounts/AccountTable.tsx
+++ b/src/components/accounts/AccountTable.tsx
@@ -429,7 +429,7 @@ function AccountRowContent({
                                     onChange={(e) => setLabelInput(e.target.value)}
                                     onKeyDown={handleKeyDown}
                                     autoFocus
-                                    maxLength={20}
+                                    maxLength={15}
                                     onClick={(e) => e.stopPropagation()}
                                 />
                                 <button


### PR DESCRIPTION
  ## Summary
  - Add custom label field for accounts, displayed as orange badge next to subscription type (ULTRA/PRO/FREE)
  - Support inline editing of labels in both card and table views
  - Persist labels to account JSON files

  ## Changes
  - Frontend: AccountCard, AccountTable, AccountGrid components
  - Backend: Rust command `update_account_label`
  - i18n: Added zh/en translations

  ## Test plan
  - [x] Add a custom label to an account in card view
  - [x] Add a custom label to an account in table view
  - [x] Verify label persists after app restart
  - [x] Verify label displays correctly in both views
  
  
<img width="2280" height="1830" alt="d771bca45e7f7160000a00470c75cb68" src="https://github.com/user-attachments/assets/1e2bbaab-ea9d-4d77-862c-57f116f6915b" />

<img width="2280" height="1354" alt="image" src="https://github.com/user-attachments/assets/6864bdce-8686-40f5-97b1-9b6f848940fd" />
