### PR TITLE
fix(proxy): Cloud Code API 404 错误增加账号轮换重试机制

### DIFF
--- a/src-tauri/src/proxy/tests/mod.rs
+++ b/src-tauri/src/proxy/tests/mod.rs
@@ -3,3 +3,5 @@ pub mod security_ip_tests;
 pub mod security_integration_tests;
 pub mod quota_protection;
 pub mod ultra_priority_tests;
+pub mod retry_strategy_tests;
+pub mod rate_limit_404_tests;

--- a/src-tauri/src/proxy/tests/rate_limit_404_tests.rs
+++ b/src-tauri/src/proxy/tests/rate_limit_404_tests.rs
@@ -1,0 +1,56 @@
+//! 测试 RateLimitTracker::parse_from_error 对 404 状态码的处理逻辑：
+//! - 短时锁定（5s）
+//! - 不累加失败计数
+//! - 与 5xx 锁定时长的差异
+
+use crate::proxy::rate_limit::{RateLimitReason, RateLimitTracker};
+
+#[test]
+fn test_parse_from_error_404_short_lockout() {
+    let tracker = RateLimitTracker::new();
+    let backoff_steps = vec![60, 300, 1800, 7200];
+
+    let info = tracker.parse_from_error("acc_404", 404, None, "Not Found", None, &backoff_steps);
+    assert!(info.is_some(), "404 should return Some(RateLimitInfo)");
+    let info = info.unwrap();
+    assert_eq!(info.retry_after_sec, 5, "404 should lock out for 5 seconds");
+    assert_eq!(info.reason, RateLimitReason::ServerError, "404 reason should be ServerError");
+}
+
+#[test]
+fn test_404_does_not_accumulate_failure_count() {
+    let tracker = RateLimitTracker::new();
+    let backoff_steps = vec![60, 300, 1800, 7200];
+
+    // 连续多次 404，锁定时间应始终为 5s（不像 429 QuotaExhausted 那样递增）
+    for i in 1..=5 {
+        // 清除上一次的限流记录，模拟轮换后再次遇到 404
+        tracker.clear("acc_404_repeat");
+        let info = tracker.parse_from_error(
+            "acc_404_repeat", 404, None, "Not Found", None, &backoff_steps,
+        );
+        assert!(info.is_some(), "404 attempt {} should return Some", i);
+        assert_eq!(
+            info.unwrap().retry_after_sec, 5,
+            "404 attempt {} should still lock for 5s, not escalate", i
+        );
+    }
+}
+
+#[test]
+fn test_404_vs_5xx_lockout_duration() {
+    let tracker = RateLimitTracker::new();
+    let backoff_steps = vec![60, 300, 1800, 7200];
+
+    // 404 → 5s lockout
+    let info_404 = tracker.parse_from_error(
+        "acc_cmp_404", 404, None, "Not Found", None, &backoff_steps,
+    );
+    assert_eq!(info_404.unwrap().retry_after_sec, 5, "404 should lock for 5s");
+
+    // 503 → 8s lockout
+    let info_503 = tracker.parse_from_error(
+        "acc_cmp_503", 503, None, "Service Unavailable", None, &backoff_steps,
+    );
+    assert_eq!(info_503.unwrap().retry_after_sec, 8, "503 should lock for 8s");
+}

