### PR TITLE
feat(opencode): isolate sync into antigravity-manager provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,10 +242,20 @@ claude
 
 ### 如何接入 OpenCode?
 1.  进入 **API 反代**页面 → **外部 Providers** → 点击 **OpenCode Sync** 卡片。
-2.  点击 **Sync** 按钮，将自动生成 `~/.config/opencode/opencode.json` 配置文件（包含代理 baseURL 与 apiKey，支持 Anthropic/Google 双 Provider）。
-3.  可选：勾选 **Sync accounts** 可同时导出 `antigravity-accounts.json` 账号列表，供 OpenCode 插件直接导入使用。
+2.  点击 **Sync** 按钮，将自动生成 `~/.config/opencode/opencode.json` 配置文件：
+    - 创建独立 provider `antigravity-manager`（不覆盖 google/anthropic 原生配置）
+    - 可选：勾选 **Sync accounts** 导出 `antigravity-accounts.json`（plugin-compatible v3 格式），供 OpenCode 插件直接导入
+3.  点击 **Clear Config** 可一键清除 Manager 配置并清理 legacy 残留；点击 **Restore** 可从备份恢复。
 4.  Windows 用户路径为 `C:\Users\<用户名>\.config\opencode\`（与 `~/.config/opencode` 规则一致）。
-5.  如需回滚，可点击 **Restore** 按钮从备份恢复之前的配置。
+
+**快速验证命令：**
+```bash
+# 测试 antigravity-manager provider（支持 --variant）
+opencode run "test" --model antigravity-manager/claude-sonnet-4-5-thinking --variant high
+
+# 若已安装 opencode-antigravity-auth 插件，验证 google provider 仍可独立工作
+opencode run "test" --model google/antigravity-claude-sonnet-4-5-thinking --variant max
+```
 
 ### 如何接入 Kilo Code?
 1.  **协议选择**: 建议优先使用 **Gemini 协议**。

--- a/README_EN.md
+++ b/README_EN.md
@@ -231,10 +231,20 @@ claude
 
 ### How to use with OpenCode?
 1. Go to **API Proxy** → **External Providers** → click the **OpenCode Sync** card.
-2. Click **Sync** to generate `~/.config/opencode/opencode.json` with proxy baseURL and apiKey (supports both Anthropic and Google providers).
-3. Optional: Check **Sync accounts** to export `antigravity-accounts.json` for OpenCode plugin usage.
+2. Click **Sync** to generate `~/.config/opencode/opencode.json`:
+    - Creates a dedicated provider `antigravity-manager` (does not overwrite google/anthropic providers)
+    - Optional: Check **Sync accounts** to export `antigravity-accounts.json` (plugin-compatible v3 format) for the OpenCode plugin
+3. Click **Clear Config** to remove Manager configuration and clean up legacy entries; click **Restore** to revert from backup.
 4. On Windows, the path is `C:\Users\<User>\.config\opencode\` (same `~/.config/opencode` rule).
-5. Use the **Restore** button to revert from backup if needed.
+
+**Quick verification commands:**
+```bash
+# Test antigravity-manager provider (supports --variant)
+opencode run "test" --model antigravity-manager/claude-sonnet-4-5-thinking --variant high
+
+# If opencode-antigravity-auth is installed, verify google provider still works independently
+opencode run "test" --model google/antigravity-claude-sonnet-4-5-thinking --variant max
+```
 
 ### How to use in Python?
 ```python

