### PR TITLE
fix: Encapsulate user token creation parameters in request object

### DIFF
--- a/src/pages/UserToken.tsx
+++ b/src/pages/UserToken.tsx
@@ -89,12 +89,14 @@ const UserToken: React.FC = () => {
         setCreating(true);
         try {
             await invoke('create_user_token', {
-                username: newUsername,
-                expires_type: newExpiresType,
-                description: newDesc || undefined,
-                max_ips: newMaxIps,
-                curfew_start: newCurfewStart || undefined,
-                curfew_end: newCurfewEnd || undefined
+                request: {
+                    username: newUsername,
+                    expires_type: newExpiresType,
+                    description: newDesc || undefined,
+                    max_ips: newMaxIps,
+                    curfew_start: newCurfewStart || undefined,
+                    curfew_end: newCurfewEnd || undefined
+                }
             });
             showToast(t('common.create_success') || 'Created successfully', 'success');
             setShowCreateModal(false);


### PR DESCRIPTION
<img width="835" height="63" alt="image" src="https://github.com/user-attachments/assets/e5fb2e31-7646-4dce-9baa-e7ef1d0d4b34" />
