### PR TITLE
fix: add Linux platform support to auto-update (updater.json)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,15 +181,19 @@ jobs:
           MACOS_AARCH64_SIG=$(read_sig "*_aarch64.app.tar.gz.sig")
           MACOS_X64_SIG=$(read_sig "*_x64.app.tar.gz.sig")
           WINDOWS_NSIS_SIG=$(read_sig "*_x64-setup.exe.sig")
+          LINUX_AMD64_SIG=$(read_sig "*_amd64.AppImage.sig")
+          LINUX_AARCH64_SIG=$(read_sig "*_aarch64.AppImage.sig")
 
           echo "Signatures found:"
           [ -n "$MACOS_AARCH64_SIG" ] && echo "  macOS aarch64: YES" || echo "  macOS aarch64: NO"
           [ -n "$MACOS_X64_SIG" ] && echo "  macOS x64: YES" || echo "  macOS x64: NO"
           [ -n "$WINDOWS_NSIS_SIG" ] && echo "  Windows x64: YES" || echo "  Windows x64: NO"
+          [ -n "$LINUX_AMD64_SIG" ] && echo "  Linux amd64: YES" || echo "  Linux amd64: NO"
+          [ -n "$LINUX_AARCH64_SIG" ] && echo "  Linux aarch64: YES" || echo "  Linux aarch64: NO"
 
           # Build updater.json with platform-specific download URLs and signatures
           # macOS: arch-suffixed filenames (no version in name)
-          # Windows: version included in filename
+          # Windows/Linux: version included in filename
           jq -n \
             --arg version "$VER" \
             --arg notes "See release page for details" \
@@ -198,6 +202,8 @@ jobs:
             --arg mac_a64_sig "$MACOS_AARCH64_SIG" \
             --arg mac_x64_sig "$MACOS_X64_SIG" \
             --arg win_nsis_sig "$WINDOWS_NSIS_SIG" \
+            --arg linux_amd64_sig "$LINUX_AMD64_SIG" \
+            --arg linux_a64_sig "$LINUX_AARCH64_SIG" \
             --arg ver "$VER" \
             '{
               version: $version,
@@ -215,6 +221,14 @@ jobs:
                 "windows-x86_64": {
                   url: "\($dl)/Antigravity.Tools_\($ver)_x64-setup.exe",
                   signature: $win_nsis_sig
+                },
+                "linux-x86_64": {
+                  url: "\($dl)/Antigravity.Tools_\($ver)_amd64.AppImage",
+                  signature: $linux_amd64_sig
+                },
+                "linux-aarch64": {
+                  url: "\($dl)/Antigravity.Tools_\($ver)_aarch64.AppImage",
+                  signature: $linux_a64_sig
                 }
               }
             }' > updater.json


### PR DESCRIPTION
## Summary

Add `linux-x86_64` and `linux-aarch64` platform entries to the `updater.json` generated during release workflow. This enables **Tauri v2 auto-update for Linux AppImage users**, who currently don't receive update notifications.

## Problem

The current release workflow generates `updater.json` with only macOS (`darwin-aarch64`, `darwin-x86_64`) and Windows (`windows-x86_64`) platforms. Linux users running the AppImage version never receive auto-update notifications despite:
- The Tauri v2 updater plugin supporting Linux auto-update via AppImage format
- The release workflow already generating `.AppImage.sig` signature files
- The app's `tauri.conf.json` having updater enabled with `createUpdaterArtifacts: true`

## Changes

In `.github/workflows/release.yml`:
- Read `.sig` files for Linux `amd64` and `aarch64` AppImage artifacts
- Add `linux-x86_64` and `linux-aarch64` entries to `updater.json` with correct download URLs and signatures
- Add debug logging for signature file reading

## Testing

- Simulated `jq` command locally — generates valid JSON with all 5 platforms
- Verified all artifact URLs return HTTP 200 against v4.1.15 release
- Confirmed Tauri v2 updater plugin docs support `linux-x86_64` platform key

## Refs

- #1538 (macOS auto-updater request — same pattern now extended to Linux)
- #484 (update notification system)
- #1850 (native auto-update implementation)