--- a/src-tauri/src/proxy/tests/retry_strategy_tests.rs
+++ b/src-tauri/src/proxy/tests/retry_strategy_tests.rs
@@ -1,0 +1,134 @@
+//! 测试 determine_retry_strategy 和 should_rotate_account 的所有分支，
+//! 重点覆盖 404 重试与账号轮换逻辑。
+
+use std::time::Duration;
+use crate::proxy::handlers::common::{determine_retry_strategy, should_rotate_account, RetryStrategy};
+
+// ===== determine_retry_strategy =====
+
+#[test]
+fn test_retry_strategy_404() {
+    let strategy = determine_retry_strategy(404, "", false);
+    match strategy {
+        RetryStrategy::FixedDelay(d) => assert_eq!(d, Duration::from_millis(300)),
+        other => panic!("Expected FixedDelay(300ms), got {:?}", other),
+    }
+}
+
+#[test]
+fn test_retry_strategy_429_no_delay() {
+    let strategy = determine_retry_strategy(429, "rate limited", false);
+    assert!(
+        matches!(strategy, RetryStrategy::LinearBackoff { base_ms: 5000 }),
+        "Expected LinearBackoff {{ base_ms: 5000 }}, got {:?}",
+        strategy
+    );
+}
+
+#[test]
+fn test_retry_strategy_503() {
+    let strategy = determine_retry_strategy(503, "", false);
+    assert!(
+        matches!(strategy, RetryStrategy::ExponentialBackoff { base_ms: 10000, max_ms: 60000 }),
+        "Expected ExponentialBackoff {{ base_ms: 10000, max_ms: 60000 }}, got {:?}",
+        strategy
+    );
+}
+
+#[test]
+fn test_retry_strategy_529() {
+    let strategy = determine_retry_strategy(529, "", false);
+    assert!(
+        matches!(strategy, RetryStrategy::ExponentialBackoff { base_ms: 10000, max_ms: 60000 }),
+        "Expected ExponentialBackoff {{ base_ms: 10000, max_ms: 60000 }}, got {:?}",
+        strategy
+    );
+}
+
+#[test]
+fn test_retry_strategy_500() {
+    let strategy = determine_retry_strategy(500, "", false);
+    assert!(
+        matches!(strategy, RetryStrategy::LinearBackoff { base_ms: 3000 }),
+        "Expected LinearBackoff {{ base_ms: 3000 }}, got {:?}",
+        strategy
+    );
+}
+
+#[test]
+fn test_retry_strategy_401_403() {
+    for status in [401, 403] {
+        let strategy = determine_retry_strategy(status, "", false);
+        match strategy {
+            RetryStrategy::FixedDelay(d) => assert_eq!(d, Duration::from_millis(200)),
+            other => panic!("Expected FixedDelay(200ms) for {}, got {:?}", status, other),
+        }
+    }
+}
+
+#[test]
+fn test_retry_strategy_other() {
+    for status in [200, 201, 301, 418, 502] {
+        let strategy = determine_retry_strategy(status, "", false);
+        assert!(
+            matches!(strategy, RetryStrategy::NoRetry),
+            "Expected NoRetry for {}, got {:?}",
+            status,
+            strategy
+        );
+    }
+}
+
+#[test]
+fn test_retry_strategy_400_thinking_signature() {
+    let signatures = [
+        "Invalid `signature` for thinking",
+        "Error with thinking.signature",
+        "thinking.thinking block failed",
+        "Corrupted thought signature detected",
+    ];
+    for sig in signatures {
+        let strategy = determine_retry_strategy(400, sig, false);
+        match strategy {
+            RetryStrategy::FixedDelay(d) => assert_eq!(d, Duration::from_millis(200)),
+            other => panic!(
+                "Expected FixedDelay(200ms) for 400 + '{}', got {:?}",
+                sig, other
+            ),
+        }
+    }
+}
+
+#[test]
+fn test_retry_strategy_400_no_signature() {
+    let strategy = determine_retry_strategy(400, "bad request", false);
+    assert!(
+        matches!(strategy, RetryStrategy::NoRetry),
+        "Expected NoRetry for 400 without signature, got {:?}",
+        strategy
+    );
+}
+
+// ===== should_rotate_account =====
+
+#[test]
+fn test_rotate_account_true_cases() {
+    for status in [429, 401, 403, 404, 500] {
+        assert!(
+            should_rotate_account(status),
+            "Expected should_rotate_account({}) == true",
+            status
+        );
+    }
+}
+
+#[test]
+fn test_rotate_account_false_cases() {
+    for status in [400, 503, 529, 200, 502] {
+        assert!(
+            !should_rotate_account(status),
+            "Expected should_rotate_account({}) == false",
+            status
+        );
+    }
+}


