### PR TITLE
# fix(core): resolve account data corruption and background task infinite loops

### DIFF
--- a/src/components/common/BackgroundTaskRunner.tsx
+++ b/src/components/common/BackgroundTaskRunner.tsx
@@ -29,7 +29,7 @@ function BackgroundTaskRunner() {
             intervalId = setInterval(() => {
                 console.log('[BackgroundTask] Auto-refreshing all quotas...');
                 refreshAllQuotas();
-            }, refresh_interval * 60 * 1000);
+            }, Math.min(refresh_interval * 60 * 1000, 2147483647));
         }
 
         return () => {
@@ -60,7 +60,7 @@ function BackgroundTaskRunner() {
             intervalId = setInterval(() => {
                 console.log('[BackgroundTask] Auto-syncing current account from DB...');
                 syncAccountFromDb();
-            }, sync_interval * 60 * 1000);
+            }, Math.min(sync_interval * 60 * 1000, 2147483647));
         }
 
         return () => {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -707,9 +707,9 @@ function Settings() {
                                             type="number"
                                             className="w-24 px-3 py-2 bg-gray-50 dark:bg-base-200 border border-gray-100 dark:border-base-300 rounded-lg focus:ring-2 focus:ring-blue-500 outline-none text-sm font-bold text-blue-600 dark:text-blue-400"
                                             min="1"
-                                            max="60"
+                                            max="35791"
                                             value={formData.refresh_interval}
-                                            onChange={(e) => setFormData({ ...formData, refresh_interval: parseInt(e.target.value) })}
+                                            onChange={(e) => setFormData({ ...formData, refresh_interval: isNaN(parseInt(e.target.value)) ? 1 : Math.min(Math.max(parseInt(e.target.value), 1), 35791) })}
                                         />
                                     </div>
                                 </div>
@@ -745,9 +745,9 @@ function Settings() {
                                             type="number"
                                             className="w-24 px-3 py-2 bg-gray-50 dark:bg-base-200 border border-gray-100 dark:border-base-300 rounded-lg focus:ring-2 focus:ring-emerald-500 outline-none text-sm font-bold text-emerald-600 dark:text-emerald-400"
                                             min="1"
-                                            max="60"
+                                            max="35791"
                                             value={formData.sync_interval}
-                                            onChange={(e) => setFormData({ ...formData, sync_interval: parseInt(e.target.value) })}
+                                            onChange={(e) => setFormData({ ...formData, sync_interval: isNaN(parseInt(e.target.value)) ? 1 : Math.min(Math.max(parseInt(e.target.value), 1), 35791) })}
                                         />
                                     </div>
                                 )}


### PR DESCRIPTION
## Summary

Fixes two cascading critical bugs: a **`setInterval` 32-bit overflow** creating 1ms polling loops, and **non-atomic `fs::write` calls** causing permanent JSON corruption under the resulting concurrency flood.

---

## Root Cause

When a user enters an excessively large value for `refresh_interval` or `sync_interval`, the following chain of failures occurs:

```
Large interval input (e.g. 999999999)
  → interval * 60 * 1000 exceeds 2^31 - 1 (2,147,483,647 ms)
  → JS engine silently clamps setInterval delay to 1ms (per spec)
  → Frontend fires refreshAllQuotas/syncAccountFromDb thousands of times per second
  → Backend save_account hit with concurrent flood of write requests
  → Multiple threads call fs::write on the same [uuid].json (truncate + write, non-atomic)
  → Byte streams interleave → residual fragments left at file tail
  → serde_json parse error: "trailing characters at line 1 column XXX"
  → Account data permanently corrupted on disk
```

**Observed errors:**

```
ERROR [tauri::ipc] ExecutionFailed("failed_to_parse_account_data: trailing characters at line 1 column 927")
ERROR [tauri::ipc] ExecutionFailed("failed_to_parse_account_data: trailing characters at line 1 column 784")
```

---

## Changes

### 1. Atomic file writes — `account.rs`

`save_account` previously called `fs::write` directly, which performs a non-atomic `open(O_TRUNC) → write` sequence. Under concurrent access, multiple threads can truncate and partially overwrite the same file simultaneously, producing malformed JSON.

**Fix:** Write to a UUID-suffixed temp file in the same directory, then atomically replace the target via `fs::rename` (POSIX) or `MoveFileExW` (Windows). Since both files reside in the same directory, the rename is guaranteed atomic by the OS.

### 2. `setInterval` overflow guard — `BackgroundTaskRunner.tsx`

Per the [HTML spec](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers), any `setInterval` delay exceeding a signed 32-bit integer is implementation-defined — browsers clamp it to 1ms, creating a tight infinite loop.

**Fix:** Clamp the computed delay with `Math.min(interval * 60 * 1000, 2147483647)` before passing to `setInterval`. Applied to both the refresh and sync timers.

### 3. Input validation — `Settings.tsx`

The interval inputs had no bounds checking — `parseInt("")` yields `NaN`, and arbitrarily large values pass through unchecked.

**Fix:**

- `onChange` now clamps to `[1, 35791]` with `NaN` fallback to `1`
- HTML `max` attribute updated from `60` to `35791` to match (35791 min × 60000 = 2,147,460,000 < INT32_MAX)

---

## Files Changed

| File                                             | Change                                                                      |
| ------------------------------------------------ | --------------------------------------------------------------------------- |
| `src-tauri/src/modules/account.rs`               | `save_account`: write-to-temp + atomic rename instead of direct `fs::write` |
| `src/components/common/BackgroundTaskRunner.tsx` | `setInterval` delay clamped to `INT32_MAX`                                  |
| `src/pages/Settings.tsx`                         | Interval inputs: `[1, 35791]` clamp, `NaN` guard, `max` attr sync           |

## How to Verify

1. **Input bounds:** Hold `9` in an interval input field — value caps at `35791`.
2. **No overflow loop:** Set `refresh_interval` to `999999999` in the config file, restart — console should NOT show rapid-fire `Auto-refreshing` logs.
3. **Write atomicity:** Rapidly invoke `save_account` from DevTools — the on-disk JSON file must always be valid.
