### PR TITLE
feat: add cross-platform install scripts (Linux/macOS/Windows)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,182 @@
+# Antigravity Tools Install Script for Windows
+# Usage: irm https://raw.githubusercontent.com/lbjlaq/Antigravity-Manager/main/install.ps1 | iex
+#
+# Parameters (set before running):
+#   $Version = "4.1.15"  # Install specific version
+#   $DryRun = $true      # Preview commands without executing
+
+if (-not $Version) { $Version = "" }
+if (-not $DryRun) { $DryRun = $false }
+
+$ErrorActionPreference = "Continue"
+
+$Repo = "lbjlaq/Antigravity-Manager"
+$AppName = "Antigravity Tools"
+$GithubApi = "https://api.github.com/repos/$Repo/releases"
+$script:ReleaseVersion = ""
+$script:DownloadUrl = ""
+$script:Filename = ""
+$script:HasError = $false
+
+# Colors helper
+function Write-ColorOutput {
+    param([string]$ForegroundColor, [string]$Message)
+    Write-Host $Message -ForegroundColor $ForegroundColor
+}
+
+function Info { Write-ColorOutput "Cyan" "[INFO] $args" }
+function Success { Write-ColorOutput "Green" "[OK] $args" }
+function Warn { Write-ColorOutput "Yellow" "[WARN] $args" }
+function Script-Error {
+    Write-ColorOutput "Red" "[ERROR] $args"
+    $script:HasError = $true
+}
+
+function Wait-AndExit {
+    param([int]$ExitCode = 0)
+    Write-Host ""
+    Write-Host "Press any key to exit..." -ForegroundColor Gray
+    $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+    exit $ExitCode
+}
+
+function Get-ReleaseVersion {
+    if ($Version) {
+        $script:ReleaseVersion = $Version
+        Info "Using specified version: v$($script:ReleaseVersion)"
+        return $true
+    }
+
+    Info "Fetching latest version..."
+
+    # Method 1: Try GitHub API
+    try {
+        $release = Invoke-RestMethod -Uri "$GithubApi/latest" -Headers @{
+            "User-Agent" = "Antigravity-Installer"
+            "Accept"     = "application/vnd.github.v3+json"
+        } -TimeoutSec 10
+        $script:ReleaseVersion = $release.tag_name -replace "^v", ""
+        Info "Latest version: v$($script:ReleaseVersion)"
+        return $true
+    } catch {
+        Warn "GitHub API failed (rate limit?), trying fallback..."
+    }
+
+    # Method 2: Fallback - parse updater.json from releases (no API rate limit)
+    try {
+        $updaterJson = Invoke-RestMethod -Uri "https://github.com/$Repo/releases/latest/download/updater.json" -TimeoutSec 10
+        $script:ReleaseVersion = $updaterJson.version -replace "^v", ""
+        Info "Latest version (from updater.json): v$($script:ReleaseVersion)"
+        return $true
+    } catch {
+        Warn "Fallback failed, trying redirect method..."
+    }
+
+    # Method 3: Last resort - follow redirect from /releases/latest
+    try {
+        Invoke-WebRequest -Uri "https://github.com/$Repo/releases/latest" -MaximumRedirection 0 -ErrorAction SilentlyContinue -UseBasicParsing
+    } catch {
+        $redirectUrl = $_.Exception.Response.Headers.Location
+        if ($redirectUrl -and $redirectUrl -match "/tag/v?(.+)$") {
+            $script:ReleaseVersion = $Matches[1]
+            Info "Latest version (from redirect): v$($script:ReleaseVersion)"
+            return $true
+        }
+    }
+
+    Script-Error "Failed to determine latest version. Try specifying version manually:"
+    Write-Host '  $Version = "4.1.15"; irm https://raw.githubusercontent.com/lbjlaq/Antigravity-Manager/main/install.ps1 | iex' -ForegroundColor Yellow
+    return $false
+}
+
+function Get-DownloadUrl {
+    # NSIS installer: Antigravity.Tools_4.1.15_x64-setup.exe
+    $script:DownloadUrl = "https://github.com/$Repo/releases/download/v$($script:ReleaseVersion)/Antigravity.Tools_$($script:ReleaseVersion)_x64-setup.exe"
+    $script:Filename = "Antigravity.Tools_$($script:ReleaseVersion)_x64-setup.exe"
+
+    Info "Download URL: $($script:DownloadUrl)"
+}
+
+function Install-App {
+    $tempDir = [System.IO.Path]::GetTempPath()
+    $downloadPath = Join-Path $tempDir $script:Filename
+
+    Info "Downloading $AppName v$($script:ReleaseVersion)..."
+
+    if ($DryRun) {
+        Write-ColorOutput "Yellow" "[DRY-RUN] Invoke-WebRequest -Uri $($script:DownloadUrl) -OutFile $downloadPath"
+    } else {
+        try {
+            $ProgressPreference = 'Continue'
+            Invoke-WebRequest -Uri $script:DownloadUrl -OutFile $downloadPath -UseBasicParsing
+        } catch {
+            Script-Error "Download failed: $_"
+            Script-Error "URL: $($script:DownloadUrl)"
+            return $false
+        }
+    }
+
+    # Verify download
+    if (-not $DryRun -and -not (Test-Path $downloadPath)) {
+        Script-Error "Downloaded file not found at $downloadPath"
+        return $false
+    }
+
+    Success "Downloaded to $downloadPath"
+
+    Info "Running installer..."
+
+    if ($DryRun) {
+        Write-ColorOutput "Yellow" "[DRY-RUN] Start-Process -FilePath $downloadPath -Wait"
+    } else {
+        try {
+            Start-Process -FilePath $downloadPath -Wait
+        } catch {
+            Script-Error "Installation failed: $_"
+            return $false
+        }
+    }
+
+    # Cleanup
+    if (-not $DryRun -and (Test-Path $downloadPath)) {
+        Remove-Item $downloadPath -Force
+        Info "Cleaned up installer file"
+    }
+
+    return $true
+}
+
+# Main
+Write-Host ""
+Write-ColorOutput "Cyan" "========================================"
+Write-ColorOutput "Cyan" "    $AppName Installer"
+Write-ColorOutput "Cyan" "========================================"
+Write-Host ""
+
+# Step 1: Get version
+if (-not (Get-ReleaseVersion)) {
+    Wait-AndExit 1
+}
+
+# Step 2: Build download URL
+Get-DownloadUrl
+
+# Step 3: Download and install
+if (-not (Install-App)) {
+    Wait-AndExit 1
+}
+
+if ($script:HasError) {
+    Wait-AndExit 1
+}
+
+Write-Host ""
+Success "Installation complete!"
+Write-Host ""
+Info "Launch '$AppName' from the Start Menu or desktop shortcut."
+Write-Host ""
+
+# Only wait if running interactively
+if ($Host.Name -eq "ConsoleHost") {
+    Wait-AndExit 0
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# Antigravity Tools Install Script (Linux + macOS)
+# Usage: curl -fsSL https://raw.githubusercontent.com/lbjlaq/Antigravity-Manager/main/install.sh | bash
+#
+# Environment variables:
+#   VERSION     - Install specific version (e.g., "4.1.15"), default: latest
+#   DRY_RUN     - Set to "1" to print commands without executing
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+REPO="lbjlaq/Antigravity-Manager"
+APP_NAME="Antigravity Tools"
+APP_ID="com.lbjlaq.antigravity-tools"
+GITHUB_API="https://api.github.com/repos/${REPO}/releases"
+
+# Helper functions
+info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+success() { echo -e "${GREEN}[OK]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1" >&2; exit 1; }
+
+run() {
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        echo -e "${YELLOW}[DRY-RUN]${NC} $*"
+    else
+        "$@"
+    fi
+}
+
+# Show help
+show_help() {
+    cat << EOF
+${APP_NAME} Install Script
+
+Usage:
+    curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash
+
+    # Install specific version
+    curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | VERSION=4.1.15 bash
+
+Options:
+    --help      Show this help message
+    --version   Show script version
+
+Environment Variables:
+    VERSION     Install specific version (default: latest)
+    DRY_RUN     Set to "1" to preview commands without executing
+
+Supported Platforms:
+    - Linux x86_64:  .deb (Debian/Ubuntu), .rpm (Fedora/RHEL), .AppImage (Universal)
+    - Linux aarch64: .deb (Debian/Ubuntu), .rpm (Fedora/RHEL), .AppImage (Universal)
+    - macOS x86_64:  .dmg
+    - macOS arm64:   .dmg
+
+EOF
+    exit 0
+}
+
+# Detect OS and architecture
+detect_platform() {
+    OS="$(uname -s)"
+    ARCH="$(uname -m)"
+
+    case "$OS" in
+        Linux)  PLATFORM="linux" ;;
+        Darwin) PLATFORM="macos" ;;
+        *)      error "Unsupported OS: $OS. Use install.ps1 for Windows." ;;
+    esac
+
+    case "$ARCH" in
+        x86_64|amd64)   ARCH_LABEL="x86_64"; DEB_ARCH="amd64"; RPM_ARCH="x86_64" ;;
+        aarch64|arm64)  ARCH_LABEL="aarch64"; DEB_ARCH="arm64"; RPM_ARCH="aarch64" ;;
+        *)              error "Unsupported architecture: $ARCH" ;;
+    esac
+
+    info "Detected: $PLATFORM ($ARCH_LABEL)"
+}
+
+# Detect Linux package manager
+detect_linux_distro() {
+    if [[ "$PLATFORM" != "linux" ]]; then
+        return
+    fi
+
+    if command -v apt-get &>/dev/null; then
+        PKG_MANAGER="apt"
+        PKG_EXT="deb"
+    elif command -v dnf &>/dev/null; then
+        PKG_MANAGER="dnf"
+        PKG_EXT="rpm"
+    elif command -v yum &>/dev/null; then
+        PKG_MANAGER="yum"
+        PKG_EXT="rpm"
+    else
+        PKG_MANAGER="appimage"
+        PKG_EXT="AppImage"
+        warn "No supported package manager found, using AppImage"
+    fi
+
+    info "Package manager: $PKG_MANAGER ($PKG_EXT)"
+}
+
+# Get latest or specific version
+get_version() {
+    if [[ -n "${VERSION:-}" ]]; then
+        RELEASE_VERSION="$VERSION"
+        info "Using specified version: v$RELEASE_VERSION"
+        return
+    fi
+
+    info "Fetching latest version..."
+
+    # Method 1: Try GitHub API
+    local response
+    if response=$(curl -fsSL -H "User-Agent: Antigravity-Installer" "${GITHUB_API}/latest" 2>/dev/null); then
+        RELEASE_VERSION=$(echo "$response" | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
+        if [[ -n "$RELEASE_VERSION" ]]; then
+            info "Latest version: v$RELEASE_VERSION"
+            return
+        fi
+    fi
+
+    # Method 2: Fallback - parse from redirect URL (no rate limit)
+    info "API rate limited, using fallback method..."
+    local redirect_url
+    redirect_url=$(curl -fsSI "https://github.com/${REPO}/releases/latest" 2>/dev/null | grep -i "^location:" | tr -d '\r' | awk '{print $2}')
+
+    if [[ -n "$redirect_url" ]]; then
+        RELEASE_VERSION=$(echo "$redirect_url" | sed -E 's|.*/tag/v||')
+    fi
+
+    if [[ -z "${RELEASE_VERSION:-}" ]]; then
+        error "Failed to fetch latest version. Try specifying VERSION=x.x.x"
+    fi
+
+    info "Latest version: v$RELEASE_VERSION"
+}
+
+# Build download URL based on platform and package manager
+build_download_url() {
+    local base_url="https://github.com/${REPO}/releases/download/v${RELEASE_VERSION}"
+
+    case "$PLATFORM" in
+        linux)
+            case "$PKG_EXT" in
+                deb)
+                    # Antigravity.Tools_4.1.15_amd64.deb or _arm64.deb
+                    DOWNLOAD_URL="${base_url}/Antigravity.Tools_${RELEASE_VERSION}_${DEB_ARCH}.deb"
+                    FILENAME="Antigravity.Tools_${RELEASE_VERSION}_${DEB_ARCH}.deb"
+                    ;;
+                rpm)
+                    # Antigravity.Tools-4.1.15-1.x86_64.rpm or -1.aarch64.rpm
+                    DOWNLOAD_URL="${base_url}/Antigravity.Tools-${RELEASE_VERSION}-1.${RPM_ARCH}.rpm"
+                    FILENAME="Antigravity.Tools-${RELEASE_VERSION}-1.${RPM_ARCH}.rpm"
+                    ;;
+                AppImage)
+                    # Antigravity.Tools_4.1.15_amd64.AppImage or _aarch64.AppImage
+                    local appimage_arch
+                    if [[ "$ARCH_LABEL" == "x86_64" ]]; then
+                        appimage_arch="amd64"
+                    else
+                        appimage_arch="aarch64"
+                    fi
+                    DOWNLOAD_URL="${base_url}/Antigravity.Tools_${RELEASE_VERSION}_${appimage_arch}.AppImage"
+                    FILENAME="Antigravity.Tools_${RELEASE_VERSION}_${appimage_arch}.AppImage"
+                    ;;
+            esac
+            ;;
+        macos)
+            # Prefer universal DMG, fallback to arch-specific
+            DOWNLOAD_URL="${base_url}/Antigravity.Tools_${RELEASE_VERSION}_universal.dmg"
+            FILENAME="Antigravity.Tools_${RELEASE_VERSION}_universal.dmg"
+            ;;
+    esac
+
+    info "Download URL: $DOWNLOAD_URL"
+}
+
+# Download installer
+download_installer() {
+    TEMP_DIR=$(mktemp -d)
+    DOWNLOAD_PATH="${TEMP_DIR}/${FILENAME}"
+
+    info "Downloading ${APP_NAME} v${RELEASE_VERSION}..."
+    run curl -fSL --progress-bar -o "$DOWNLOAD_PATH" "$DOWNLOAD_URL"
+
+    if [[ "${DRY_RUN:-0}" != "1" ]] && [[ ! -f "$DOWNLOAD_PATH" ]]; then
+        error "Download failed. Check your network or try a different version."
+    fi
+
+    success "Downloaded to $DOWNLOAD_PATH"
+}
+
+# Install on Linux
+install_linux() {
+    info "Installing ${APP_NAME}..."
+
+    case "$PKG_MANAGER" in
+        apt)
+            run sudo dpkg -i "$DOWNLOAD_PATH"
+            run sudo apt-get install -f -y  # Fix dependencies if needed
+            ;;
+        dnf)
+            run sudo dnf install -y "$DOWNLOAD_PATH"
+            ;;
+        yum)
+            run sudo yum install -y "$DOWNLOAD_PATH"
+            ;;
+        appimage)
+            local install_dir="${HOME}/.local/bin"
+            run mkdir -p "$install_dir"
+            run chmod +x "$DOWNLOAD_PATH"
+            run cp "$DOWNLOAD_PATH" "${install_dir}/antigravity-tools"
+
+            if [[ ":$PATH:" != *":${install_dir}:"* ]]; then
+                warn "Add ${install_dir} to your PATH to run antigravity-tools from anywhere"
+
+                local shell_name rc_file export_line
+                shell_name="$(basename "${SHELL:-/bin/bash}")"
+                case "$shell_name" in
+                    zsh)  rc_file="$HOME/.zshrc" ;;
+                    fish) rc_file="$HOME/.config/fish/config.fish" ;;
+                    *)    rc_file="$HOME/.bashrc" ;;
+                esac
+
+                export_line="export PATH=\"${install_dir}:\$PATH\""
+                [[ "$shell_name" == "fish" ]] && export_line="fish_add_path ${install_dir}"
+
+                if [[ -f "$rc_file" ]] && grep -qF "$install_dir" "$rc_file" 2>/dev/null; then
+                    info "PATH entry already in $rc_file"
+                else
+                    run echo "$export_line" >> "$rc_file"
+                    info "Added ${install_dir} to PATH in $rc_file"
+                    warn "Run: source $rc_file  (or restart terminal)"
+                fi
+            fi
+            ;;
+    esac
+
+    success "${APP_NAME} installed successfully!"
+}
+
+# Install on macOS
+install_macos() {
+    info "Installing ${APP_NAME}..."
+
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        echo -e "${YELLOW}[DRY-RUN]${NC} hdiutil attach $DOWNLOAD_PATH -nobrowse -noautoopen"
+        echo -e "${YELLOW}[DRY-RUN]${NC} cp -R <mount>/${APP_NAME}.app /Applications/"
+        echo -e "${YELLOW}[DRY-RUN]${NC} hdiutil detach <mount>"
+        echo -e "${YELLOW}[DRY-RUN]${NC} sudo xattr -rd com.apple.quarantine /Applications/${APP_NAME}.app"
+        return
+    fi
+
+    # Mount DMG
+    local mount_output mount_point
+    mount_output=$(hdiutil attach "$DOWNLOAD_PATH" -nobrowse -noautoopen 2>&1)
+    mount_point=$(echo "$mount_output" | grep -o '/Volumes/.*' | head -n1)
+
+    if [[ -z "$mount_point" ]]; then
+        error "Failed to mount DMG. Output: $mount_output"
+    fi
+
+    # Copy app to /Applications
+    if [[ -d "/Applications/${APP_NAME}.app" ]]; then
+        info "Removing existing installation..."
+        rm -rf "/Applications/${APP_NAME}.app"
+    fi
+    cp -R "${mount_point}/${APP_NAME}.app" /Applications/
+
+    # Unmount DMG
+    hdiutil detach "$mount_point" -quiet 2>/dev/null || true
+
+    # Remove quarantine attribute to avoid "app is damaged" error
+    info "Removing quarantine attribute..."
+    sudo xattr -rd com.apple.quarantine "/Applications/${APP_NAME}.app" 2>/dev/null || true
+
+    success "${APP_NAME} installed to /Applications!"
+}
+
+# Cleanup
+cleanup() {
+    if [[ -n "${TEMP_DIR:-}" ]] && [[ -d "$TEMP_DIR" ]]; then
+        rm -rf "$TEMP_DIR"
+    fi
+}
+
+# Main
+main() {
+    for arg in "$@"; do
+        case "$arg" in
+            --help|-h)    show_help ;;
+            --version|-v) echo "install.sh v1.0.0"; exit 0 ;;
+        esac
+    done
+
+    echo ""
+    echo -e "${BLUE}========================================${NC}"
+    echo -e "${BLUE}    ${APP_NAME} Installer${NC}"
+    echo -e "${BLUE}========================================${NC}"
+    echo ""
+
+    trap cleanup EXIT
+
+    detect_platform
+    detect_linux_distro
+    get_version
+    build_download_url
+    download_installer
+
+    case "$PLATFORM" in
+        linux) install_linux ;;
+        macos) install_macos ;;
+    esac
+
+    echo ""
+    success "Installation complete!"
+    echo ""
+    info "Launch '${APP_NAME}' from your application menu or launcher."
+    echo ""
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add one-line install scripts for all platforms, making it easy for users to install Antigravity Tools without manually downloading from GitHub Releases.

