### PR TITLE
fix(account): self-heal corrupted accounts index

### DIFF
--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -12,6 +12,309 @@ use crate::modules;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    // Global mutex to prevent concurrent test execution
+    static TEST_MUTEX: Lazy<StdMutex<()>> = Lazy::new(|| StdMutex::new(()));
+
+    struct TestDataDir {
+        path: PathBuf,
+    }
+
+    impl TestDataDir {
+        fn new() -> Self {
+            let temp_path = std::env::temp_dir().join(format!(
+                "antigravity_test_{}_{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis()
+            ));
+            fs::create_dir_all(&temp_path).expect("Failed to create temp dir");
+            
+            Self {
+                path: temp_path,
+            }
+        }
+
+        fn path(&self) -> &PathBuf {
+            &self.path
+        }
+    }
+
+    impl Drop for TestDataDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    /// Helper to write corrupted content to accounts.json
+    fn write_corrupted_index(path: &PathBuf, content: &[u8]) {
+        let index_path = path.join("accounts.json");
+        fs::write(&index_path, content).expect("Failed to write corrupted index");
+    }
+
+    /// Helper to create a valid account file in accounts/ directory
+    fn create_account_file(path: &PathBuf, account_id: &str, email: &str) {
+        let accounts_dir = path.join("accounts");
+        fs::create_dir_all(&accounts_dir).expect("Failed to create accounts dir");
+        
+        let account = Account::new(
+            account_id.to_string(),
+            email.to_string(),
+            TokenData::new(
+                "test_access_token".to_string(),
+                "test_refresh_token".to_string(),
+                3600,
+                Some(email.to_string()),
+                None,
+                None,
+            ),
+        );
+        
+        let content = serde_json::to_string_pretty(&account).expect("Failed to serialize account");
+        let account_path = accounts_dir.join(format!("{}.json", account_id));
+        fs::write(&account_path, content).expect("Failed to write account file");
+    }
+
+    #[test]
+    fn test_load_account_index_with_bom_prefix() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = TestDataDir::new();
+
+        // UTF-8 BOM followed by valid JSON
+        let bom = [0xEF, 0xBB, 0xBF];
+        let json = r#"{"version":"2.0","accounts":[],"current_account_id":null}"#;
+        let mut content = Vec::new();
+        content.extend_from_slice(&bom);
+        content.extend_from_slice(json.as_bytes());
+        
+        write_corrupted_index(dir.path(), &content);
+
+        let result = load_account_index_in_dir(dir.path());
+        
+        // New behavior: BOM is stripped and JSON parses successfully
+        assert!(result.is_ok(), "BOM should be stripped and JSON should parse: {:?}", result);
+        let index = result.unwrap();
+        assert!(index.accounts.is_empty());
+        println!("BOM case: successfully loaded index after sanitization");
+    }
+
+    #[test]
+    fn test_load_account_index_with_nul_prefix() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = TestDataDir::new();
+
+        // NUL byte prefix followed by valid JSON
+        let nul = [0x00];
+        let json = r#"{"version":"2.0","accounts":[],"current_account_id":null}"#;
+        let mut content = Vec::new();
+        content.extend_from_slice(&nul);
+        content.extend_from_slice(json.as_bytes());
+        
+        write_corrupted_index(dir.path(), &content);
+
+        let result = load_account_index_in_dir(dir.path());
+        
+        // New behavior: NUL bytes are stripped and JSON parses successfully
+        assert!(result.is_ok(), "NUL prefix should be stripped and JSON should parse: {:?}", result);
+        let index = result.unwrap();
+        assert!(index.accounts.is_empty());
+        println!("NUL prefix case: successfully loaded index after sanitization");
+    }
+
+    #[test]
+    fn test_load_account_index_with_garbage_content() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = TestDataDir::new();
+
+        // Non-JSON garbage content - should trigger recovery
+        write_corrupted_index(dir.path(), b"\0\0not json");
+
+        let result = load_account_index_in_dir(dir.path());
+        
+        // New behavior: garbage content triggers recovery, returns empty index
+        assert!(result.is_ok(), "Garbage content should trigger recovery and return Ok: {:?}", result);
+        let index = result.unwrap();
+        assert!(index.accounts.is_empty(), "Recovered index should be empty when no account files exist");
+        println!("Garbage content case: successfully recovered to empty index");
+    }
+
+    #[test]
+    fn test_load_account_index_with_empty_file() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = TestDataDir::new();
+
+        // Empty file
+        write_corrupted_index(dir.path(), b"");
+
+        let result = load_account_index_in_dir(dir.path());
+        
+        // Current behavior: empty file returns new empty index
+        assert!(result.is_ok());
+        let index = result.unwrap();
+        assert!(index.accounts.is_empty());
+    }
+
+    #[test]
+    fn test_load_account_index_with_whitespace_only() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = TestDataDir::new();
+
+        // Whitespace-only file
+        write_corrupted_index(dir.path(), b"   \n\t  ");
+
+        let result = load_account_index_in_dir(dir.path());
+        
+        // Current behavior: whitespace-only file returns new empty index
+        assert!(result.is_ok());
+        let index = result.unwrap();
+        assert!(index.accounts.is_empty());
+    }
+
+    #[test]
+    fn test_missing_index_with_existing_accounts() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = TestDataDir::new();
+
+        // Create accounts directory with account files but NO accounts.json index
+        create_account_file(dir.path(), "test-id-1", "user1@example.com");
+        create_account_file(dir.path(), "test-id-2", "user2@example.com");
+
+        // accounts.json does not exist
+        let index_path = dir.path().join("accounts.json");
+        assert!(!index_path.exists());
+
+        // Load account index - should recover from accounts directory
+        let result = load_account_index_in_dir(dir.path());
+        assert!(result.is_ok(), "Should recover from accounts directory");
+        let index = result.unwrap();
+        assert_eq!(index.accounts.len(), 2, "Index should have 2 accounts recovered from accounts directory");
+        
+        // Verify recovered accounts have correct data
+        let emails: Vec<_> = index.accounts.iter().map(|s| s.email.clone()).collect();
+        assert!(emails.contains(&"user1@example.com".to_string()));
+        assert!(emails.contains(&"user2@example.com".to_string()));
+
+        // Verify account files still exist
+        let accounts_dir = dir.path().join("accounts");
+        let account_files: Vec<_> = fs::read_dir(&accounts_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().map_or(false, |ext| ext == "json"))
+            .collect();
+        assert_eq!(account_files.len(), 2, "Account files should still exist on disk");
+        
+        println!("Missing index with existing accounts: successfully recovered {} accounts", index.accounts.len());
+    }
+
+    #[test]
+    fn test_save_account_index_roundtrip() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = TestDataDir::new();
+
+        // Build an AccountIndex with 2 accounts
+        let now = chrono::Utc::now().timestamp();
+        let index = AccountIndex {
+            version: "2.0".to_string(),
+            accounts: vec![
+                AccountSummary {
+                    id: "acc-1".to_string(),
+                    email: "user1@example.com".to_string(),
+                    name: Some("User One".to_string()),
+                    disabled: false,
+                    proxy_disabled: false,
+                    created_at: now,
+                    last_used: now,
+                },
+                AccountSummary {
+                    id: "acc-2".to_string(),
+                    email: "user2@example.com".to_string(),
+                    name: None,
+                    disabled: true,
+                    proxy_disabled: true,
+                    created_at: now - 100,
+                    last_used: now - 50,
+                },
+            ],
+            current_account_id: Some("acc-1".to_string()),
+        };
+
+        // Save the index
+        save_account_index_in_dir(dir.path(), &index).expect("Failed to save account index");
+
+        // Load it back
+        let loaded = load_account_index_in_dir(dir.path()).expect("Failed to load account index");
+
+        // Assert it matches
+        assert_eq!(loaded.accounts.len(), 2, "Should have 2 accounts");
+        assert_eq!(loaded.current_account_id, Some("acc-1".to_string()), "current_account_id should match");
+        
+        // Check first account
+        let acc1 = loaded.accounts.iter().find(|a| a.id == "acc-1").expect("acc-1 should exist");
+        assert_eq!(acc1.email, "user1@example.com");
+        assert_eq!(acc1.name, Some("User One".to_string()));
+        assert!(!acc1.disabled);
+        assert!(!acc1.proxy_disabled);
+        
+        // Check second account
+        let acc2 = loaded.accounts.iter().find(|a| a.id == "acc-2").expect("acc-2 should exist");
+        assert_eq!(acc2.email, "user2@example.com");
+        assert_eq!(acc2.name, None);
+        assert!(acc2.disabled);
+        assert!(acc2.proxy_disabled);
+
+        println!("save_account_index roundtrip: successfully saved and loaded index with {} accounts", loaded.accounts.len());
+    }
+
+    #[test]
+    fn test_backup_created_on_parse_failure() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = TestDataDir::new();
+
+        // Create a valid account file
+        create_account_file(dir.path(), "recovered-acc", "recovered@example.com");
+
+        // Create corrupt accounts.json with garbage (non-empty)
+        let garbage_content = b"this is not valid json { broken";
+        write_corrupted_index(dir.path(), garbage_content);
+
+        // Verify accounts.json exists and is corrupt
+        let index_path = dir.path().join("accounts.json");
+        assert!(index_path.exists(), "accounts.json should exist");
+
+        // Call load_account_index to trigger recovery and backup creation
+        let recovered = load_account_index_in_dir(dir.path()).expect("Should recover from accounts");
+        assert_eq!(recovered.accounts.len(), 1, "Should recover 1 account");
+        assert_eq!(recovered.accounts[0].email, "recovered@example.com");
+        assert_eq!(recovered.current_account_id, Some("recovered-acc".to_string()));
+
+        // Assert a backup file exists with prefix "accounts.json.corrupt-"
+        let data_dir = dir.path();
+        let backup_files: Vec<_> = fs::read_dir(data_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .map_or(false, |name| name.starts_with("accounts.json.corrupt-"))
+            })
+            .collect();
+        
+        assert_eq!(backup_files.len(), 1, "Should have exactly one backup file");
+        
+        // Verify backup contains the original garbage content
+        let backup_content = fs::read(&backup_files[0].path()).expect("Should be able to read backup file");
+        assert_eq!(backup_content, garbage_content, "Backup should contain original corrupt content");
+
+        println!("Backup creation on parse failure: successfully created backup");
+    }
+}
+
 /// Global account write lock to prevent corruption during concurrent operations
 static ACCOUNT_INDEX_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
