### PR TITLE
Fix 403 forbidden marking during warmup operations

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "antigravity_tools"
-version = "4.1.12"
+version = "4.1.13"
 dependencies = [
  "aes-gcm",
  "anyhow",


### PR DESCRIPTION
Accounts returning 403 during warmup were not marked as `is_forbidden`, so invalid accounts continued participating in polling/rotation. The 403 marking only triggered in the proxy request handlers (`openai.rs`, `claude.rs`), not in any warmup code path.

### Changes

- **`warmup.rs`** — Call `token_manager.set_forbidden()` when upstream returns 403 during warmup, matching the existing pattern in `openai.rs`/`claude.rs`
- **`scheduler.rs`** — Check `is_forbidden` on quota data returned by `fetch_quota_with_cache()` in both `start_scheduler` and `trigger_warmup_for_account`; persist via `update_account_quota()` and skip the account
- **`quota.rs`** — Same `is_forbidden` check in `warm_up_all_accounts` and `warm_up_account`

### Example (warmup.rs)

```rust
// Before: 403 response logged but account not marked
let error_text = response.text().await.unwrap_or_default();

// After: mark account as forbidden on 403, same as openai/claude handlers
if status_code == 403 && !account_id.is_empty() {
    if let Err(e) = state.token_manager.set_forbidden(&account_id, &error_text).await {
        warn!("[Warmup-API] Failed to set forbidden status: {}", e);
    }
}
```    