### PR TITLE
fix: 调整 v1internal 端点优先级顺序（Daily → Sandbox → Prod）

### DIFF
--- a/src-tauri/src/proxy/upstream/client.rs
+++ b/src-tauri/src/proxy/upstream/client.rs
@@ -43,17 +43,17 @@ pub fn mask_email(email: &str) -> String {
     }
 }
 
-// Cloud Code v1internal endpoints (fallback order: Sandbox → Daily → Prod)
-// 优先使用 Sandbox/Daily 环境以避免 Prod环境的 429 错误 (Ref: Issue #1176)
+// Cloud Code v1internal endpoints (fallback order: Daily → Sandbox → Prod)
+// 优先使用 Daily/Sandbox 环境以避免 Prod环境的 429 错误 (Ref: Issue #1176)
 const V1_INTERNAL_BASE_URL_PROD: &str = "https://cloudcode-pa.googleapis.com/v1internal";
 const V1_INTERNAL_BASE_URL_DAILY: &str = "https://daily-cloudcode-pa.googleapis.com/v1internal";
 const V1_INTERNAL_BASE_URL_SANDBOX: &str =
     "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal";
 
 const V1_INTERNAL_BASE_URL_FALLBACKS: [&str; 3] = [
-    V1_INTERNAL_BASE_URL_SANDBOX, // 优先级 1: Sandbox (已知有效且稳定)
-    V1_INTERNAL_BASE_URL_DAILY,   // 优先级 2: Daily (备用)
-    V1_INTERNAL_BASE_URL_PROD,    // 优先级 3: Prod (仅作为兜底)
+    V1_INTERNAL_BASE_URL_DAILY, // 优先级 1: Daily (IDE日志观察到调用频率最高)
+    V1_INTERNAL_BASE_URL_SANDBOX, // 优先级 2: Sandbox (备用)
+    V1_INTERNAL_BASE_URL_PROD,  // 优先级 3: Prod (仅作为兜底)
 ];
 
 pub struct UpstreamClient {


### PR DESCRIPTION
根据 Antigravity IDE 日志观察，Daily 端点被实际调用频率最高，
将其从优先级 2 提升至优先级 1，Sandbox 降为优先级 2，Prod 保持兜底不变。