@@ -20,10 +323,9 @@ const DATA_DIR: &str = ".antigravity_tools";
 const ACCOUNTS_INDEX: &str = "accounts.json";
 const ACCOUNTS_DIR: &str = "accounts";
 
-// ... existing functions get_data_dir, get_accounts_dir, load_account_index, save_account_index ...
 /// Get data directory path
 pub fn get_data_dir() -> Result<PathBuf, String> {
-    // [NEW] 支持通过环境变量自定义数据目录
+    // [NEW] Support custom data directory via environment variable
     if let Ok(env_path) = std::env::var("ABV_DATA_DIR") {
         if !env_path.trim().is_empty() {
             let data_dir = PathBuf::from(env_path);
@@ -58,65 +360,288 @@ pub fn get_accounts_dir() -> Result<PathBuf, String> {
     Ok(accounts_dir)
 }
 
-/// Load account index
-pub fn load_account_index() -> Result<AccountIndex, String> {
-    let data_dir = get_data_dir()?;
+/// Load account index from a specific directory (internal helper)
+fn load_account_index_in_dir(data_dir: &PathBuf) -> Result<AccountIndex, String> {
     let index_path = data_dir.join(ACCOUNTS_INDEX);
 
     if !index_path.exists() {
-        crate::modules::logger::log_warn("Account index file not found");
-        return Ok(AccountIndex::new());
+        crate::modules::logger::log_warn(
+            "Account index file not found, attempting recovery from accounts directory",
+        );
+        let recovered = rebuild_index_from_accounts_in_dir(data_dir)?;
+        try_save_recovered_index(data_dir, &index_path, &recovered, None)?;
+        return Ok(recovered);
     }
 
-    let content = fs::read_to_string(&index_path)
+    let raw_content = fs::read(&index_path)
         .map_err(|e| format!("failed_to_read_account_index: {}", e))?;
 
-    // If file content is empty, treat as new index
-    if content.trim().is_empty() {
-        crate::modules::logger::log_warn("Account index is empty, initializing new index");
-        return Ok(AccountIndex::new());
+    // If file is empty, attempt recovery
+    if raw_content.is_empty() {
+        crate::modules::logger::log_warn(
+            "Account index is empty, attempting recovery from accounts directory",
+        );
+        let recovered = rebuild_index_from_accounts_in_dir(data_dir)?;
+        try_save_recovered_index(data_dir, &index_path, &recovered, None)?;
+        return Ok(recovered);
     }
 
-    let index: AccountIndex = serde_json::from_str(&content)
-        .map_err(|e| format!("failed_to_parse_account_index: {}", e))?;
+    // Sanitize content: strip BOM and leading NUL bytes
+    let sanitized = sanitize_index_content(&raw_content);
 
-    crate::modules::logger::log_info(&format!(
-        "Successfully loaded index with {} accounts",
-        index.accounts.len()
-    ));
-    Ok(index)
+    // If sanitized content is empty/whitespace, attempt recovery
+    if sanitized.trim().is_empty() {
+        crate::modules::logger::log_warn(
+            "Account index is empty after sanitization, attempting recovery from accounts directory",
+        );
+        let recovered = rebuild_index_from_accounts_in_dir(data_dir)?;
+        try_save_recovered_index(data_dir, &index_path, &recovered, None)?;
+        return Ok(recovered);
+    }
+
+    // Try to parse sanitized content
+    match serde_json::from_str::<AccountIndex>(&sanitized) {
+        Ok(index) => {
+            crate::modules::logger::log_info(&format!(
+                "Successfully loaded index with {} accounts",
+                index.accounts.len()
+            ));
+            Ok(index)
+        }
+        Err(parse_err) => {
+            crate::modules::logger::log_error(&format!(
+                "Failed to parse account index: {}. Attempting recovery from accounts directory",
+                parse_err
+            ));
+            let recovered = rebuild_index_from_accounts_in_dir(data_dir)?;
+            try_save_recovered_index(data_dir, &index_path, &recovered, Some(&raw_content))?;
+            Ok(recovered)
+        }
+    }
 }
 
-/// Save account index (atomic write)
-pub fn save_account_index(index: &AccountIndex) -> Result<(), String> {
-    let data_dir = get_data_dir()?;
+/// Save account index to a specific directory (internal helper)
+fn save_account_index_in_dir(data_dir: &PathBuf, index: &AccountIndex) -> Result<(), String> {
     let index_path = data_dir.join(ACCOUNTS_INDEX);
-    let temp_path = data_dir.join(format!("{}.tmp", ACCOUNTS_INDEX));
+    // Use unique temp file name per write to avoid collision
+    let temp_filename = format!("{}.tmp.{}", ACCOUNTS_INDEX, Uuid::new_v4());
+    let temp_path = data_dir.join(&temp_filename);
 
     let content = serde_json::to_string_pretty(index)
         .map_err(|e| format!("failed_to_serialize_account_index: {}", e))?;
 
     // Write to temporary file
-    fs::write(&temp_path, content)
-        .map_err(|e| format!("failed_to_write_temp_index_file: {}", e))?;
+    if let Err(e) = fs::write(&temp_path, content) {
+        // Clean up temp file on failure
+        let _ = fs::remove_file(&temp_path);
+        return Err(format!("failed_to_write_temp_index_file: {}", e));
+    }
 
-    // Atomic rename
-    fs::rename(temp_path, index_path).map_err(|e| format!("failed_to_replace_index_file: {}", e))
+    // Atomic rename with platform-specific handling
+    if let Err(e) = atomic_replace_file(&temp_path, &index_path) {
+        // Clean up temp file on failure
+        let _ = fs::remove_file(&temp_path);
+        return Err(format!("failed_to_replace_index_file: {}", e));
+    }
+
+    Ok(())
+}
+
+/// Rebuild AccountIndex by scanning accounts/*.json files in specific directory
+fn rebuild_index_from_accounts_in_dir(data_dir: &PathBuf) -> Result<AccountIndex, String> {
+    let accounts_dir = data_dir.join(ACCOUNTS_DIR);
+    let mut summaries = Vec::new();
+
+    if accounts_dir.exists() {
+        if let Ok(entries) = fs::read_dir(&accounts_dir) {
+            for entry in entries.filter_map(|e| e.ok()) {
+                let path = entry.path();
+                if path.extension().map_or(false, |ext| ext == "json") {
+                    if let Some(account_id) = path.file_stem().and_then(|s| s.to_str()) {
+                        match load_account_at_path(&path) {
+                            Ok(account) => {
+                                summaries.push(AccountSummary {
+                                    id: account.id,
+                                    email: account.email,
+                                    name: account.name,
+                                    disabled: account.disabled,
+                                    proxy_disabled: account.proxy_disabled,
+                                    created_at: account.created_at,
+                                    last_used: account.last_used,
+                                });
+                            }
+                            Err(e) => {
+                                crate::modules::logger::log_warn(&format!(
+                                    "Failed to load account {} during recovery: {}",
+                                    account_id, e
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Sort by last_used desc, then by email for deterministic order
+    summaries.sort_by(|a, b| {
+        b.last_used
+            .cmp(&a.last_used)
+            .then_with(|| a.email.cmp(&b.email))
+    });
+
+    let current_account_id = summaries.first().map(|s| s.id.clone());
+
+    crate::modules::logger::log_info(&format!(
+        "Rebuilt index from accounts directory: {} accounts recovered",
+        summaries.len()
+    ));
+
+    Ok(AccountIndex {
+        version: "2.0".to_string(),
+        accounts: summaries,
+        current_account_id,
+    })
+}
+
+/// Load account from a specific path (internal helper)
+fn load_account_at_path(account_path: &PathBuf) -> Result<Account, String> {
+    let content = fs::read_to_string(account_path)
+        .map_err(|e| format!("failed_to_read_account_data: {}", e))?;
+    serde_json::from_str(&content).map_err(|e| format!("failed_to_parse_account_data: {}", e))
+}
+
+/// Load account index with recovery support
+pub fn load_account_index() -> Result<AccountIndex, String> {
+    let data_dir = get_data_dir()?;
+    load_account_index_in_dir(&data_dir)
+}
+
+/// Sanitize index file content by stripping BOM and leading NUL bytes
+fn sanitize_index_content(raw: &[u8]) -> String {
+    // Skip UTF-8 BOM if present
+    let without_bom = if raw.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        &raw[3..]
+    } else {
+        raw
+    };
+
+    // Skip leading NUL bytes
+    let without_nul = without_bom
+        .iter()
+        .skip_while(|&&b| b == 0x00)
+        .copied()
+        .collect::<Vec<u8>>();
+
+    // Convert to string (lossy - invalid UTF-8 sequences become replacement chars)
+    String::from_utf8_lossy(&without_nul).into_owned()
+}
+
+/// Best-effort save of recovered index without deadlocking
+fn try_save_recovered_index(
+    data_dir: &PathBuf,
+    _index_path: &PathBuf,
+    index: &AccountIndex,
+    corrupt_content: Option<&[u8]>,
+) -> Result<(), String> {
+    // Backup corrupt file if content provided
+    if let Some(content) = corrupt_content {
+        let timestamp = chrono::Utc::now().timestamp();
+        let backup_name = format!("accounts.json.corrupt-{}-{}", timestamp, Uuid::new_v4());
+        let backup_path = data_dir.join(&backup_name);
+        if let Err(e) = fs::write(&backup_path, content) {
+            crate::modules::logger::log_warn(&format!(
+                "Failed to backup corrupt index to {}: {}",
+                backup_name, e
+            ));
+        } else {
+            crate::modules::logger::log_info(&format!(
+                "Backed up corrupt index to {}",
+                backup_name
+            ));
+        }
+    }
+
+    // Try to acquire lock without blocking - if we can't get it, skip saving
+    match ACCOUNT_INDEX_LOCK.try_lock() {
+        Ok(_guard) => {
+            if let Err(e) = save_account_index_in_dir(data_dir, index) {
+                crate::modules::logger::log_warn(&format!(
+                    "Failed to save recovered index: {}. Will retry on next load.",
+                    e
+                ));
+            } else {
+                crate::modules::logger::log_info("Successfully saved recovered index");
+            }
+        }
+        Err(_) => {
+            crate::modules::logger::log_warn(
+                "Could not acquire lock to save recovered index. Will retry on next load."
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Save account index (atomic write)
+pub fn save_account_index(index: &AccountIndex) -> Result<(), String> {
+    let data_dir = get_data_dir()?;
+    save_account_index_in_dir(&data_dir, index)
+}
+
+/// Platform-specific atomic file replacement
+#[cfg(target_os = "windows")]
+fn atomic_replace_file(src: &PathBuf, dst: &PathBuf) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt;
+
+    type Bool = i32;
+    type Dword = u32;
+
+    #[link(name = "Kernel32")]
+    extern "system" {
+        fn MoveFileExW(lp_existing_file_name: *const u16, lp_new_file_name: *const u16, dw_flags: Dword) -> Bool;
+    }
+
+    let src_wide: Vec<u16> = src
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let dst_wide: Vec<u16> = dst
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // MOVEFILE_REPLACE_EXISTING = 0x1
+    // MOVEFILE_WRITE_THROUGH = 0x8
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+    let flags = MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH;
+
+    let result = unsafe { MoveFileExW(src_wide.as_ptr(), dst_wide.as_ptr(), flags) };
+    if result == 0 {
+        let err = std::io::Error::last_os_error();
+        // Clean up source file on failure
+        let _ = fs::remove_file(src);
+        return Err(format!("MoveFileExW failed: {}", err));
+    }
+
+    Ok(())
+}
+
+/// Non-Windows: use standard rename
+#[cfg(not(target_os = "windows"))]
+fn atomic_replace_file(src: &PathBuf, dst: &PathBuf) -> Result<(), String> {
+    fs::rename(src, dst).map_err(|e| format!("rename failed: {}", e))
 }
 
 /// Load account data
 pub fn load_account(account_id: &str) -> Result<Account, String> {
     let accounts_dir = get_accounts_dir()?;
     let account_path = accounts_dir.join(format!("{}.json", account_id));
-
-    if !account_path.exists() {
-        return Err(format!("Account not found: {}", account_id));
-    }
-
-    let content = fs::read_to_string(&account_path)
-        .map_err(|e| format!("failed_to_read_account_data: {}", e))?;
-
-    serde_json::from_str(&content).map_err(|e| format!("failed_to_parse_account_data: {}", e))
+    load_account_at_path(&account_path)
 }
 
 /// Save account data
@@ -307,7 +832,7 @@ pub fn delete_account(account_id: &str) -> Result<(), String> {
             .map_err(|e| format!("failed_to_delete_account_file: {}", e))?;
     }
 
-    // [FIX #1477] 触发 TokenManager 缓存清理信号
+    // [FIX #1477] Trigger TokenManager cache cleanup signal
     crate::proxy::server::trigger_account_delete(account_id);
 
     Ok(())
@@ -337,7 +862,7 @@ pub fn delete_accounts(account_ids: &[String]) -> Result<(), String> {
             let _ = fs::remove_file(&account_path);
         }
 
-        // [FIX #1477] 触发 TokenManager 缓存清理信号
+        // [FIX #1477] Trigger TokenManager cache cleanup signal
         crate::proxy::server::trigger_account_delete(account_id);
     }
 
@@ -499,7 +1024,8 @@ pub fn bind_device_profile(account_id: &str, mode: &str) -> Result<DeviceProfile
 
     let mut account = load_account(account_id)?;
     let _ = device::save_global_original(&profile);
-    apply_profile_to_account(&mut account, profile.clone(), Some(mode.to_string()), true)?;
+    apply_profile_to_account(
+        &mut account, profile.clone(), Some(mode.to_string()), true)?;
 
     Ok(profile)
 }
@@ -723,11 +1249,11 @@ pub fn update_account_quota(account_id: &str, quota: QuotaData) -> Result<(), St
     }
     // --- Quota protection logic end ---
 
-    // 先保存账号
+    // Save account first
     save_account(&account)?;
 
-    // [FIX] 触发 TokenManager 的账号重新加载信号
-    // 这样内存中的 protected_models 会被同步更新
+    // [FIX] Trigger TokenManager account reload signal
+    // This ensures in-memory protected_models are updated
     crate::proxy::server::trigger_account_reload(account_id);
 
     Ok(())
@@ -739,6 +1265,10 @@ pub fn toggle_proxy_status(
     enable: bool,
     reason: Option<&str>,
 ) -> Result<(), String> {
+    let _lock = ACCOUNT_INDEX_LOCK
+        .lock()
+        .map_err(|e| format!("failed_to_acquire_lock: {}", e))?;
+
     let mut account = load_account(account_id)?;
 
     account.proxy_disabled = !enable;
@@ -1023,7 +1553,7 @@ pub async fn refresh_all_quotas_logic() -> Result<RefreshStats, String> {
                 ));
                 return false;
             }
-            // [FIX] 检查 proxy_disabled 状态
+            // [FIX] Check proxy_disabled status
             if account.proxy_disabled {
                 crate::modules::logger::log_info(&format!(
                     "  - Skipping {} (Proxy Disabled)",
@@ -1056,7 +1586,7 @@ pub async fn refresh_all_quotas_logic() -> Result<RefreshStats, String> {
                             crate::modules::logger::log_error(&msg);
                             Err(msg)
                         } else {
-                            crate::modules::logger::log_info(&format!("    ✅ {} Success", email));
+                            crate::modules::logger::log_info(&format!("    Success {}", email));
                             Ok(())
                         }
                     }


### PR DESCRIPTION
## Problem
- After upgrading, accounts may disappear and importing fails with `failed_to_parse_account_index: expected value at line 1 column 1`.
- The app currently hard-fails on a corrupted `accounts.json` index (BOM/NUL/garbage/partial write).
- A race in `toggle_proxy_status` can write the index without `ACCOUNT_INDEX_LOCK`, and previously all writers shared the same temp file name (`accounts.json.tmp`).

## Fix
- `load_account_index` now sanitizes UTF-8 BOM and leading NUL bytes.
- If the index is missing/empty/invalid, it rebuilds the index by scanning `accounts/*.json` so accounts are not "lost".
- On parse failure, it backs up the corrupt index to `accounts.json.corrupt-<timestamp>-<uuid>`.
- `save_account_index` now uses a unique temp file per write and does an atomic replace on Windows via `MoveFileExW`.
- `toggle_proxy_status` now acquires `ACCOUNT_INDEX_LOCK` before updating the index.

## Tests
- Added unit tests for BOM/NUL sanitization, recovery from garbage, rebuild when index is missing, save/load roundtrip, and backup creation on parse failure.