### PR TITLE
修正 README.md 中的"思思维链"为"思维链"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 ### 3. 🔌 协议转换与中继 (API Proxy)
 *   **全协议适配 (Multi-Sink)**:
     *   **OpenAI 格式**: 提供 `/v1/chat/completions` 端点，兼容 99% 的现有 AI 应用。
-    *   **Anthropic 格式**: 提供原生 `/v1/messages` 接口，支持 **Claude Code CLI** 的全功能（如思思维链、系统提示词）。
+    *   **Anthropic 格式**: 提供原生 `/v1/messages` 接口，支持 **Claude Code CLI** 的全功能（如思维链、系统提示词）。
     *   **Gemini 格式**: 支持 Google 官方 SDK 直接调用。
 *   **智能状态自愈**: 当请求遇到 `429 (Too Many Requests)` 或 `401 (Expire)` 时，后端会毫秒级触发 **自动重试与静默轮换**，确保业务不中断。
 


### PR DESCRIPTION
## 📝 修改说明

将 README.md 中出现的 "思思维链" 一词更正为 "思维链"，以与行业通用术语（Chain-of-Thought）保持一致。

## 🔍 修改详情

- **文件**: README.md
- **位置**: 第 71 行
- **类型**: 文档修正（错别字修复）
- **影响**: 仅文档，不影响代码或功能

## 📊 修改内容

```diff
- **Anthropic 格式**: 提供原生 `/v1/messages` 接口，支持 **Claude Code CLI** 的全功能（如思思维链、系统提示词）。
+ **Anthropic 格式**: 提供原生 `/v1/messages` 接口，支持 **Claude Code CLI** 的全功能（如思维链、系统提示词）。