### PR TITLE
feat: add Volta bin path support for CLI detection

### DIFF
--- a/src-tauri/src/proxy/cli_sync.rs
+++ b/src-tauri/src/proxy/cli_sync.rs
@@ -123,6 +123,7 @@ pub fn check_cli_installed(app: &CliApp) -> (bool, Option<String>) {
         let mut common_paths = vec![
             home.join(".local/bin"),
             home.join(".npm-global/bin"),
+            home.join(".volta/bin"),
             home.join("bin"),
             PathBuf::from("/opt/homebrew/bin"),
             PathBuf::from("/usr/local/bin"),

--- a/src-tauri/src/proxy/opencode_sync.rs
+++ b/src-tauri/src/proxy/opencode_sync.rs
@@ -196,6 +196,7 @@ fn resolve_opencode_path_unix() -> Option<PathBuf> {
     let user_bins = [
         home.join(".local").join("bin").join("opencode"),
         home.join(".npm-global").join("bin").join("opencode"),
+        home.join(".volta").join("bin").join("opencode"),
         home.join("bin").join("opencode"),
     ];
     


### PR DESCRIPTION
- Add ~/.volta/bin to CLI search paths in cli_sync.rs
- Add ~/.volta/bin to OpenCode path resolution in opencode_sync.rs
- Improves detection of CLI tools installed via Volta package manager