### PR TITLE
feat(user-token): add custom expiration time and fix edit data sync

### DIFF
--- a/docs/fix-opus-ultra-priority.md
+++ b/docs/fix-opus-ultra-priority.md
@@ -1,0 +1,49 @@
+# 修复 Opus 4.6 调用报错 & UserToken 显示优化
+
+## 问题
+
+号池混着 Pro 和 Ultra 账号。Pro 没有 Opus 4.6 权限，Ultra 有。
+
+之前轮询按配额高低选账号，不管订阅等级。用户调 Opus 4.6 时，系统可能选到 Pro 账号，直接报错。
+
+## 改动
+
+### 1. Ultra 优先调度
+
+调 Opus 4.6/4.5 时，先按订阅等级排序：
+
+```
+Ultra > Pro > Free
+```
+
+同等级再按配额排。其他模型还是老逻辑，配额优先。
+
+匹配规则：模型名包含 `claude-opus-4-6`、`claude-opus-4-5` 或 `opus` 就走 Ultra 优先。
+
+### 2. UserToken 编辑数据不显示
+
+点编辑 Token 时，IP 限制和宵禁时间显示空的。
+
+问题：
+- 前端传参用 `undefined`，Rust 需要 `null`
+- 读取用 `||`，0 和空字符串被吃掉了，改成 `??`
+
+### 3. 自定义过期时间
+
+创建 Token 多了个 Custom 选项，选日期时间，精确到小时。
+
+## 文件
+
+```
+src-tauri/src/proxy/token_manager.rs      # 排序逻辑
+src-tauri/src/proxy/tests/mod.rs          # 测试模块
+src-tauri/src/proxy/tests/ultra_priority_tests.rs  # Ultra 优先测试
+src-tauri/src/commands/user_token.rs      # 自定义过期参数
+src-tauri/src/modules/user_token_db.rs    # 数据库
+src/pages/UserToken.tsx                   # 前端
+```
+
+## 验证
+
+1. 调 Opus 4.6，看日志确认走的是 Ultra 账号
+2. 创建 Token 设置 IP 限制和宵禁，编辑时确认数据正常回显

--- a/src-tauri/src/commands/user_token.rs
+++ b/src-tauri/src/commands/user_token.rs
@@ -10,6 +10,7 @@ pub struct CreateTokenRequest {
     pub max_ips: i32,
     pub curfew_start: Option<String>,
     pub curfew_end: Option<String>,
+    pub custom_expires_at: Option<i64>,  // 自定义过期时间戳 (秒)
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -40,6 +41,7 @@ pub async fn create_user_token(request: CreateTokenRequest) -> Result<UserToken,
         request.max_ips,
         request.curfew_start,
         request.curfew_end,
+        request.custom_expires_at,
     )
 }
 

