### PR TITLE
fix(opencode): restore Opus 4.6 thinking sync and variant hint mapping

### DIFF
--- a/docs/testing/opencode_sync_followup_roadmap.md
+++ b/docs/testing/opencode_sync_followup_roadmap.md
@@ -1,0 +1,69 @@
+# OpenCode Sync Follow-up Roadmap
+
+## Context
+
+This follow-up addresses two production issues reported after the OpenCode provider-isolation change:
+
+1. `Claude Opus 4.6 Thinking` can be selected in the app sync modal, but does not appear in OpenCode model picker after sync.
+2. Thinking variant changes (for example via `Ctrl+T` in OpenCode) are not reliably applied by proxy logic.
+
+## Objectives
+
+- Keep OpenCode model catalog in sync with app model registry.
+- Ensure thinking hints are extracted from both root payload fields and `providerOptions` fields.
+- Preserve backward compatibility for existing thinking payload shapes.
+
+## Scope
+
+### In scope
+
+- `src-tauri/src/proxy/opencode_sync.rs`
+  - Correct catalog model ID and metadata for Opus 4.6.
+  - Keep legacy cleanup compatibility list up to date.
+  - Add regression tests for Opus 4.6 sync output.
+- `src-tauri/src/proxy/handlers/claude.rs`
+  - Add robust extraction of thinking hints from `providerOptions`.
+  - Keep root-level fields as highest-priority source.
+  - Add focused unit tests for extraction precedence and provider keys.
+
+### Out of scope
+
+- Frontend UI redesign.
+- OpenCode client implementation changes.
+- Global rustfmt cleanup across unrelated modules.
+
+## Design Notes
+
+- Root-level thinking fields remain highest precedence.
+- `providerOptions` fallback is supported with preferred provider keys:
+  - `anthropic`
+  - `antigravity-manager`
+  - `google`
+- Additional provider keys are scanned as a safe fallback to reduce schema drift risk.
+
+## Delivery Phases
+
+1. Catalog correction and cleanup-list update.
+2. Thinking extraction enhancement and precedence enforcement.
+3. Unit test additions for both modules.
+4. Build/check verification and manual OpenCode validation.
+
+## Validation Matrix
+
+| Area | Method | Expected |
+|---|---|---|
+| Catalog sync output | Rust unit tests in `opencode_sync.rs` | `claude-opus-4-6-thinking` exists and includes variants |
+| Thinking extraction | Unit tests in `claude.rs` | Root precedence works, providerOptions fallback works |
+| Rust compile | `cargo check` in `src-tauri` | Pass |
+| OpenCode manual flow | Sync config then inspect model picker | Opus 4.6 appears |
+| Thinking behavior manual flow | Select thinking variant and send prompt | Proxy logs show applied hint and mapped budget/effort |
+
+## Known Verification Constraints
+
+- `cargo test proxy::opencode_sync::tests --lib` on current baseline can fail due unrelated existing test compilation issues in `openai/request.rs` (not introduced by this follow-up).
+- Frontend build may fail locally if environment is missing `@tailwindcss/container-queries` dependency.
+
+## Rollback Plan
+
+- Revert follow-up commit(s) if any behavior regression is observed.
+- Restore previous OpenCode config via built-in restore feature or backup files (`*.antigravity-manager.bak`).

