### PR TITLE
highlight config hint command in AdminAuthGuard

### DIFF
--- a/src/components/common/AdminAuthGuard.tsx
+++ b/src/components/common/AdminAuthGuard.tsx
@@ -112,6 +112,29 @@ export const AdminAuthGuard: React.FC<{ children: React.ReactNode }> = ({ childr
         { code: 'es', name: 'Español' },
         { code: 'my', name: 'Bahasa Melayu' },
     ];
+    const configHintText = t('login.config_hint');
+    const configHintCommand = `grep -E '"api_key"|"admin_password"' ~/.antigravity_tools/gui_config.json`;
+    const configHintCommandIndex = configHintText.indexOf(configHintCommand);
+    const configHintPrefix = configHintCommandIndex >= 0 ? configHintText.slice(0, configHintCommandIndex) : '';
+    const configHintSuffix =
+        configHintCommandIndex >= 0
+            ? configHintText.slice(configHintCommandIndex + configHintCommand.length)
+            : '';
+    const configHintContent = (
+        <span className="group">
+            {configHintCommandIndex >= 0 ? (
+                <>
+                    {configHintPrefix}
+                    <span className="rounded px-1 transition-colors duration-150 group-hover:bg-amber-200/80 dark:group-hover:bg-amber-400/20">
+                        {configHintCommand}
+                    </span>
+                    {configHintSuffix}
+                </>
+            ) : (
+                configHintText
+            )}
+        </span>
+    );
 
     if (isAuthenticated) {
         return <>{children}</>;
@@ -196,7 +219,7 @@ export const AdminAuthGuard: React.FC<{ children: React.ReactNode }> = ({ childr
                             <br />
                             {t('login.lookup_hint')}
                             <br />
-                            {t('login.config_hint')}
+                            {configHintContent}
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
highlight config hint command in AdminAuthGuard when mouse hover

<img width="498" height="576" alt="QQ20260224-135738" src="https://github.com/user-attachments/assets/067db3f2-c0fa-4d6a-86d3-fe49a967e23b" />
<img width="494" height="583" alt="QQ20260224-135754" src="https://github.com/user-attachments/assets/16d52573-562c-44b1-ab83-f44823389a22" />