### Linux / macOS
```bash
curl -fsSL https://raw.githubusercontent.com/lbjlaq/Antigravity-Manager/main/install.sh | bash
```

### Windows (PowerShell)
```powershell
irm https://raw.githubusercontent.com/lbjlaq/Antigravity-Manager/main/install.ps1 | iex
```

## Features

### install.sh (Linux + macOS)
- **OS detection**: Linux and macOS
- **Architecture detection**: x86_64, aarch64/arm64
- **Linux package format selection**: auto-detect package manager
  - `apt` (Debian/Ubuntu) → `.deb`
  - `dnf`/`yum` (Fedora/RHEL) → `.rpm`
  - Other → `.AppImage` (universal fallback)
- **macOS**: Download `.dmg`, mount, copy to `/Applications`, fix quarantine
- **Version detection**: GitHub API with redirect URL fallback
- **DRY_RUN mode**: Preview commands without executing (`DRY_RUN=1 bash install.sh`)

### install.ps1 (Windows)
- Downloads NSIS `.exe` installer and runs it
- **3-tier version detection**: GitHub API → updater.json → redirect URL
- **DRY_RUN mode**: Preview commands (`$DryRun = $true`)
- Interactive wait-and-exit for terminal users

## Testing

- `install.sh` syntax validated with `bash -n`
- DRY_RUN mode tested end-to-end
- All artifact download URLs verified (HTTP 200) against v4.1.15 release
- Version detection tested: both GitHub API and redirect fallback return correct version

## Refs

- #1108 (install fails on Arch — this provides AppImage fallback)
- #1235 (brew install error — this provides alternative install method)
- #846 (improve installation UX)