### PR TITLE
feat(updater): enable native auto-update for macOS and Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,19 +157,70 @@ jobs:
             echo "See the assets to download this version and install." > release_notes.md
           fi
 
-      - name: Merge updater JSONs
+      - name: Build updater.json from signatures
+        env:
+          VERSION: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
         run: |
-          echo "Merging updater.json files..."
-          echo "{}" > merged_updater.json
-          find all-artifacts -name "*.json" -type f | while read json_file; do
-            if jq -e . "$json_file" >/dev/null 2>&1; then
-              echo "Merging valid JSON: $json_file..."
-              jq -s '.[0] * .[1]' merged_updater.json "$json_file" > temp.json && mv temp.json merged_updater.json
+          DOWNLOAD_BASE="https://github.com/${REPO}/releases/download/${VERSION}"
+          VER="${VERSION#v}"
+
+          # Helper: read signature content from .sig file in artifacts
+          read_sig() {
+            local pattern="$1"
+            local sig_file
+            sig_file=$(find all-artifacts -name "$pattern" -type f 2>/dev/null | head -1)
+            if [ -n "$sig_file" ] && [ -f "$sig_file" ]; then
+              cat "$sig_file"
             else
-              echo "Skipping invalid JSON: $json_file"
+              echo ""
             fi
-          done
-          mv merged_updater.json updater.json
+          }
+
+          # Read signatures for each platform
+          MACOS_AARCH64_SIG=$(read_sig "*_aarch64.app.tar.gz.sig")
+          MACOS_X64_SIG=$(read_sig "*_x64.app.tar.gz.sig")
+          WINDOWS_NSIS_SIG=$(read_sig "*_x64-setup.exe.sig")
+
+          echo "Signatures found:"
+          [ -n "$MACOS_AARCH64_SIG" ] && echo "  macOS aarch64: YES" || echo "  macOS aarch64: NO"
+          [ -n "$MACOS_X64_SIG" ] && echo "  macOS x64: YES" || echo "  macOS x64: NO"
+          [ -n "$WINDOWS_NSIS_SIG" ] && echo "  Windows x64: YES" || echo "  Windows x64: NO"
+
+          # Build updater.json with platform-specific download URLs and signatures
+          # macOS: arch-suffixed filenames (no version in name)
+          # Windows: version included in filename
+          jq -n \
+            --arg version "$VER" \
+            --arg notes "See release page for details" \
+            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg dl "$DOWNLOAD_BASE" \
+            --arg mac_a64_sig "$MACOS_AARCH64_SIG" \
+            --arg mac_x64_sig "$MACOS_X64_SIG" \
+            --arg win_nsis_sig "$WINDOWS_NSIS_SIG" \
+            --arg ver "$VER" \
+            '{
+              version: $version,
+              notes: $notes,
+              pub_date: $pub_date,
+              platforms: {
+                "darwin-aarch64": {
+                  url: "\($dl)/Antigravity.Tools_aarch64.app.tar.gz",
+                  signature: $mac_a64_sig
+                },
+                "darwin-x86_64": {
+                  url: "\($dl)/Antigravity.Tools_x64.app.tar.gz",
+                  signature: $mac_x64_sig
+                },
+                "windows-x86_64": {
+                  url: "\($dl)/Antigravity.Tools_\($ver)_x64-setup.exe",
+                  signature: $win_nsis_sig
+                }
+              }
+            }' > updater.json
+
+          echo "Generated updater.json:"
+          cat updater.json
 
       # 使用 ncipollo/release-action 进行统一发布，支持稳健覆盖
       - name: Create or Update GitHub Release

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -26,6 +26,7 @@
     "autostart:allow-disable",
     "autostart:allow-is-enabled",
     "window-state:default",
+    "updater:default",
     "process:allow-restart",
     "process:allow-exit"
   ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,7 +43,7 @@
   },
   "plugins": {
     "updater": {
-      "active": false,
+      "active": true,
       "endpoints": [
         "https://github.com/lbjlaq/Antigravity-Manager/releases/latest/download/updater.json"
       ],


### PR DESCRIPTION
## Summary

Enable Tauri's built-in auto-updater so users can download and install updates in-app instead of being redirected to the GitHub releases page for manual download.

**Root cause of the current broken state:**
- `plugins.updater.active` was set to `false` (disabled in commit c2caeb1 due to signing key issues during local builds)
- `updater:default` capability was missing, blocking frontend API calls
- The release workflow's "Merge updater JSONs" step produced empty `{}` for **all releases** (v4.1.11, v4.1.12, v4.1.13) because `find` found no JSON files to merge

**What this PR does:**
- `tauri.conf.json`: `active: false` → `true`
- `capabilities/default.json`: add `updater:default` permission
- `release.yml`: replace the broken merge step with a new script that reads `.sig` signature files from build artifacts and constructs a proper `updater.json` with correct platform URLs

**Platforms supported:**
- macOS (aarch64 + x86_64)
- Windows (x86_64)

**No code changes needed** — the frontend (`UpdateNotification.tsx`) already implements the full auto-update flow: `tauriCheck()` → `downloadAndInstall(progress)` → `tauriRelaunch()`. This PR simply unblocks the pipeline.

## Verified

- [x] `cargo build` compiles successfully
- [x] Signing keys confirmed working (existing `.sig` files in releases contain valid signatures)
- [x] `pubkey` already configured in `tauri.conf.json`
- [x] `process:allow-restart` already present in capabilities (added by upstream)
- [x] macOS entitlements include `com.apple.security.network.client`
- [x] `createUpdaterArtifacts: true` already set in bundle config
- [x] Release workflow generates `.sig` files for all platforms

## Note

- Local `cargo tauri build` requires `TAURI_SIGNING_PRIVATE_KEY` env var (CI has this configured as a secret)
- Homebrew Cask users may need separate handling (upstream already added `is_homebrew_installed()` detection — can be addressed in a follow-up)