### PR TITLE
fix: remove duplicate WEB_SEARCH_FALLBACK_MODEL downgrade — fixes OpenClaw compatibility

### DIFF
--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -419,18 +419,13 @@ pub fn transform_claude_request_in(
         build_system_instruction(&claude_req.system, &claude_req.model, has_mcp_tools);
 
     //  Map model name (Use standard mapping)
-    // [IMPROVED] 提取 web search 模型为常量，便于维护
-    const WEB_SEARCH_FALLBACK_MODEL: &str = "gemini-2.5-flash";
-
-    let mapped_model = if has_web_search_tool {
-        tracing::debug!(
-            "[Claude-Request] Web search tool detected, using fallback model: {}",
-            WEB_SEARCH_FALLBACK_MODEL
-        );
-        WEB_SEARCH_FALLBACK_MODEL.to_string()
-    } else {
-        crate::proxy::common::model_mapping::map_claude_model_to_gemini(&claude_req.model)
-    };
+    // [FIX] Removed duplicate WEB_SEARCH_FALLBACK_MODEL downgrade.
+    // The fallback logic already exists in common_utils::resolve_request_config(),
+    // which correctly checks the model allowlist before downgrading.
+    // The previous unconditional downgrade here was overriding high-quality models
+    // (e.g. gemini-3-pro) that natively support web search.
+    let mapped_model =
+        crate::proxy::common::model_mapping::map_claude_model_to_gemini(&claude_req.model);
 
     // 将 Claude 工具转为 Value 数组以便探测联网
     let tools_val: Option<Vec<Value>> = claude_req.tools.as_ref().map(|list| {


### PR DESCRIPTION
## Summary

- Removed the unconditional `WEB_SEARCH_FALLBACK_MODEL` downgrade in `request.rs` (Claude protocol mapper) that duplicated the same logic already present in `common_utils::resolve_request_config()`.
- **Fixes OpenClaw compatibility**: requests from OpenClaw were always detected as having `web_search_tool`, causing every model to be unconditionally downgraded to `gemini-2.5-flash` regardless of actual capabilities.

## Problem

Two places performed web-search model downgrade:

1. **`request.rs` L423-433** (removed) — unconditionally replaced **any** model with `gemini-2.5-flash` when `has_web_search_tool == true`
2. **`common_utils.rs` `resolve_request_config()`** — correctly checks an allowlist before downgrading, preserving high-quality models that natively support Google Search

The first check ran before `resolve_request_config()`, so by the time the allowlist check executed, the model was already `gemini-2.5-flash` — making the allowlist logic dead code.

### Impact

Models like `claude-sonnet-4-5-thinking` (maps to itself, in allowlist via `contains("claude-sonnet")`), `claude-opus-4-6-thinking` (maps to itself, in allowlist via `contains("claude-opus")`), `gemini-3-pro`, etc. were unnecessarily downgraded to `gemini-2.5-flash` for web search requests, even though they natively support Google Search and are explicitly in the allowlist.

This particularly affected **OpenClaw** users, since OpenClaw requests always include web search tool definitions, triggering the unconditional downgrade on every single request — effectively making it impossible to use any model other than `gemini-2.5-flash` through the Claude protocol.

## Fix

Removed the first unconditional downgrade. Now `mapped_model` always goes through normal mapping via `map_claude_model_to_gemini()`, and `resolve_request_config()` handles the downgrade only when the model is **not** in the search-capable allowlist.

## Files Changed

- `src-tauri/src/proxy/mappers/claude/request.rs` — 1 file, +7 / -12 lines