### PR TITLE
fix(proxy): route opus 4.6 thinking alias to physical id

### DIFF
--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -90,6 +90,13 @@ export const MODEL_CONFIG: Record<string, ModelConfig> = {
         protectedKey: 'claude-opus',
         Icon: Claude.Color,
     },
+    // Opus 4.6 upstream id (some clients / quota APIs may report without "-thinking")
+    'claude-opus-4-6': {
+        label: 'Claude 4.6 Opus',
+        shortLabel: 'Claude 4.6 Op',
+        protectedKey: 'claude-opus',
+        Icon: Claude.Color,
+    },
     'claude-opus-4-6-thinking': {
         label: 'Claude 4.6 Opus Think',
         shortLabel: 'Claude 4.6 Op',
@@ -203,4 +210,3 @@ export function sortModels<T extends { id: string }>(models: T[]): T[] {
         return a.id.localeCompare(b.id);
     });
 }
-

--- a/src/hooks/useProxyModels.tsx
+++ b/src/hooks/useProxyModels.tsx
@@ -82,6 +82,13 @@ export const useProxyModels = () => {
             icon: <Cpu size={16} />
         },
         {
+            id: 'claude-opus-4-6',
+            name: 'Claude 4.6 Opus',
+            desc: t('proxy.model.claude_opus_thinking'),
+            group: 'Claude 4.6',
+            icon: <Cpu size={16} />
+        },
+        {
             id: 'claude-opus-4-6-thinking',
             name: 'Claude 4.6 Opus (Thinking)',
             desc: t('proxy.model.claude_opus_thinking'),


### PR DESCRIPTION
- Map claude-opus-4-6-thinking and versioned aliases to claude-opus-4-6

- Normalize all opus 4.6 variants to a dedicated standard id for capability filtering

- Add claude-opus-4-6 to UI model registries for quota display / CLI sync