--- a/src-tauri/src/modules/user_token_db.rs
+++ b/src-tauri/src/modules/user_token_db.rs
@@ -149,7 +149,8 @@ pub fn create_token(
     description: Option<String>,
     max_ips: i32,
     curfew_start: Option<String>,
-    curfew_end: Option<String>
+    curfew_end: Option<String>,
+    custom_expires_at: Option<i64>  // 自定义过期时间戳 (秒)
 ) -> Result<UserToken, String> {
     let conn = connect_db()?;
     let id = Uuid::new_v4().to_string();
@@ -160,6 +161,7 @@ pub fn create_token(
         "day" => Some(Utc::now().checked_add_signed(chrono::Duration::days(1)).unwrap().timestamp()),
         "week" => Some(Utc::now().checked_add_signed(chrono::Duration::weeks(1)).unwrap().timestamp()),
         "month" => Some(Utc::now().checked_add_signed(chrono::Duration::days(30)).unwrap().timestamp()),
+        "custom" => custom_expires_at, // 使用自定义时间戳
         _ => None, // "never" or other
     };
 

--- a/src-tauri/src/proxy/tests/mod.rs
+++ b/src-tauri/src/proxy/tests/mod.rs
@@ -2,3 +2,4 @@ pub mod comprehensive;
 pub mod security_ip_tests;
 pub mod security_integration_tests;
 pub mod quota_protection;
+pub mod ultra_priority_tests;

--- a/src-tauri/src/proxy/tests/ultra_priority_tests.rs
+++ b/src-tauri/src/proxy/tests/ultra_priority_tests.rs
@@ -1,0 +1,220 @@
+//! Ultra Priority Tests for High-End Models (Opus 4.6/4.5)
+//!
+//! 这些测试验证高端模型（如 Claude Opus 4.6/4.5）优先使用 Ultra 账号的逻辑。
+//!
+//! ## 背景
+//! 用户的账号池包含大量 Gemini Pro 账号和少量 Ultra 账号。当请求 Claude Opus 4.6 模型时，
+//! 系统按配额优先的策略可能会选择 Pro 账号，但 Pro 账号无法访问 Opus 4.6，导致 API 返回错误。
+//!
+//! ## 解决方案
+//! 当用户请求高端模型时，优先选择 Ultra 账号；只有 Ultra 账号都不可用时才降级到 Pro/Free 账号。
+//!
+//! ## 测试覆盖
+//! - `test_is_ultra_required_model`: 验证模型识别逻辑
+//! - `test_ultra_priority_for_high_end_models`: 验证 Ultra 优先于 Pro（即使 Pro 配额更高）
+//! - `test_ultra_accounts_sorted_by_quota`: 验证同为 Ultra 时按配额排序
+//! - `test_full_sorting_mixed_accounts`: 验证混合账号池的完整排序
+
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+
+use crate::proxy::token_manager::ProxyToken;
+
+/// 创建测试用的 ProxyToken
+fn create_test_token(
+    email: &str,
+    tier: Option<&str>,
+    health_score: f32,
+    reset_time: Option<i64>,
+    remaining_quota: Option<i32>,
+) -> ProxyToken {
+    ProxyToken {
+        account_id: email.to_string(),
+        access_token: "test_token".to_string(),
+        refresh_token: "test_refresh".to_string(),
+        expires_in: 3600,
+        timestamp: chrono::Utc::now().timestamp() + 3600,
+        email: email.to_string(),
+        account_path: PathBuf::from("/tmp/test"),
+        project_id: None,
+        subscription_tier: tier.map(|s| s.to_string()),
+        remaining_quota,
+        protected_models: HashSet::new(),
+        health_score,
+        reset_time,
+        validation_blocked: false,
+        validation_blocked_until: 0,
+        model_quotas: HashMap::new(),
+    }
+}
+
+/// 需要 Ultra 账号的高端模型列表
+const ULTRA_REQUIRED_MODELS: &[&str] = &[
+    "claude-opus-4-6",
+    "claude-opus-4-5",
+    "opus", // 通配匹配
+];
+
+/// 检查模型是否需要 Ultra 账号
+fn is_ultra_required_model(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    ULTRA_REQUIRED_MODELS.iter().any(|m| lower.contains(m))
+}
+
+/// 测试 is_ultra_required_model 辅助函数
+#[test]
+fn test_is_ultra_required_model() {
+    // 应该识别为高端模型
+    assert!(is_ultra_required_model("claude-opus-4-6"));
+    assert!(is_ultra_required_model("claude-opus-4-5"));
+    assert!(is_ultra_required_model("Claude-Opus-4-6")); // 大小写不敏感
+    assert!(is_ultra_required_model("CLAUDE-OPUS-4-5")); // 大小写不敏感
+    assert!(is_ultra_required_model("opus")); // 通配匹配
+    assert!(is_ultra_required_model("opus-4-6-latest"));
+    assert!(is_ultra_required_model("models/claude-opus-4-6"));
+
+    // 应该识别为普通模型
+    assert!(!is_ultra_required_model("claude-sonnet-4-5"));
+    assert!(!is_ultra_required_model("claude-sonnet"));
+    assert!(!is_ultra_required_model("gemini-1.5-flash"));
+    assert!(!is_ultra_required_model("gemini-2.0-pro"));
+    assert!(!is_ultra_required_model("claude-haiku"));
+}
+
+/// 模拟 token_manager.rs 中的排序逻辑
+fn compare_tokens_for_model(a: &ProxyToken, b: &ProxyToken, target_model: &str) -> Ordering {
+    let requires_ultra = is_ultra_required_model(target_model);
+
+    let tier_priority = |tier: &Option<String>| {
+        let t = tier.as_deref().unwrap_or("").to_lowercase();
+        if t.contains("ultra") { 0 }
+        else if t.contains("pro") { 1 }
+        else if t.contains("free") { 2 }
+        else { 3 }
+    };
+
+    // Priority 0: 高端模型时，订阅等级优先
+    if requires_ultra {
+        let tier_cmp = tier_priority(&a.subscription_tier)
+            .cmp(&tier_priority(&b.subscription_tier));
+        if tier_cmp != Ordering::Equal {
+            return tier_cmp;
+        }
+    }
+
+    // Priority 1: Quota (higher is better)
+    let quota_a = a.remaining_quota.unwrap_or(0);
+    let quota_b = b.remaining_quota.unwrap_or(0);
+    let quota_cmp = quota_b.cmp(&quota_a);
+    if quota_cmp != Ordering::Equal {
+        return quota_cmp;
+    }
+
+    // Priority 2: Health score
+    let health_cmp = b.health_score.partial_cmp(&a.health_score)
+        .unwrap_or(Ordering::Equal);
+    if health_cmp != Ordering::Equal {
+        return health_cmp;
+    }
+
+    // Priority 3: Tier (for non-high-end models)
+    if !requires_ultra {
+        let tier_cmp = tier_priority(&a.subscription_tier)
+            .cmp(&tier_priority(&b.subscription_tier));
+        if tier_cmp != Ordering::Equal {
+            return tier_cmp;
+        }
+    }
+
+    Ordering::Equal
+}
+
+/// 测试高端模型排序：Ultra 账号优先于 Pro 账号（即使 Pro 配额更高）
+#[test]
+fn test_ultra_priority_for_high_end_models() {
+    // 创建测试账号：Ultra 低配额 vs Pro 高配额
+    let ultra_low_quota = create_test_token("ultra@test.com", Some("ULTRA"), 1.0, None, Some(20));
+    let pro_high_quota = create_test_token("pro@test.com", Some("PRO"), 1.0, None, Some(80));
+
+    // 高端模型 (Opus 4.6): Ultra 应该优先，即使配额低
+    assert_eq!(
+        compare_tokens_for_model(&ultra_low_quota, &pro_high_quota, "claude-opus-4-6"),
+        Ordering::Less, // Ultra 排在前面
+        "Opus 4.6 should prefer Ultra account over Pro even with lower quota"
+    );
+
+    // 高端模型 (Opus 4.5): Ultra 应该优先
+    assert_eq!(
+        compare_tokens_for_model(&ultra_low_quota, &pro_high_quota, "claude-opus-4-5"),
+        Ordering::Less,
+        "Opus 4.5 should prefer Ultra account over Pro"
+    );
+
+    // 普通模型 (Sonnet): 高配额 Pro 应该优先
+    assert_eq!(
+        compare_tokens_for_model(&ultra_low_quota, &pro_high_quota, "claude-sonnet-4-5"),
+        Ordering::Greater, // Pro (高配额) 排在前面
+        "Sonnet should prefer high-quota Pro over low-quota Ultra"
+    );
+
+    // 普通模型 (Flash): 高配额 Pro 应该优先
+    assert_eq!(
+        compare_tokens_for_model(&ultra_low_quota, &pro_high_quota, "gemini-1.5-flash"),
+        Ordering::Greater,
+        "Flash should prefer high-quota Pro over low-quota Ultra"
+    );
+}
+
+/// 测试排序：同为 Ultra 时按配额排序
+#[test]
+fn test_ultra_accounts_sorted_by_quota() {
+    let ultra_high = create_test_token("ultra_high@test.com", Some("ULTRA"), 1.0, None, Some(80));
+    let ultra_low = create_test_token("ultra_low@test.com", Some("ULTRA"), 1.0, None, Some(20));
+
+    // Opus 4.6: 同为 Ultra，高配额优先
+    assert_eq!(
+        compare_tokens_for_model(&ultra_high, &ultra_low, "claude-opus-4-6"),
+        Ordering::Less, // ultra_high 排在前面
+        "Among Ultra accounts, higher quota should come first"
+    );
+}
+
+/// 测试完整排序场景：混合账号池
+#[test]
+fn test_full_sorting_mixed_accounts() {
+    fn sort_tokens_for_model(tokens: &mut Vec<ProxyToken>, target_model: &str) {
+        tokens.sort_by(|a, b| compare_tokens_for_model(a, b, target_model));
+    }
+
+    // 创建混合账号池
+    let ultra_high = create_test_token("ultra_high@test.com", Some("ULTRA"), 1.0, None, Some(80));
+    let ultra_low = create_test_token("ultra_low@test.com", Some("ULTRA"), 1.0, None, Some(20));
+    let pro_high = create_test_token("pro_high@test.com", Some("PRO"), 1.0, None, Some(90));
+    let pro_low = create_test_token("pro_low@test.com", Some("PRO"), 1.0, None, Some(30));
+    let free = create_test_token("free@test.com", Some("FREE"), 1.0, None, Some(100));
+
+    // 高端模型 (Opus 4.6) 排序
+    let mut tokens_opus = vec![pro_high.clone(), free.clone(), ultra_low.clone(), pro_low.clone(), ultra_high.clone()];
+    sort_tokens_for_model(&mut tokens_opus, "claude-opus-4-6");
+
+    let emails_opus: Vec<&str> = tokens_opus.iter().map(|t| t.email.as_str()).collect();
+    // 期望顺序: Ultra(高配额) > Ultra(低配额) > Pro(高配额) > Pro(低配额) > Free
+    assert_eq!(
+        emails_opus,
+        vec!["ultra_high@test.com", "ultra_low@test.com", "pro_high@test.com", "pro_low@test.com", "free@test.com"],
+        "Opus 4.6 should sort Ultra first, then by quota within each tier"
+    );
+
+    // 普通模型 (Sonnet) 排序
+    let mut tokens_sonnet = vec![pro_high.clone(), free.clone(), ultra_low.clone(), pro_low.clone(), ultra_high.clone()];
+    sort_tokens_for_model(&mut tokens_sonnet, "claude-sonnet-4-5");
+
+    let emails_sonnet: Vec<&str> = tokens_sonnet.iter().map(|t| t.email.as_str()).collect();
+    // 期望顺序: Free(100%) > Pro(90%) > Ultra(80%) > Pro(30%) > Ultra(20%) - 按配额优先
+    assert_eq!(
+        emails_sonnet,
+        vec!["free@test.com", "pro_high@test.com", "ultra_high@test.com", "pro_low@test.com", "ultra_low@test.com"],
+        "Sonnet should sort by quota first, then by tier as tiebreaker"
+    );
+}

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -1005,13 +1005,46 @@ impl TokenManager {
         // 优先级: 目标模型配额 > 健康分 > 订阅等级 > 刷新时间
         // -> 高配额账号优先被选中，避免 PRO/ULTRA 先用完丢失5小时刷新周期
         // [FIX] 使用目标模型的 quota 而非 max(所有模型)
+        // [NEW] 高端模型 (Opus 4.6/4.5) 优先使用 Ultra 账号
         const RESET_TIME_THRESHOLD_SECS: i64 = 600; // 10 分钟阈值，差异小于此值视为相同
+
+        // 需要 Ultra 账号才能访问的高端模型
+        const ULTRA_REQUIRED_MODELS: &[&str] = &[
+            "claude-opus-4-6",
+            "claude-opus-4-5",
+            "opus", // 通配匹配
+        ];
+
+        fn is_ultra_required_model(model: &str) -> bool {
+            let lower = model.to_lowercase();
+            ULTRA_REQUIRED_MODELS.iter().any(|m| lower.contains(m))
+        }
+
+        let requires_ultra = is_ultra_required_model(target_model);
 
         let normalized_target =
             crate::proxy::common::model_mapping::normalize_to_standard_id(target_model)
                 .unwrap_or_else(|| target_model.to_string());
 
         tokens_snapshot.sort_by(|a, b| {
+            // Priority 0 (NEW): 高端模型时，订阅等级优先 (ULTRA > PRO > FREE)
+            // -> 确保 Opus 4.6/4.5 等高端模型优先使用 Ultra 账号
+            let tier_priority = |tier: &Option<String>| {
+                let t = tier.as_deref().unwrap_or("").to_lowercase();
+                if t.contains("ultra") { 0 }
+                else if t.contains("pro") { 1 }
+                else if t.contains("free") { 2 }
+                else { 3 }
+            };
+
+            if requires_ultra {
+                let tier_cmp = tier_priority(&a.subscription_tier)
+                    .cmp(&tier_priority(&b.subscription_tier));
+                if tier_cmp != std::cmp::Ordering::Equal {
+                    return tier_cmp;
+                }
+            }
+
             // Priority 1: 目标模型的 quota (higher is better) -> 保护低配额账号
             // [OPTIMIZATION] 使用内存缓存，不再读取磁盘 IO
             let quota_a = a.model_quotas.get(&normalized_target).copied()
@@ -1032,17 +1065,13 @@ impl TokenManager {
             }
 
             // Priority 3: Subscription tier (ULTRA > PRO > FREE) -> 平局时高级账号优先
-            let tier_priority = |tier: &Option<String>| {
-                let t = tier.as_deref().unwrap_or("").to_lowercase();
-                if t.contains("ultra") { 0 }
-                else if t.contains("pro") { 1 }
-                else if t.contains("free") { 2 }
-                else { 3 }
-            };
-            let tier_cmp = tier_priority(&a.subscription_tier)
-                .cmp(&tier_priority(&b.subscription_tier));
-            if tier_cmp != std::cmp::Ordering::Equal {
-                return tier_cmp;
+            // (对于非高端模型，订阅等级在此作为次要优先级)
+            if !requires_ultra {
+                let tier_cmp = tier_priority(&a.subscription_tier)
+                    .cmp(&tier_priority(&b.subscription_tier));
+                if tier_cmp != std::cmp::Ordering::Equal {
+                    return tier_cmp;
+                }
             }
 
             // Priority 4: Reset time (earlier is better, but only if diff > 10 min)
@@ -3030,5 +3059,249 @@ mod tests {
 
         let result = manager.select_with_p2c(&candidates, &attempted, "claude-sonnet", false);
         assert!(result.is_none());
+    }
+
+    // ===== Ultra 优先逻辑测试 =====
+
+    /// 测试 is_ultra_required_model 辅助函数
+    #[test]
+    fn test_is_ultra_required_model() {
+        // 需要 Ultra 账号的高端模型
+        const ULTRA_REQUIRED_MODELS: &[&str] = &[
+            "claude-opus-4-6",
+            "claude-opus-4-5",
+            "opus",
+        ];
+
+        fn is_ultra_required_model(model: &str) -> bool {
+            let lower = model.to_lowercase();
+            ULTRA_REQUIRED_MODELS.iter().any(|m| lower.contains(m))
+        }
+
+        // 应该识别为高端模型
+        assert!(is_ultra_required_model("claude-opus-4-6"));
+        assert!(is_ultra_required_model("claude-opus-4-5"));
+        assert!(is_ultra_required_model("Claude-Opus-4-6")); // 大小写不敏感
+        assert!(is_ultra_required_model("CLAUDE-OPUS-4-5")); // 大小写不敏感
+        assert!(is_ultra_required_model("opus")); // 通配匹配
+        assert!(is_ultra_required_model("opus-4-6-latest"));
+        assert!(is_ultra_required_model("models/claude-opus-4-6"));
+
+        // 应该识别为普通模型
+        assert!(!is_ultra_required_model("claude-sonnet-4-5"));
+        assert!(!is_ultra_required_model("claude-sonnet"));
+        assert!(!is_ultra_required_model("gemini-1.5-flash"));
+        assert!(!is_ultra_required_model("gemini-2.0-pro"));
+        assert!(!is_ultra_required_model("claude-haiku"));
+    }
+
+    /// 测试高端模型排序：Ultra 账号优先于 Pro 账号（即使 Pro 配额更高）
+    #[test]
+    fn test_ultra_priority_for_high_end_models() {
+        const RESET_TIME_THRESHOLD_SECS: i64 = 600;
+
+        // 模拟高端模型排序逻辑
+        fn compare_tokens_for_model(a: &ProxyToken, b: &ProxyToken, target_model: &str) -> Ordering {
+            const ULTRA_REQUIRED_MODELS: &[&str] = &["claude-opus-4-6", "claude-opus-4-5", "opus"];
+            let requires_ultra = {
+                let lower = target_model.to_lowercase();
+                ULTRA_REQUIRED_MODELS.iter().any(|m| lower.contains(m))
+            };
+
+            let tier_priority = |tier: &Option<String>| {
+                let t = tier.as_deref().unwrap_or("").to_lowercase();
+                if t.contains("ultra") { 0 }
+                else if t.contains("pro") { 1 }
+                else if t.contains("free") { 2 }
+                else { 3 }
+            };
+
+            // Priority 0: 高端模型时，订阅等级优先
+            if requires_ultra {
+                let tier_cmp = tier_priority(&a.subscription_tier)
+                    .cmp(&tier_priority(&b.subscription_tier));
+                if tier_cmp != Ordering::Equal {
+                    return tier_cmp;
+                }
+            }
+
+            // Priority 1: Quota (higher is better)
+            let quota_a = a.remaining_quota.unwrap_or(0);
+            let quota_b = b.remaining_quota.unwrap_or(0);
+            let quota_cmp = quota_b.cmp(&quota_a);
+            if quota_cmp != Ordering::Equal {
+                return quota_cmp;
+            }
+
+            // Priority 2: Health score
+            let health_cmp = b.health_score.partial_cmp(&a.health_score)
+                .unwrap_or(Ordering::Equal);
+            if health_cmp != Ordering::Equal {
+                return health_cmp;
+            }
+
+            // Priority 3: Tier (for non-high-end models)
+            if !requires_ultra {
+                let tier_cmp = tier_priority(&a.subscription_tier)
+                    .cmp(&tier_priority(&b.subscription_tier));
+                if tier_cmp != Ordering::Equal {
+                    return tier_cmp;
+                }
+            }
+
+            Ordering::Equal
+        }
+
+        // 创建测试账号：Ultra 低配额 vs Pro 高配额
+        let ultra_low_quota = create_test_token("ultra@test.com", Some("ULTRA"), 1.0, None, Some(20));
+        let pro_high_quota = create_test_token("pro@test.com", Some("PRO"), 1.0, None, Some(80));
+
+        // 高端模型 (Opus 4.6): Ultra 应该优先，即使配额低
+        assert_eq!(
+            compare_tokens_for_model(&ultra_low_quota, &pro_high_quota, "claude-opus-4-6"),
+            Ordering::Less, // Ultra 排在前面
+            "Opus 4.6 should prefer Ultra account over Pro even with lower quota"
+        );
+
+        // 高端模型 (Opus 4.5): Ultra 应该优先
+        assert_eq!(
+            compare_tokens_for_model(&ultra_low_quota, &pro_high_quota, "claude-opus-4-5"),
+            Ordering::Less,
+            "Opus 4.5 should prefer Ultra account over Pro"
+        );
+
+        // 普通模型 (Sonnet): 高配额 Pro 应该优先
+        assert_eq!(
+            compare_tokens_for_model(&ultra_low_quota, &pro_high_quota, "claude-sonnet-4-5"),
+            Ordering::Greater, // Pro (高配额) 排在前面
+            "Sonnet should prefer high-quota Pro over low-quota Ultra"
+        );
+
+        // 普通模型 (Flash): 高配额 Pro 应该优先
+        assert_eq!(
+            compare_tokens_for_model(&ultra_low_quota, &pro_high_quota, "gemini-1.5-flash"),
+            Ordering::Greater,
+            "Flash should prefer high-quota Pro over low-quota Ultra"
+        );
+    }
+
+    /// 测试排序：同为 Ultra 时按配额排序
+    #[test]
+    fn test_ultra_accounts_sorted_by_quota() {
+        fn compare_tokens_for_model(a: &ProxyToken, b: &ProxyToken, target_model: &str) -> Ordering {
+            const ULTRA_REQUIRED_MODELS: &[&str] = &["claude-opus-4-6", "claude-opus-4-5", "opus"];
+            let requires_ultra = {
+                let lower = target_model.to_lowercase();
+                ULTRA_REQUIRED_MODELS.iter().any(|m| lower.contains(m))
+            };
+
+            let tier_priority = |tier: &Option<String>| {
+                let t = tier.as_deref().unwrap_or("").to_lowercase();
+                if t.contains("ultra") { 0 }
+                else if t.contains("pro") { 1 }
+                else if t.contains("free") { 2 }
+                else { 3 }
+            };
+
+            if requires_ultra {
+                let tier_cmp = tier_priority(&a.subscription_tier)
+                    .cmp(&tier_priority(&b.subscription_tier));
+                if tier_cmp != Ordering::Equal {
+                    return tier_cmp;
+                }
+            }
+
+            let quota_a = a.remaining_quota.unwrap_or(0);
+            let quota_b = b.remaining_quota.unwrap_or(0);
+            quota_b.cmp(&quota_a)
+        }
+
+        let ultra_high = create_test_token("ultra_high@test.com", Some("ULTRA"), 1.0, None, Some(80));
+        let ultra_low = create_test_token("ultra_low@test.com", Some("ULTRA"), 1.0, None, Some(20));
+
+        // Opus 4.6: 同为 Ultra，高配额优先
+        assert_eq!(
+            compare_tokens_for_model(&ultra_high, &ultra_low, "claude-opus-4-6"),
+            Ordering::Less, // ultra_high 排在前面
+            "Among Ultra accounts, higher quota should come first"
+        );
+    }
+
+    /// 测试完整排序场景：混合账号池
+    #[test]
+    fn test_full_sorting_mixed_accounts() {
+        fn sort_tokens_for_model(tokens: &mut Vec<ProxyToken>, target_model: &str) {
+            const ULTRA_REQUIRED_MODELS: &[&str] = &["claude-opus-4-6", "claude-opus-4-5", "opus"];
+            let requires_ultra = {
+                let lower = target_model.to_lowercase();
+                ULTRA_REQUIRED_MODELS.iter().any(|m| lower.contains(m))
+            };
+
+            tokens.sort_by(|a, b| {
+                let tier_priority = |tier: &Option<String>| {
+                    let t = tier.as_deref().unwrap_or("").to_lowercase();
+                    if t.contains("ultra") { 0 }
+                    else if t.contains("pro") { 1 }
+                    else if t.contains("free") { 2 }
+                    else { 3 }
+                };
+
+                if requires_ultra {
+                    let tier_cmp = tier_priority(&a.subscription_tier)
+                        .cmp(&tier_priority(&b.subscription_tier));
+                    if tier_cmp != Ordering::Equal {
+                        return tier_cmp;
+                    }
+                }
+
+                let quota_a = a.remaining_quota.unwrap_or(0);
+                let quota_b = b.remaining_quota.unwrap_or(0);
+                let quota_cmp = quota_b.cmp(&quota_a);
+                if quota_cmp != Ordering::Equal {
+                    return quota_cmp;
+                }
+
+                if !requires_ultra {
+                    let tier_cmp = tier_priority(&a.subscription_tier)
+                        .cmp(&tier_priority(&b.subscription_tier));
+                    if tier_cmp != Ordering::Equal {
+                        return tier_cmp;
+                    }
+                }
+
+                Ordering::Equal
+            });
+        }
+
+        // 创建混合账号池
+        let ultra_high = create_test_token("ultra_high@test.com", Some("ULTRA"), 1.0, None, Some(80));
+        let ultra_low = create_test_token("ultra_low@test.com", Some("ULTRA"), 1.0, None, Some(20));
+        let pro_high = create_test_token("pro_high@test.com", Some("PRO"), 1.0, None, Some(90));
+        let pro_low = create_test_token("pro_low@test.com", Some("PRO"), 1.0, None, Some(30));
+        let free = create_test_token("free@test.com", Some("FREE"), 1.0, None, Some(100));
+
+        // 高端模型 (Opus 4.6) 排序
+        let mut tokens_opus = vec![pro_high.clone(), free.clone(), ultra_low.clone(), pro_low.clone(), ultra_high.clone()];
+        sort_tokens_for_model(&mut tokens_opus, "claude-opus-4-6");
+
+        let emails_opus: Vec<&str> = tokens_opus.iter().map(|t| t.email.as_str()).collect();
+        // 期望顺序: Ultra(高配额) > Ultra(低配额) > Pro(高配额) > Pro(低配额) > Free
+        assert_eq!(
+            emails_opus,
+            vec!["ultra_high@test.com", "ultra_low@test.com", "pro_high@test.com", "pro_low@test.com", "free@test.com"],
+            "Opus 4.6 should sort Ultra first, then by quota within each tier"
+        );
+
+        // 普通模型 (Sonnet) 排序
+        let mut tokens_sonnet = vec![pro_high.clone(), free.clone(), ultra_low.clone(), pro_low.clone(), ultra_high.clone()];
+        sort_tokens_for_model(&mut tokens_sonnet, "claude-sonnet-4-5");
+
+        let emails_sonnet: Vec<&str> = tokens_sonnet.iter().map(|t| t.email.as_str()).collect();
+        // 期望顺序: Free(100%) > Pro(90%) > Ultra(80%) > Pro(30%) > Ultra(20%) - 按配额优先
+        assert_eq!(
+            emails_sonnet,
+            vec!["free@test.com", "pro_high@test.com", "ultra_high@test.com", "pro_low@test.com", "ultra_low@test.com"],
+            "Sonnet should sort by quota first, then by tier as tiebreaker"
+        );
     }
 }

--- a/src/pages/UserToken.tsx
+++ b/src/pages/UserToken.tsx
@@ -54,10 +54,11 @@ const UserToken: React.FC = () => {
     // Create Form State
     const [newUsername, setNewUsername] = useState('');
     const [newDesc, setNewDesc] = useState('');
-    const [newExpiresType, setNewExpiresType] = useState('month'); // day, week, month, never
+    const [newExpiresType, setNewExpiresType] = useState('month'); // day, week, month, never, custom
     const [newMaxIps, setNewMaxIps] = useState(0);
     const [newCurfewStart, setNewCurfewStart] = useState('');
     const [newCurfewEnd, setNewCurfewEnd] = useState('');
+    const [newCustomExpires, setNewCustomExpires] = useState(''); // datetime-local value
 
     const loadData = async () => {
         setLoading(true);
@@ -86,15 +87,29 @@ const UserToken: React.FC = () => {
             return;
         }
 
+        // 验证自定义时间
+        if (newExpiresType === 'custom' && !newCustomExpires) {
+            showToast(t('user_token.custom_expires_required') || 'Please select a custom expiration time', 'error');
+            return;
+        }
+
         setCreating(true);
         try {
+            // 计算自定义过期时间戳
+            const customExpiresAt = newExpiresType === 'custom' && newCustomExpires
+                ? Math.floor(new Date(newCustomExpires).getTime() / 1000)
+                : undefined;
+
             await invoke('create_user_token', {
-                username: newUsername,
-                expires_type: newExpiresType,
-                description: newDesc || undefined,
-                max_ips: newMaxIps,
-                curfew_start: newCurfewStart || undefined,
-                curfew_end: newCurfewEnd || undefined
+                request: {
+                    username: newUsername,
+                    expires_type: newExpiresType,
+                    description: newDesc || null,
+                    max_ips: newMaxIps,
+                    curfew_start: newCurfewStart || null,
+                    curfew_end: newCurfewEnd || null,
+                    custom_expires_at: customExpiresAt || null
+                }
             });
             showToast(t('common.create_success') || 'Created successfully', 'success');
             setShowCreateModal(false);
@@ -104,6 +119,7 @@ const UserToken: React.FC = () => {
             setNewMaxIps(0);
             setNewCurfewStart('');
             setNewCurfewEnd('');
+            setNewCustomExpires('');
             loadData();
         } catch (e) {
             console.error('Failed to create token', e);
@@ -124,12 +140,13 @@ const UserToken: React.FC = () => {
     };
 
     const handleEdit = (token: UserToken) => {
+        console.log('Editing token:', token); // 调试日志
         setEditingToken(token);
         setEditUsername(token.username);
         setEditDesc(token.description || '');
-        setEditMaxIps(token.max_ips);
-        setEditCurfewStart(token.curfew_start || '');
-        setEditCurfewEnd(token.curfew_end || '');
+        setEditMaxIps(token.max_ips ?? 0);  // 使用 ?? 确保 null/undefined 变为 0
+        setEditCurfewStart(token.curfew_start ?? '');
+        setEditCurfewEnd(token.curfew_end ?? '');
         setShowEditModal(true);
     };
 
@@ -148,8 +165,9 @@ const UserToken: React.FC = () => {
                     username: editUsername,
                     description: editDesc || undefined,
                     max_ips: editMaxIps,
-                    curfew_start: editCurfewStart || null,
-                    curfew_end: editCurfewEnd || null
+                    // 使用双层包装: undefined = 不更新, null = 清空, string = 设置值
+                    curfew_start: editCurfewStart === '' ? null : editCurfewStart,
+                    curfew_end: editCurfewEnd === '' ? null : editCurfewEnd
                 }
             });
             showToast(t('common.update_success') || 'Updated successfully', 'success');
@@ -194,6 +212,7 @@ const UserToken: React.FC = () => {
             case 'week': return t('user_token.expires_week', { defaultValue: '1 Week' });
             case 'month': return t('user_token.expires_month', { defaultValue: '1 Month' });
             case 'never': return t('user_token.expires_never', { defaultValue: 'Never' });
+            case 'custom': return t('user_token.expires_custom', { defaultValue: 'Custom' });
             default: return type;
         }
     };
@@ -481,6 +500,7 @@ const UserToken: React.FC = () => {
                                     <option value="day">{t('user_token.expires_day', { defaultValue: '1 Day' })}</option>
                                     <option value="week">{t('user_token.expires_week', { defaultValue: '1 Week' })}</option>
                                     <option value="month">{t('user_token.expires_month', { defaultValue: '1 Month' })}</option>
+                                    <option value="custom">{t('user_token.expires_custom', { defaultValue: 'Custom' })}</option>
                                     <option value="never">{t('user_token.expires_never', { defaultValue: 'Never' })}</option>
                                 </select>
                             </div>
@@ -502,6 +522,25 @@ const UserToken: React.FC = () => {
                                 </label>
                             </div>
                         </div>
+
+                        {/* Custom Expiration Time Picker */}
+                        {newExpiresType === 'custom' && (
+                            <div className="form-control w-full mb-3">
+                                <label className="label">
+                                    <span className="label-text">{t('user_token.custom_expires_at', { defaultValue: 'Expiration Date & Time' })} *</span>
+                                </label>
+                                <input
+                                    type="datetime-local"
+                                    className="input input-bordered w-full"
+                                    value={newCustomExpires}
+                                    onChange={e => setNewCustomExpires(e.target.value)}
+                                    min={new Date().toISOString().slice(0, 16)}
+                                />
+                                <label className="label">
+                                    <span className="label-text-alt text-gray-500">{t('user_token.hint_custom_expires', { defaultValue: 'Select the exact date and hour when this token expires' })}</span>
+                                </label>
+                            </div>
+                        )}
 
                         <div className="form-control w-full mb-3">
                             <label className="label">


### PR DESCRIPTION
# 修复 Opus 4.6 调用报错 & UserToken 显示优化

  ## 问题

  号池混着 Pro 和 Ultra 账号。Pro 没有 Opus 4.6 权限，Ultra 有。

  之前轮询按配额高低选账号，不管订阅等级。用户调 Opus 4.6 时，系统可能选到 Pro 账号，直接报错。
![~(`M$JJ~S3BPCAB9%A1CS{A](https://github.com/user-attachments/assets/5d01813a-0ad8-4c50-8dcc-cae3c5a486f7)

  ## 改动

  ### 1. Ultra 优先调度

  调 Opus 4.6/4.5 时，先按订阅等级排序：

  Ultra > Pro > Free

  同等级再按配额排。其他模型还是老逻辑，配额优先。

  匹配规则：模型名包含 claude-opus-4-6、claude-opus-4-5 或 opus 就走 Ultra 优先。

  ### 2. UserToken 编辑数据不显示

  点编辑 Token 时，IP 限制和宵禁时间显示空的。

  问题：
  - 前端传参用 undefined，Rust 需要 null
  - 读取用 ||，0 和空字符串被吃掉了，改成 ??

  ### 3. 自定义过期时间

  创建 Token 多了个 Custom 选项，选日期时间，精确到小时。

  ## 验证

  1. 调 Opus 4.6，看日志确认走的是 Ultra 账号
  2. 创建 Token 设置 IP 限制和宵禁，编辑时确认数据正常回显