--- a/docs/testing/opencode_sync_verification_checklist.md
+++ b/docs/testing/opencode_sync_verification_checklist.md
@@ -1,0 +1,174 @@
+# OpenCode Sync Verification Checklist
+
+> Manual test checklist for OpenCode sync feature PR
+
+## 1. Pre-check
+
+### 1.1 Backup Files Path
+- [ ] Verify backup suffix: `.antigravity-manager.bak` (new) and `.antigravity.bak` (legacy)
+- [ ] Verify backup location: `~/.config/opencode/opencode.json.antigravity-manager.bak`
+- [ ] Verify accounts backup: `~/.config/opencode/antigravity-accounts.json.antigravity-manager.bak`
+
+### 1.2 Plugin Installation Scenarios
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Plugin NOT installed | Sync button available, shows "OpenCode not detected" warning |
+| Plugin installed | Shows version, sync enabled |
+| Plugin path auto-detect | Finds opencode in PATH, npm, pnpm, yarn, nvm, fnm, Volta |
+
+---
+
+## 2. Sync Behavior Verification
+
+### 2.1 Provider Creation
+- [ ] `provider.antigravity-manager` created with correct structure
+- [ ] `npm`: `@ai-sdk/anthropic`
+- [ ] `name`: `Antigravity Manager`
+- [ ] `options.baseURL`: ends with `/v1` (auto-normalized)
+- [ ] `options.apiKey`: matches proxy API key
+
+### 2.2 Existing Providers Not Overwritten
+- [ ] `provider.google` preserved (if exists)
+- [ ] `provider.anthropic` preserved (if exists)
+- [ ] Other providers untouched
+
+### 2.3 Accounts Export File (v3 Structure)
+```json
+{
+  "version": 3,
+  "accounts": [...],
+  "activeIndex": 0,
+  "activeIndexByFamily": {
+    "claude": 0,
+    "gemini": 0
+  }
+}
+```
+- [ ] File created at `~/.config/opencode/antigravity-accounts.json`
+- [ ] `version` field = 3
+- [ ] `activeIndex` clamped to valid range
+- [ ] `activeIndexByFamily` contains `claude` and `gemini` keys
+- [ ] Disabled accounts excluded from export
+
+---
+
+## 3. Variants/Thinking Behavior Verification
+
+### 3.1 Claude Thinking Models
+```bash
+opencode run "test" --model antigravity-manager/claude-sonnet-4-5-thinking --variant high
+```
+- [ ] `--variant low` → `thinkingBudget: 8192`
+- [ ] `--variant medium` → `thinkingBudget: 16384`
+- [ ] `--variant high` → `thinkingBudget: 24576`
+- [ ] `--variant max` → `thinkingBudget: 32768`
+
+### 3.2 Gemini 3 Pro Models
+```bash
+opencode run "test" --model antigravity-manager/gemini-3-pro-high --variant low
+```
+- [ ] `--variant low` → `thinkingLevel: "low"`
+- [ ] `--variant high` → `thinkingLevel: "high"`
+
+### 3.3 Gemini 3 Flash Models
+- [ ] `--variant minimal` → `thinkingLevel: "minimal"`
+- [ ] `--variant low` → `thinkingLevel: "low"`
+- [ ] `--variant medium` → `thinkingLevel: "medium"`
+- [ ] `--variant high` → `thinkingLevel: "high"`
+
+### 3.4 Gemini 2.5 Flash Thinking
+- [ ] `--variant low` → `thinkingBudget: 8192`
+- [ ] `--variant medium` → `thinkingBudget: 12288`
+- [ ] `--variant high` → `thinkingBudget: 16384`
+- [ ] `--variant max` → `thinkingBudget: 24576`
+
+---
+
+## 4. Plugin Compatibility Verification
+
+### 4.1 Plugin Model Unaffected
+```bash
+# If opencode-antigravity-auth plugin installed
+opencode run "test" --model google/antigravity-claude-sonnet-4-5-thinking --variant max
+```
+- [ ] Plugin provider works independently
+- [ ] Manager sync does not interfere with plugin accounts
+- [ ] Both can coexist
+
+---
+
+## 5. Clear/Restore Verification
+
+### 5.1 Clear Config
+- [ ] Removes `provider.antigravity-manager`
+- [ ] Optional: clears legacy entries from `provider.google` and `provider.anthropic`
+- [ ] Preserves other providers
+
+### 5.2 Restore Function
+| Backup Type | Expected Result |
+|-------------|-----------------|
+| New suffix (`.antigravity-manager.bak`) | Restores successfully |
+| Old suffix (`.antigravity.bak`) | Restores successfully (backward compatible) |
+| Both exist | Prefers new suffix |
+| None exists | Shows "No backup files found" error |
+
+---
+
+## 6. Pass/Fail Summary Table
+
+| Test Category | Test Item | Status |
+|---------------|-----------|--------|
+| Pre-check | Backup path correct | ⬜ Pass / ⬜ Fail |
+| Pre-check | Plugin detection works | ⬜ Pass / ⬜ Fail |
+| Sync | Provider created correctly | ⬜ Pass / ⬜ Fail |
+| Sync | Existing providers preserved | ⬜ Pass / ⬜ Fail |
+| Sync | Accounts v3 structure valid | ⬜ Pass / ⬜ Fail |
+| Variants | Claude thinking budgets | ⬜ Pass / ⬜ Fail |
+| Variants | Gemini 3 Pro levels | ⬜ Pass / ⬜ Fail |
+| Variants | Gemini 3 Flash levels | ⬜ Pass / ⬜ Fail |
+| Variants | Gemini 2.5 thinking budgets | ⬜ Pass / ⬜ Fail |
+| Compatibility | Plugin unaffected | ⬜ Pass / ⬜ Fail |
+| Clear/Restore | Clear removes manager provider | ⬜ Pass / ⬜ Fail |
+| Clear/Restore | Restore with new suffix | ⬜ Pass / ⬜ Fail |
+| Clear/Restore | Restore with old suffix | ⬜ Pass / ⬜ Fail |
+
+---
+
+## 7. Troubleshooting Notes
+
+### Issue: Sync fails with "Failed to get OpenCode config directory"
+**Cause:** Cannot determine home directory  
+**Fix:** Ensure `HOME` (Unix) or `USERPROFILE` (Windows) env var is set
+
+### Issue: Variant not applied
+**Cause:** Model ID mismatch or variant type not defined  
+**Fix:** Check model ID in catalog matches request; verify `variant_type` in `build_model_catalog()`
+
+### Issue: Backup not created
+**Cause:** Backup file already exists (idempotent)  
+**Fix:** Delete existing `.bak` files manually if you need fresh backup
+
+### Issue: Accounts not exported
+**Cause:** All accounts disabled or `sync_accounts` not checked  
+**Fix:** Enable at least one account; check "Sync accounts" option in UI
+
+### Issue: Plugin conflicts with manager provider
+**Cause:** Both using same model IDs  
+**Fix:** Use different model IDs or disable one provider
+
+### Issue: Restore fails
+**Cause:** Backup files missing or permissions  
+**Check:** 
+```bash
+ls -la ~/.config/opencode/*.bak
+```
+
+---
+
+## Test Environment
+
+- **OS**: 
+- **OpenCode Version**: 
+- **Antigravity Manager Version**: 
+- **Test Date**: 
+- **Tester**: 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -450,6 +450,7 @@ pub fn run() {
             proxy::opencode_sync::execute_opencode_sync,
             proxy::opencode_sync::execute_opencode_restore,
             proxy::opencode_sync::get_opencode_config_content,
+            proxy::opencode_sync::execute_opencode_clear,
             proxy::droid_sync::get_droid_sync_status,
             proxy::droid_sync::execute_droid_sync,
             proxy::droid_sync::execute_droid_restore,

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -509,6 +509,7 @@ impl AxumServer {
             .route("/proxy/opencode/status", post(admin_get_opencode_sync_status))
             .route("/proxy/opencode/sync", post(admin_execute_opencode_sync))
             .route("/proxy/opencode/restore", post(admin_execute_opencode_restore))
+            .route("/proxy/opencode/clear", post(admin_execute_opencode_clear))
             .route("/proxy/opencode/config", post(admin_get_opencode_config_content))
             .route("/proxy/droid/status", post(admin_get_droid_sync_status))
             .route("/proxy/droid/sync", post(admin_execute_droid_sync))
@@ -3406,6 +3407,25 @@ async fn admin_get_opencode_config_content(
             Json(ErrorResponse { error: e.to_string() }),
         ))?
         .map(Json)
+        .map_err(|e| (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse { error: e }),
+        ))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OpencodeClearRequest {
+    proxy_url: Option<String>,
+    clear_legacy: Option<bool>,
+}
+
+async fn admin_execute_opencode_clear(
+    Json(payload): Json<OpencodeClearRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    crate::proxy::opencode_sync::execute_opencode_clear(payload.proxy_url, payload.clear_legacy)
+        .await
+        .map(|_| StatusCode::OK)
         .map_err(|e| (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse { error: e }),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -746,10 +746,15 @@
                 "btn_view": "View Config",
                 "btn_restore": "Restore",
                 "btn_restore_backup": "Restore Backup",
+                "btn_clear": "Clear Config",
+                "clear_confirm_title": "Confirm Clear Config",
+                "clear_confirm_message": "Are you sure you want to clear OpenCode configuration? This will remove the config file.",
                 "toast": {
                     "config_missing": "Please generate API Key and start service first",
                     "sync_success": "OpenCode config synced successfully",
-                    "sync_error": "OpenCode sync failed: {{error}}"
+                    "sync_error": "OpenCode sync failed: {{error}}",
+                    "clear_success": "OpenCode config cleared successfully",
+                    "clear_error": "Failed to clear OpenCode config: {{error}}"
                 },
                 "modal": {
                     "view_title": "OpenCode Config Viewer",
@@ -761,6 +766,7 @@
                 "restore_backup_confirm": "Are you sure you want to restore OpenCode config from backup?",
                 "modal_title": "Select OpenCode Models",
                 "select_models": "Select models to sync",
+                "auth_plugin_warning": "Detected opencode-antigravity-auth plugin. Sync only creates provider antigravity-manager and will not overwrite the google provider/plugin.",
                 "btn_confirm_sync": "Confirm Sync"
             },
             "droid_sync": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -767,10 +767,15 @@
         "btn_view": "設定を表示",
         "btn_restore": "復元",
         "btn_restore_backup": "バックアップから復元",
+        "btn_clear": "設定をクリア",
+        "clear_confirm_title": "設定のクリアを確認",
+        "clear_confirm_message": "OpenCode の設定をクリアしてもよろしいですか？設定ファイルが削除されます。",
         "toast": {
           "config_missing": "APIキーを生成し、サービスを先に起動してください",
           "sync_success": "OpenCode の設定を同期しました",
-          "sync_error": "OpenCode の同期に失敗しました: {{error}}"
+          "sync_error": "OpenCode の同期に失敗しました: {{error}}",
+          "clear_success": "OpenCode の設定をクリアしました",
+          "clear_error": "OpenCode の設定クリアに失敗しました: {{error}}"
         },
         "modal": {
           "view_title": "OpenCode 設定ビューアー",
@@ -779,7 +784,8 @@
         "sync_confirm_title": "同期の確認",
         "sync_confirm_message": "現在のプロキシ設定に基づき、OpenCode の設定が上書きされます。続行しますか？",
         "restore_confirm": "OpenCode をデフォルト設定に復元しますか？",
-        "restore_backup_confirm": "バックアップから OpenCode の設定を復元しますか？"
+        "restore_backup_confirm": "バックアップから OpenCode の設定を復元しますか？",
+        "auth_plugin_warning": "opencode-antigravity-auth プラグインを検出しました。同期では antigravity-manager provider のみ作成し、google provider/plugin は上書きしません。"
       },
       "droid_sync": {
         "modal_title": "Droid にモデルを追加",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -737,10 +737,15 @@
                 "btn_view": "查看配置",
                 "btn_restore": "还原配置",
                 "btn_restore_backup": "从备份还原",
+                "btn_clear": "清除配置",
+                "clear_confirm_title": "确认清除配置",
+                "clear_confirm_message": "确定要清除 OpenCode 配置吗？这将删除配置文件。",
                 "toast": {
                     "config_missing": "请先生成 API Key 并启动服务",
                     "sync_success": "OpenCode 配置同步成功",
-                    "sync_error": "OpenCode 同步失败: {{error}}"
+                    "sync_error": "OpenCode 同步失败: {{error}}",
+                    "clear_success": "OpenCode 配置已清除",
+                    "clear_error": "清除 OpenCode 配置失败: {{error}}"
                 },
                 "modal": {
                     "view_title": "OpenCode 配置文件预览",
@@ -752,6 +757,7 @@
                 "restore_backup_confirm": "确定要从备份还原 OpenCode 配置吗？",
                 "modal_title": "选择 OpenCode 模型",
                 "select_models": "选择要同步的模型",
+                "auth_plugin_warning": "检测到 opencode-antigravity-auth 插件。同步仅会创建 antigravity-manager provider，不会覆盖 google provider/plugin。",
                 "btn_confirm_sync": "确认同步"
             },
             "droid_sync": {

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -71,6 +71,7 @@ const COMMAND_MAPPING: Record<string, { url: string; method: 'GET' | 'POST' | 'D
   'get_opencode_sync_status': { url: '/api/proxy/opencode/status', method: 'POST' },
   'execute_opencode_sync': { url: '/api/proxy/opencode/sync', method: 'POST' },
   'execute_opencode_restore': { url: '/api/proxy/opencode/restore', method: 'POST' },
+  'execute_opencode_clear': { url: '/api/proxy/opencode/clear', method: 'POST' },
   'get_opencode_config_content': { url: '/api/proxy/opencode/config', method: 'POST' },
 
   // Stats


### PR DESCRIPTION
## Summary
- Move OpenCode sync to a dedicated `provider.antigravity-manager` instead of modifying `provider.google`/`provider.anthropic`, preventing conflicts with `opencode-antigravity-auth`.
- Add full OpenCode config management flow: `Clear Config` (with optional legacy cleanup), backup/restore compatibility for both `.antigravity-manager.bak` and legacy `.antigravity.bak`.
- Add provider model catalog + variant support (Claude/Gemini thinking options), plugin-compatible account export format v3, and OpenCode-thinking hint mapping in Claude handler.

## Key Changes
- **Backend (`src-tauri`)**
  - Refactor OpenCode sync/status logic to target only `provider.antigravity-manager`.
  - Normalize OpenCode base URL to `/v1` consistently for sync/status matching.
  - Add dedicated clear command: `execute_opencode_clear(proxyUrl?, clearLegacy?)`.
  - Add `/api/proxy/opencode/clear` admin route and Tauri invoke wiring.
  - Export `antigravity-accounts.json` in plugin-compatible v3 shape (`version`, `accounts`, `activeIndex`, `activeIndexByFamily`) while preserving existing account state fields.
  - Add pure sync/clear helpers and extensive unit tests for safety-critical behavior.
- **Frontend (`src`)**
  - Add OpenCode `Clear Config` action with destructive confirmation and toast feedback.
  - Add OpenCode modal warning when `opencode-antigravity-auth` plugin is detected.
  - Add web request mapping for `execute_opencode_clear`.
  - Update i18n strings (`en/zh/ja`) for clear flow and plugin-warning messaging.
- **Docs**
  - Update `README.md` and `README_EN.md` OpenCode sections for dedicated provider flow.
  - Add manual test guide: `docs/testing/opencode_sync_verification_checklist.md`.

## Validation
- `npm run build`
- `cargo test proxy::opencode_sync::tests --lib`
- `cargo check`

## Notes / Rollback
- Existing configs are backed up before sync/clear; restore supports both new and old backup suffixes.
- Clear supports optional legacy cleanup of old sync footprints in `provider.google`/`provider.anthropic` only when proxy URL matches.