### PR TITLE
feat: Support Antigravity 3.1 and Claude Sonnet 4.6

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -12,7 +12,7 @@ const FALLBACK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Known stable configuration (for Docker/Headless fallback)
 /// Antigravity 1.16.5 uses Electron 39.2.3 which corresponds to Chrome 132.0.6834.160
-const KNOWN_STABLE_VERSION: &str = "1.16.5";
+const KNOWN_STABLE_VERSION: &str = "3.1.0";
 const KNOWN_STABLE_ELECTRON: &str = "39.2.3";
 const KNOWN_STABLE_CHROME: &str = "132.0.6834.160";
 

--- a/src-tauri/src/proxy/common/model_mapping.rs
+++ b/src-tauri/src/proxy/common/model_mapping.rs
@@ -6,10 +6,13 @@ static CLAUDE_TO_GEMINI: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|
     let mut m = HashMap::new();
 
     // 直接支持的模型
+    m.insert("claude-sonnet-4-6", "claude-sonnet-4-6-thinking");
+    m.insert("claude-sonnet-4-6-thinking", "claude-sonnet-4-6-thinking");
     m.insert("claude-sonnet-4-5", "claude-sonnet-4-5");
     m.insert("claude-sonnet-4-5-thinking", "claude-sonnet-4-5-thinking");
 
     // 别名映射
+    m.insert("claude-sonnet-4-6-20260219", "claude-sonnet-4-6-thinking");
     m.insert("claude-sonnet-4-5-20250929", "claude-sonnet-4-5-thinking");
     m.insert("claude-3-5-sonnet-20241022", "claude-sonnet-4-5");
     m.insert("claude-3-5-sonnet-20240620", "claude-sonnet-4-5");

--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -671,6 +671,8 @@ fn should_enable_thinking_by_default(model: &str) -> bool {
         || model_lower.contains("opus-4.5")
         || model_lower.contains("opus-4-6")
         || model_lower.contains("opus-4.6")
+        || model_lower.contains("sonnet-4-6")
+        || model_lower.contains("sonnet-4.6")
     {
         tracing::debug!(
             "[Thinking-Mode] Auto-enabling thinking for Opus model: {}",

--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -78,6 +78,18 @@ export const MODEL_CONFIG: Record<string, ModelConfig> = {
         protectedKey: 'claude',
         Icon: Claude.Color,
     },
+    'claude-sonnet-4-6': {
+        label: 'Claude 4.6',
+        shortLabel: 'Claude 4.6',
+        protectedKey: 'claude',
+        Icon: Claude.Color,
+    },
+    'claude-sonnet-4-6-thinking': {
+        label: 'Claude 4.6 TK',
+        shortLabel: 'Claude 4.6 TK',
+        protectedKey: 'claude',
+        Icon: Claude.Color,
+    },
     'claude-opus-4-6-thinking': {
         label: 'Claude 4.6 TK',
         shortLabel: 'Claude 4.6 TK',

--- a/src/hooks/useProxyModels.tsx
+++ b/src/hooks/useProxyModels.tsx
@@ -78,6 +78,20 @@ export const useProxyModels = () => {
             icon: <Cpu size={16} />
         },
         {
+            id: 'claude-sonnet-4-6',
+            name: 'Claude 4.6',
+            desc: t('proxy.model.claude_4_5'), // Use 4.5 translation as fallback or update locale
+            group: 'Claude 4.6',
+            icon: <Cpu size={16} />
+        },
+        {
+            id: 'claude-sonnet-4-6-thinking',
+            name: 'Claude 4.6 TK',
+            desc: t('proxy.model.claude_sonnet_thinking'),
+            group: 'Claude 4.6',
+            icon: <Cpu size={16} />
+        },
+        {
             id: 'claude-opus-4-6-thinking',
             name: 'Claude 4.6 TK',
             desc: t('proxy.model.claude_opus_thinking'),


### PR DESCRIPTION
This PR updates the Antigravity Manager to support the latest release:
- Updated KNOWN_STABLE_VERSION to 3.1.0 for better fingerprinting.
- Added support for Claude Sonnet 4.6 and Sonnet 4.6 Thinking models.
- Enabled auto-thinking mode for Sonnet 4.6 models.
- Updated frontend model configurations and hooks to include the new models.

Bhaichara maintain rahe, isliye update kar diya hai. 🦾