### PR TITLE
feat: replace export with copy-to-clipboard and add dynamic label filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "tauri:debug": "RUST_LOG=debug npm run tauri dev"
+    "tauri:debug": "RUST_LOG=debug npm run tauri dev",
+    "release": "powershell -ExecutionPolicy Bypass -File release.ps1"
   },
   "dependencies": {
     "@ant-design/icons": "^5.6.1",
@@ -21,13 +22,13 @@
     "@lobehub/icons": "^4.2.0",
     "@lobehub/ui": "^4.33.4",
     "@tanstack/react-virtual": "^3.13.18",
-    "@tauri-apps/api": "^2",
+    "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2.4.5",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
-    "@tauri-apps/plugin-updater": "^2.9.0",
+    "@tauri-apps/plugin-updater": "^2.10.0",
     "antd": "^5.24.6",
     "antd-style": "^3.7.1",
     "clsx": "^2.1.1",

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ArrowRightLeft, RefreshCw, Trash2, Download, Info, Lock, Ban, Diamond, Gem, Circle, ToggleLeft, ToggleRight, Fingerprint, Sparkles, Tag, X, Check, Clock } from 'lucide-react';
+import { ArrowRightLeft, RefreshCw, Trash2, Copy, Info, Lock, Ban, Diamond, Gem, Circle, ToggleLeft, ToggleRight, Fingerprint, Sparkles, Tag, X, Check, Clock } from 'lucide-react';
 import { Account } from '../../types/account';
 import { cn } from '../../utils/cn';
 import { useTranslation } from 'react-i18next';