### PR DESCRIPTION
## 问题描述

Google Cloud Code API 在特定账号上会间歇性返回 `404 NOT_FOUND`（"Requested entity was not found."），但同一模型在其他账号上可正常使用。这是由于 Google 模型灰度发布或账号权限不同步导致的账号级别间歇性问题。

## 根因分析

- `determine_retry_strategy(404)` 返回 `NoRetry`，直接放弃
- `should_rotate_account(404)` 返回 `false`，不触发换号
- `mark_rate_limited_async` 不包含 404，失败账号不被锁定，P2C 算法反复选中同一账号

## 修复内容

| 文件 | 修改 |
|------|------|
| `common.rs` | 404 → `FixedDelay(300ms)` 重试 + 触发账号轮换 |
| `claude.rs` | 404 触发 `mark_rate_limited_async` |
| `rate_limit.rs` | `parse_from_error` 支持 404；锁定 5 秒，不累加 failure_count |

## 修复后行为

```
account A → 404 → 锁定 A 5 秒 → 轮换到 account B → 成功 ✅
                                                    → 5 秒后 A 自动解锁
```

## 设计决策

| 决策 | 理由 |
|------|------|
| 锁定 5 秒 | 间歇性问题，短暂避让即可，非永久故障 |
| 不累加 failure_count | 避免锁定时间指数增长（60s→300s→1800s），保持固定 5 秒 |
| 复用 ServerError 逻辑 | 最小改动，不引入新枚举值 |


让404不中断反代的工作。
<img width="3646" height="1908" alt="fc67b1bb56f0e28a3c5e9c13b2f757e8" src="https://github.com/user-attachments/assets/29ca0489-8335-4e1f-9b67-1c61bd73d7cf" />
<img width="2720" height="2012" alt="647d0bc41ceb8322f42345c79e001ca4" src="https://github.com/user-attachments/assets/f4df9e06-2e70-4e3e-b43a-f13ec23f008e" />

## 测试用例

新增 14 个单元测试，覆盖 404 重试与账号轮换的所有分支逻辑。

### `retry_strategy_tests.rs` — 重试策略与账号轮换 (11 tests)

| 测试 | 验证内容 |
|------|----------|
| `test_retry_strategy_404` | 404 → `FixedDelay(300ms)` |
| `test_retry_strategy_429_no_delay` | 429 无解析延迟 → `LinearBackoff { base_ms: 5000 }` |
| `test_retry_strategy_503` | 503 → `ExponentialBackoff { base_ms: 10000, max_ms: 60000 }` |
| `test_retry_strategy_529` | 529 → 同 503 |
| `test_retry_strategy_500` | 500 → `LinearBackoff { base_ms: 3000 }` |
| `test_retry_strategy_401_403` | 401/403 → `FixedDelay(200ms)` |
| `test_retry_strategy_other` | 200/201/301/418/502 → `NoRetry` |
| `test_retry_strategy_400_thinking_signature` | 400 + thinking 签名 → `FixedDelay(200ms)` |
| `test_retry_strategy_400_no_signature` | 400 无签名 → `NoRetry` |
| `test_rotate_account_true_cases` | 429/401/403/404/500 → 轮换 |
| `test_rotate_account_false_cases` | 400/503/529/200/502 → 不轮换 |

### `rate_limit_404_tests.rs` — 限流跟踪器 404 处理 (3 tests)

| 测试 | 验证内容 |
|------|----------|
| `test_parse_from_error_404_short_lockout` | 404 → 锁定 5s，reason = `ServerError` |
| `test_404_does_not_accumulate_failure_count` | 连续 5 次 404 始终锁定 5s，不递增 |
| `test_404_vs_5xx_lockout_duration` | 404 锁 5s vs 503 锁 8s，验证差异 |

<img width="1840" height="1006" alt="image" src="https://github.com/user-attachments/assets/ff69a9f7-38db-4b08-a1b6-4860e1b25370" />

```
test result: ok. 22 passed; 0 failed; 0 ignored
```