### PR TITLE
fix: image token selection, Opus 4.6 support, thinking budget default & OpenCode CLI

### DIFF
--- a/src-tauri/src/proxy/common/model_mapping.rs
+++ b/src-tauri/src/proxy/common/model_mapping.rs
@@ -326,7 +326,6 @@ mod tests {
         );
 
         // [Regression] gemini-3-pro-image must NOT be grouped with gemini-3-pro-high
-        // This caused image requests to consume text quota instead of image quota
         assert_eq!(
             normalize_to_standard_id("gemini-3-pro-image"),
             Some("gemini-3-pro-image".to_string())


### PR DESCRIPTION
## Summary

This PR addresses **5 open issues** with targeted fixes across the proxy backend, model mapping, and CLI sync layers:

### 1. fix(proxy): replace hardcoded `dall-e-3` in image token selection — Closes #1740
- `get_token()` in `handle_images_generations` and `handle_images_edits` hardcoded `"dall-e-3"` as the target model
- `normalize_to_standard_id("dall-e-3")` returns `None`, so the capability filter falls through to the literal string — which no Google account has quota for — causing **all image generation requests to 502**
- **Fix:** Replace `"dall-e-3"` → `"gemini-3-pro-image"` in both call sites and add `"gemini-3-pro-image"` as its own group in `normalize_to_standard_id()`

### 2. feat(proxy): add Claude Opus 4.6 model support — Closes #1742
- Claude deprecated Opus 4.5; clients now request Opus 4.6 model names which were not recognized
- **Fix:** 
  - Add `claude-opus-4-6-thinking` (+ dated variant) to `CLAUDE_TO_GEMINI` mapping
  - Update `"claude-opus-4"` alias to route to 4.6
  - Add Opus 4.6 to `normalize_to_standard_id()` for quota protection
  - Add Opus 4.6 to `should_enable_thinking_by_default()`
  - Add model entry in UI selector (`useProxyModels.tsx`)
  - Update wildcard presets in `ApiProxy.tsx` to route opus patterns to 4.6

### 3. fix(proxy): inject default thinking budget when auto-enabled for Opus — Closes #1747
- When `should_enable_thinking_by_default()` triggers for Opus models but the client sends **no** `ThinkingConfig`, `thinking.budget_tokens` stays `None`
- Downstream APIs then reject with `AI_UnsupportedFunctionalityError: 'thinking requires a budget'`
- **Fix:** Before the immutable rebind of `cleaned_req`, check if thinking is `None` but the model requires it by default → inject `ThinkingConfig { type_: "enabled", budget_tokens: Some(10000) }`

### 4. feat(cli): add OpenCode CLI detection and sync support — Closes #1739
- The `CliApp` enum only had Claude/Codex/Gemini — OpenCode binary was never detected
- Tauri's process `PATH` on macOS often misses `~/.volta/bin`, causing detection failures even for installed CLIs
- **Fix:**
  - Add `CliApp::OpenCode` variant with binary name, config path (`~/.opencode/config.json`), and default URL
  - Implement sync status check (reads `providers.openai.baseURL`) and sync write logic
  - Add `~/.volta/bin` to the macOS fallback path search (benefits all CLI apps)
  - Update `CliSyncCard.tsx`: add OpenCode to type, state initializers, detection, URL formatting, and render grid

### 5. fix(proxy): prevent gemini-3-pro-image quota consumed by text requests — Closes #1770
- `normalize_to_standard_id()` uses `lower.contains("gemini") && lower.contains("pro")` to group Pro models
- This broad check catches `"gemini-3-pro-image"` and normalizes it to `"gemini-3-pro-high"`, causing **image generation requests to decrement the Pro High (text) quota** instead of the Image quota
- **Fix:** Add an explicit check for `"image"` keyword before the generic `"pro"` check, ensuring `"gemini-3-pro-image"` gets its own quota group
- Added regression tests to verify the three Pro variants normalize correctly

## Files Changed

| File | Changes |
|------|---------|
| `src-tauri/src/proxy/handlers/openai.rs` | Replace `dall-e-3` → `gemini-3-pro-image` in token selection |
| `src-tauri/src/proxy/common/model_mapping.rs` | Add Opus 4.6 mappings + `gemini-3-pro-image` normalization |
| `src-tauri/src/proxy/mappers/claude/request.rs` | Default thinking budget injection + Opus 4.6 in `should_enable_thinking_by_default` |
| `src-tauri/src/proxy/cli_sync.rs` | Add `CliApp::OpenCode` + Volta path + sync/status logic |
| `src/hooks/useProxyModels.tsx` | Add Opus 4.6 to UI model selector |
| `src/pages/ApiProxy.tsx` | Update wildcard presets to route to Opus 4.6 |
| `src/components/proxy/CliSyncCard.tsx` | Add OpenCode to frontend CLI sync card |
| `src-tauri/src/proxy/common/model_mapping.rs` | Fix image quota normalization order + regression tests |

## Test Plan

- [ ] Verify image generation (`/v1/images/generations`) no longer returns 502 — token selection should pick Google accounts with Gemini image quotas
- [ ] Verify image editing (`/v1/images/edits`) works with the same fix
- [ ] Verify `claude-opus-4-6`, `claude-opus-4-6-thinking`, and `claude-opus-4-6-20260201` are correctly mapped and routable
- [ ] Verify requests to Opus models without explicit `ThinkingConfig` no longer error with "thinking requires a budget"
- [ ] Verify OpenCode CLI is detected on macOS (both via `which` and fallback path scan including `~/.volta/bin`)
- [ ] Verify OpenCode sync writes `providers.openai.baseURL` and `apiKey` to `~/.opencode/config.json`
- [ ] Verify the UI model selector shows "Claude 4.6 Opus (Thinking)" in the Claude 4.6 group
- [ ] Verify using gemini-3-pro for text does NOT decrease gemini-3-pro-image quota (normalize_to_standard_id("gemini-3-pro-image") returns "gemini-3-pro-image", not "gemini-3-pro-high")