### PR TITLE
Pin Rust build image to bookworm to fix GLIBC_2.39 mismatch (fix #1686)   

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN npm run build
 
 # --- Backend Build Stage ---
-FROM rust:1-slim AS backend-builder
+FROM rust:1-slim-bookworm AS backend-builder
 ARG USE_MIRROR=auto
 
 # Conditionally use Aliyun mirror for APT


### PR DESCRIPTION
`rust:1-slim` is a rolling tag that recently moved to a Debian base with glibc 2.39, while the runtime stage uses `debian:bookworm-slim` (glibc 2.36). The dynamically linked binary fails at startup:

```
/app/antigravity-tools: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

- Pin build stage from `rust:1-slim` → `rust:1-slim-bookworm` to match the runtime image's glibc version 


Fix #1686 