--- a/docs/testing/opencode_sync_followup_todolist.md
+++ b/docs/testing/opencode_sync_followup_todolist.md
@@ -1,0 +1,53 @@
+# OpenCode Sync Follow-up Todo List
+
+## Implementation Checklist
+
+- [x] Replace wrong Opus catalog entry in `src-tauri/src/proxy/opencode_sync.rs`:
+  - from `claude-opus-4-5-thinking`
+  - to `claude-opus-4-6-thinking`
+- [x] Keep legacy cleanup compatibility by including `claude-opus-4-6-thinking` in `ANTIGRAVITY_MODEL_IDS`.
+- [x] Add/extend sync tests in `opencode_sync.rs`:
+  - catalog contains Opus 4.6
+  - filtered sync for Opus 4.6 works
+  - Opus 4.6 variants are present (`low`, `medium`, `high`, `max`)
+- [x] Enhance thinking extraction in `src-tauri/src/proxy/handlers/claude.rs`:
+  - support root fields and `providerOptions`
+  - support multiple budget/level keys
+  - preserve root-over-providerOptions precedence
+- [x] Add unit tests in `claude.rs` for extraction and precedence.
+
+## Verification Checklist
+
+### Rust checks
+
+- [x] Run `cargo check` in `src-tauri`.
+- [ ] Run `cargo test proxy::opencode_sync::tests --lib` in `src-tauri`.
+  - Note: may fail on current baseline due unrelated existing test compile errors in `openai/request.rs`.
+
+### Frontend/build checks
+
+- [ ] Run `npm run build` in repo root.
+  - Note: may fail if local environment misses `@tailwindcss/container-queries`.
+
+### Manual OpenCode checks
+
+- [ ] Sync OpenCode models with `Claude 4.6 TK` selected.
+- [ ] Confirm `claude-opus-4-6-thinking` exists in `~/.config/opencode/opencode.json` under `provider.antigravity-manager.models`.
+- [ ] Open model picker and confirm Opus 4.6 is visible.
+- [ ] Use thinking variant switch (for example `Ctrl+T`) and submit prompt.
+- [ ] Confirm proxy logs show applied thinking hint and mapped budget/effort.
+
+## Acceptance Criteria
+
+- [ ] Issue 1 resolved: Opus 4.6 appears after sync.
+- [ ] Issue 2 resolved: thinking variant hints are extracted reliably from root or providerOptions payloads.
+- [ ] No regressions introduced in OpenCode sync clear/restore flow.
+
+## PR Completion Checklist
+
+- [ ] Update PR description with:
+  - root cause summary
+  - files changed
+  - verification results (including known baseline/environment blockers)
+- [ ] Push branch to remote.
+- [ ] Open PR against `main` with roadmap/todo docs linked.


### PR DESCRIPTION
## Summary
- fix OpenCode sync catalog mismatch by publishing `claude-opus-4-6-thinking` (instead of stale 4.5 id), include it in compatibility cleanup IDs, and add regression coverage for Opus 4.6 variants.
- harden Claude thinking hint extraction to read both root payload fields and `providerOptions` payloads, with root-level precedence and preferred provider key order.
- add roadmap/todo tracking docs for this follow-up so verification scope and known blockers are explicit.

## Problem Statement
Two issues were observed after sync/variant workflows:
1. `Claude Opus 4.6 Thinking` could be selected in app sync UI but did not appear in OpenCode model picker.
2. Thinking variant changes (for example via `Ctrl+T` in OpenCode) were not reliably applied by backend mapping.

## Root Cause
- OpenCode sync model catalog still registered `claude-opus-4-5-thinking` instead of `claude-opus-4-6-thinking`.
- Thinking hint extraction in Claude handler primarily relied on root-level fields and missed common `providerOptions` shapes.

## Files Changed
- `src-tauri/src/proxy/opencode_sync.rs`
- `src-tauri/src/proxy/handlers/claude.rs`
- `docs/testing/opencode_sync_followup_roadmap.md`
- `docs/testing/opencode_sync_followup_todolist.md`

## Validation
### Automated
- ✅ `cargo check` (in `src-tauri`) passed.
- ❌ `cargo test proxy::opencode_sync::tests --lib` blocked by pre-existing unrelated compile errors in `src/proxy/mappers/openai/request.rs` (missing `image_size`/`effort` fields in existing tests).
- ❌ `npm run build` blocked by local env dependency issue: missing `@tailwindcss/container-queries`.

### Review Gate
- ✅ `kimi-k25` review: PASS.
- ✅ `gemini-3-pro` review: PASS.

## Manual Verification Checklist
- [ ] Sync with `Claude 4.6 TK` selected in app.
- [ ] Confirm `claude-opus-4-6-thinking` exists under `provider.antigravity-manager.models` in OpenCode config.
- [ ] Confirm model appears in OpenCode picker.
- [ ] Switch thinking variant (e.g. `Ctrl+T`) and send prompt.
- [ ] Confirm proxy applies mapped thinking budget/effort from root or providerOptions hint.

## Notes
- Existing baseline/environment blockers are documented in `docs/testing/opencode_sync_followup_roadmap.md` and `docs/testing/opencode_sync_followup_todolist.md`.