### PR TITLE
fix: detect bun-installed Claude CLI in macOS fallback paths

### DIFF
--- a/src-tauri/src/proxy/cli_sync.rs
+++ b/src-tauri/src/proxy/cli_sync.rs
@@ -122,6 +122,8 @@ pub fn check_cli_installed(app: &CliApp) -> (bool, Option<String>) {
         let home = dirs::home_dir().unwrap_or_default();
         let mut common_paths = vec![
             home.join(".local/bin"),
+            home.join(".bun/bin"),
+            home.join(".bun/install/global/node_modules/.bin"),
             home.join(".npm-global/bin"),
             home.join(".volta/bin"),
             home.join("bin"),


### PR DESCRIPTION
Fix claude code that cannot be globally installed using bun

>

修复无法用 bun 全局安装的 claude code
