### PR TITLE
fix: Use tailwindcss container to control the hiding and showing of the logo text

### DIFF
--- a/src/components/navbar/NavLogo.tsx
+++ b/src/components/navbar/NavLogo.tsx
@@ -6,16 +6,16 @@ import LogoIcon from '../../../src-tauri/icons/icon.png';
  * Logo 组件 - 独立处理响应式
  * 
  * 响应式策略:
- * - ≥ 1280px (xl): Logo + 文字
- * - < 1280px: 只有 Logo
+ * 父容器宽度 >= 200px: Logo + 文字
+ * 父容器宽度 <  200px: 只有 Logo
  */
 export function NavLogo() {
     const { t } = useTranslation();
     return (
-        <Link to="/" draggable="false" className="flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-base-content">
+        <Link to="/" draggable="false" className="flex w-full min-w-0 items-center gap-2 text-xl font-semibold text-gray-900 dark:text-base-content">
             <img src={LogoIcon} alt="Logo" className="w-8 h-8" draggable="false" />
-            {/* 820px 以下隐藏文字 */}
-            <span className="hidden min-[820px]:inline">{t('common.app_name', 'Antigravity Tools')}</span>
+            {/* 父容器宽度 < 200px 隐藏 */}
+            <span className="hidden @[200px]/logo:inline text-nowrap">{t('common.app_name', 'Antigravity Tools')}</span>
         </Link>
     );
 }

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -109,8 +109,10 @@ function Navbar() {
             <div className="max-w-7xl mx-auto px-8 relative" style={{ zIndex: 10 }}>
                 {/* Flexbox 布局 - 子组件自己处理响应式 */}
                 <div className="flex items-center h-16 gap-4">
-                    {/* Logo - 自己处理响应式 */}
-                    <NavLogo />
+                    {/* Logo - 使用父容器宽度做响应式 */}
+                    <div className="@container/logo basis-[200px] shrink min-w-0">
+                        <NavLogo />
+                    </div>
 
                     {/* 导航菜单 - 自己处理响应式 */}
                     <div className="flex-1 flex justify-center">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 import daisyui from "daisyui";
+import containerQueries from "@tailwindcss/container-queries";
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -10,7 +11,7 @@ export default {
     theme: {
         extend: {},
     },
-    plugins: [daisyui],
+    plugins: [daisyui, containerQueries],
     daisyui: {
         themes: [
             {


### PR DESCRIPTION
Preventing the logo from wrapping onto multiple lines.

before:
<img width="379" height="197" alt="image" src="https://github.com/user-attachments/assets/15033b9a-fa8b-4f3c-b940-33bf4028f936" />

after:
<img width="503" height="105" alt="image" src="https://github.com/user-attachments/assets/d7411f96-35fd-4cd3-b23c-1909f124710b" />

