### PR TITLE
fix: resolve clipboard error in UserToken page

### DIFF
--- a/src/pages/UserToken.tsx
+++ b/src/pages/UserToken.tsx
@@ -4,6 +4,7 @@ import { Plus, Trash2, RefreshCw, Copy, Activity, User, Settings, Shield, Clock,
 import { motion, AnimatePresence } from 'framer-motion';
 import { request as invoke } from '../utils/request';
 import { showToast } from '../components/common/ToastContainer';
+import { copyToClipboard } from '../utils/clipboard';
 
 interface UserToken {
     id: string;
@@ -173,9 +174,13 @@ const UserToken: React.FC = () => {
         }
     };
 
-    const copyToClipboard = (text: string) => {
-        navigator.clipboard.writeText(text);
-        showToast(t('common.copied') || 'Copied to clipboard', 'success');
+    const handleCopyToken = async (text: string) => {
+        const success = await copyToClipboard(text);
+        if (success) {
+            showToast(t('common.copied') || 'Copied to clipboard', 'success');
+        } else {
+            showToast(t('common.copy_failed') || 'Failed to copy to clipboard', 'error');
+        }
     };
 
     const formatTime = (ts?: number) => {
@@ -332,7 +337,7 @@ const UserToken: React.FC = () => {
                                                 {token.token.substring(0, 8)}••••••••
                                             </code>
                                             <button
-                                                onClick={() => copyToClipboard(token.token)}
+                                                onClick={() => handleCopyToken(token.token)}
                                                 className="p-1.5 hover:bg-gray-200 dark:hover:bg-base-300 rounded-md transition-all text-gray-400 hover:text-gray-600 dark:hover:text-white"
                                             >
                                                 <Copy size={13} />


### PR DESCRIPTION
## Summary
修复用户令牌页面的剪贴板错误

## Problem
- 修复了 "Cannot read properties of undefined (reading 'writeText')" 错误
- 在非 HTTPS 环境（如通过 Docker IP 访问 http://192.168.x.x:8045）下，直接调用 `navigator.clipboard.writeText()` 会失败，因为 Clipboard API 仅在安全上下文（HTTPS 或 localhost）中可用

## Solution
- 使用已有的 `copyToClipboard` 工具函数（位于 `src/utils/clipboard.ts`）替代直接调用 `navigator.clipboard`
- 该工具函数提供了健壮的 fallback 机制：
  1. 优先尝试现代 Clipboard API（需要安全上下文）
  2. 失败时自动回退到 `document.execCommand('copy')`（兼容 HTTP 环境）
- 添加了成功/失败的 toast 提示，提升用户体验

## Changes
- Import `copyToClipboard` from `utils/clipboard`
- Replace local `copyToClipboard` function with `handleCopyToken` async handler
- Add proper error handling with success/failure toast notifications
- Update copy button onClick handler to use the new async function

## Test Plan
- [x] Tested in HTTPS context - clipboard copy works correctly
- [x] Tested in HTTP context (Docker IP access) - fallback mechanism works
- [x] Verified success/error toast notifications display correctly

## Technical Details
The fix leverages the existing robust clipboard utility that handles both secure and non-secure contexts, ensuring the application works reliably whether accessed via HTTPS or HTTP (common in Docker deployments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)