@@ -18,7 +18,7 @@ interface AccountCardProps {
     onRefresh: () => void;
     onViewDevice: () => void;
     onViewDetails: () => void;
-    onExport: () => void;
+    onCopy: () => void;
     onDelete: () => void;
     onToggleProxy: () => void;
     onWarmup?: () => void;
@@ -34,7 +34,7 @@ const DEFAULT_MODELS = Object.entries(MODEL_CONFIG).map(([id, config]) => ({
     Icon: config.Icon
 }));
 
-function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, isRefreshing, isSwitching = false, onSwitch, onRefresh, onViewDetails, onExport, onDelete, onToggleProxy, onViewDevice, onWarmup, onUpdateLabel, onViewError }: AccountCardProps) {
+function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, isRefreshing, isSwitching = false, onSwitch, onRefresh, onViewDetails, onCopy, onDelete, onToggleProxy, onViewDevice, onWarmup, onUpdateLabel, onViewError }: AccountCardProps) {
     const { t } = useTranslation();
     const { config, showAllQuotas } = useConfigStore();
     const isDisabled = Boolean(account.disabled);
@@ -344,10 +344,10 @@ function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, is
                     </button>
                     <button
                         className="p-1.5 text-gray-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-all"
-                        onClick={(e) => { e.stopPropagation(); onExport(); }}
-                        title={t('common.export')}
+                        onClick={(e) => { e.stopPropagation(); onCopy(); }}
+                        title={t('common.copy')}
                     >
-                        <Download className="w-3.5 h-3.5" />
+                        <Copy className="w-3.5 h-3.5" />
                     </button>
                     <button
                         className={cn(

--- a/src/components/accounts/AccountGrid.tsx
+++ b/src/components/accounts/AccountGrid.tsx
@@ -13,7 +13,7 @@ interface AccountGridProps {
     onRefresh: (accountId: string) => void;
     onViewDevice: (accountId: string) => void;
     onViewDetails: (accountId: string) => void;
-    onExport: (accountId: string) => void;
+    onCopy: (accountId: string) => void;
     onDelete: (accountId: string) => void;
     onToggleProxy: (accountId: string) => void;
     onWarmup?: (accountId: string) => void;
@@ -22,7 +22,7 @@ interface AccountGridProps {
 }
 
 
-function AccountGrid({ accounts, selectedIds, refreshingIds, onToggleSelect, currentAccountId, switchingAccountId, onSwitch, onRefresh, onViewDetails, onExport, onDelete, onToggleProxy, onViewDevice, onWarmup, onUpdateLabel, onViewError }: AccountGridProps) {
+function AccountGrid({ accounts, selectedIds, refreshingIds, onToggleSelect, currentAccountId, switchingAccountId, onSwitch, onRefresh, onViewDetails, onCopy, onDelete, onToggleProxy, onViewDevice, onWarmup, onUpdateLabel, onViewError }: AccountGridProps) {
     const { t } = useTranslation();
     if (accounts.length === 0) {
         return (
@@ -48,7 +48,7 @@ function AccountGrid({ accounts, selectedIds, refreshingIds, onToggleSelect, cur
                     onRefresh={() => onRefresh(account.id)}
                     onViewDevice={() => onViewDevice(account.id)}
                     onViewDetails={() => onViewDetails(account.id)}
-                    onExport={() => onExport(account.id)}
+                    onCopy={() => onCopy(account.id)}
                     onDelete={() => onDelete(account.id)}
                     onToggleProxy={() => onToggleProxy(account.id)}
                     onWarmup={onWarmup ? () => onWarmup(account.id) : undefined}

--- a/src/components/accounts/AccountRow.tsx
+++ b/src/components/accounts/AccountRow.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightLeft, RefreshCw, Trash2, Download, Info, Lock, Ban, Diamond, Gem, Circle, Clock, ToggleLeft, ToggleRight, Fingerprint } from 'lucide-react';
+import { ArrowRightLeft, RefreshCw, Trash2, Copy, Info, Lock, Ban, Diamond, Gem, Circle, Clock, ToggleLeft, ToggleRight, Fingerprint } from 'lucide-react';
 import { Account } from '../../types/account';
 import { getQuotaColor, formatTimeRemaining, getTimeRemainingColor } from '../../utils/format';
 import { cn } from '../../utils/cn';
@@ -15,14 +15,14 @@ interface AccountRowProps {
     onRefresh: () => void;
     onViewDevice: () => void;
     onViewDetails: () => void;
-    onExport: () => void;
+    onCopy: () => void;
     onDelete: () => void;
     onToggleProxy: () => void;
 }
 
 
 
-function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSwitching = false, onSwitch, onRefresh, onViewDetails, onExport, onDelete, onToggleProxy, onViewDevice }: AccountRowProps) {
+function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSwitching = false, onSwitch, onRefresh, onViewDetails, onCopy, onDelete, onToggleProxy, onViewDevice }: AccountRowProps) {
     const { t } = useTranslation();
     // [重构] 按组聚合查找逻辑，优先显示组内配额最低的型号以与锁定状态（🔒）对齐
     const geminiProModel = account.quota?.models
@@ -345,10 +345,10 @@ function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSw
                     </button>
                     <button
                         className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 rounded-lg transition-all"
-                        onClick={(e) => { e.stopPropagation(); onExport(); }}
-                        title={t('common.export')}
+                        onClick={(e) => { e.stopPropagation(); onCopy(); }}
+                        title={t('common.copy')}
                     >
-                        <Download className="w-3.5 h-3.5" />
+                        <Copy className="w-3.5 h-3.5" />
                     </button>
                     <button
                         className={cn(

--- a/src/components/accounts/AccountTable.tsx
+++ b/src/components/accounts/AccountTable.tsx
@@ -27,7 +27,7 @@ import {
     ArrowRightLeft,
     RefreshCw,
     Trash2,
-    Download,
+    Copy,
     Fingerprint,
     Info,
     Lock,
@@ -67,7 +67,7 @@ interface AccountTableProps {
     onRefresh: (accountId: string) => void;
     onViewDevice: (accountId: string) => void;
     onViewDetails: (accountId: string) => void;
-    onExport: (accountId: string) => void;
+    onCopy: (accountId: string) => void;
     onDelete: (accountId: string) => void;
     onToggleProxy: (accountId: string) => void;
     onWarmup?: (accountId: string) => void;
@@ -89,7 +89,7 @@ interface SortableRowProps {
     onRefresh: () => void;
     onViewDevice: () => void;
     onViewDetails: () => void;
-    onExport: () => void;
+    onCopy: () => void;
     onDelete: () => void;
     onToggleProxy: () => void;
     onWarmup?: () => void;
@@ -107,7 +107,7 @@ interface AccountRowContentProps {
     onRefresh: () => void;
     onViewDevice: () => void;
     onViewDetails: () => void;
-    onExport: () => void;
+    onCopy: () => void;
     onDelete: () => void;
     onToggleProxy: () => void;
     onWarmup?: () => void;
@@ -209,7 +209,7 @@ function SortableAccountRow({
     onRefresh,
     onViewDevice,
     onViewDetails,
-    onExport,
+    onCopy,
     onDelete,
     onToggleProxy,
     onWarmup,
@@ -275,7 +275,7 @@ function SortableAccountRow({
                 onRefresh={onRefresh}
                 onViewDevice={onViewDevice}
                 onViewDetails={onViewDetails}
-                onExport={onExport}
+                onCopy={onCopy}
                 onDelete={onDelete}
                 onToggleProxy={onToggleProxy}
                 onWarmup={onWarmup}
@@ -300,7 +300,7 @@ function AccountRowContent({
     onRefresh,
     onViewDevice,
     onViewDetails,
-    onExport,
+    onCopy,
     onDelete,
     onToggleProxy,
     onWarmup,
@@ -637,10 +637,10 @@ function AccountRowContent({
                     </button>
                     <button
                         className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 rounded-lg transition-all"
-                        onClick={(e) => { e.stopPropagation(); onExport(); }}
-                        title={t('common.export')}
+                        onClick={(e) => { e.stopPropagation(); onCopy(); }}
+                        title={t('common.copy')}
                     >
-                        <Download className="w-3.5 h-3.5" />
+                        <Copy className="w-3.5 h-3.5" />
                     </button>
                     <button
                         className={cn(
@@ -691,7 +691,7 @@ function AccountTable({
     onRefresh,
     onViewDevice,
     onViewDetails,
-    onExport,
+    onCopy,
     onDelete,
     onToggleProxy,
     onReorder,
@@ -790,7 +790,7 @@ function AccountTable({
                                     onRefresh={() => onRefresh(account.id)}
                                     onViewDevice={() => onViewDevice(account.id)}
                                     onViewDetails={() => onViewDetails(account.id)}
-                                    onExport={() => onExport(account.id)}
+                                    onCopy={() => onCopy(account.id)}
                                     onDelete={() => onDelete(account.id)}
                                     onToggleProxy={() => onToggleProxy(account.id)}
                                     onWarmup={onWarmup ? () => onWarmup(account.id) : undefined}
@@ -832,7 +832,7 @@ function AccountTable({
                                         onRefresh={() => { }}
                                         onViewDevice={() => { }}
                                         onViewDetails={() => { }}
-                                        onExport={() => { }}
+                                        onCopy={() => { }}
                                         onDelete={() => { }}
                                         onToggleProxy={() => { }}
                                         isDisabled={Boolean(activeAccount.disabled)}


### PR DESCRIPTION
## Changes

### 1. Copy Button (replaces Export)
- Replace per-account export button with copy-to-clipboard
- Icon: Download -> Copy
- Copies single account JSON to clipboard
- Files: AccountCard.tsx, AccountGrid.tsx, AccountTable.tsx, AccountRow.tsx, Accounts.tsx

### 2. Dynamic Label Filter
- Add dynamic label filter tabs after PRO/ULTRA/FREE
- Labels auto-collected from custom_label field
- Purple theme for visual distinction
- File: Accounts.tsx