### PR TITLE
fix(proxy): remove invalid effortLevel from Gemini generationConfig

### DIFF
--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -1823,16 +1823,6 @@ fn build_generation_config(
         }
         
         config["thinkingConfig"] = thinking_config;
-
-        // [NEW] 如果存在 effort，除了设置 thinkingLevel 外，也保留 effortLevel 以确保最大程度的协议兼容性
-        if let Some(e) = effort {
-            config["effortLevel"] = json!(match e.to_lowercase().as_str() {
-                "high" | "max" => "HIGH",
-                "medium" => "MEDIUM",
-                "low" => "LOW",
-                _ => "HIGH",
-            });
-        }
     }
 
     // 其他参数


### PR DESCRIPTION
## Summary

Remove invalid `effortLevel` field from Gemini `generationConfig` that causes 400 INVALID_ARGUMENT errors

## Problem

The `effortLevel` field was being set at the **top level** of `generationConfig`, but it is **not a recognized field** in the Gemini v1internal API schema. This caused generic `400 INVALID_ARGUMENT` errors from Google's API

**Root cause**: When thinking mode has an `effort` parameter (e.g. from Claude Code's `output_config.effort`), the code correctly maps it to `thinkingConfig.thinkingLevel` (line 1811-1821), but then **also** redundantly sets `config["effortLevel"]` at the top level of `generationConfig`. Google's API silently rejects this unknown field with a generic 400.

**Evidence from logs**:
- 2 out of 7 total 400 errors were caused by this `effortLevel` field
- All occurred on `claude-opus-4-6-thinking` requests with `effort` parameter present
- After removing the field, those error patterns no longer reproduce

## Solution

Remove the redundant `effortLevel` assignment from `build_generation_config()`. The effort level is already correctly handled via `thinkingConfig.thinkingLevel`.

## Changes

- `request.rs`: Remove 10 lines that set `config["effortLevel"]` — this field was a duplicate of the already-correct `thinkingConfig.thinkingLevel` mapping

## Impact

- Eliminates 400 errors caused by unknown `effortLevel` field in `generationConfig`
- No behavioral change — effort level continues to work via `thinkingConfig.thinkingLevel`
- No breaking changes

## Test Plan

- [x] `cargo build` passes
- [x] `cargo test` — all tests pass
- [x] Manual: Verify thinking requests with effort parameter no longer return 400