### PR TITLE
fix(gemini): cap maxOutputTokens for gemini-3-flash to prevent 400 error

### DIFF
--- a/src-tauri/src/proxy/mappers/gemini/wrapper.rs
+++ b/src-tauri/src/proxy/mappers/gemini/wrapper.rs
@@ -243,6 +243,25 @@ pub fn wrap_request(
                 }
             }
         }
+
+        // [FIX] Cap maxOutputTokens to model-specific limits.
+        // gemini-3-flash supports max 65536; gemini-cli sends 131072 which causes 400 INVALID_ARGUMENT.
+        if let Some(max_tokens) = gen_config.get("maxOutputTokens").and_then(|v| v.as_u64()) {
+            let model_max = if final_model_name.contains("gemini-3-flash") {
+                65536u64
+            } else if final_model_name.contains("gemini-2.5-flash") {
+                65536u64
+            } else {
+                131072u64 // default reasonable cap
+            };
+            if max_tokens > model_max {
+                tracing::debug!(
+                    "[Gemini-Wrap] Capped maxOutputTokens from {} to {} for model {}",
+                    max_tokens, model_max, final_model_name
+                );
+                gen_config.insert("maxOutputTokens".to_string(), json!(model_max));
+            }
+        }
     }
 
     // [FIX] Removed forced maxOutputTokens (64000) as it exceeds limits for Gemini 1.5 Flash/Pro standard models (8192).


### PR DESCRIPTION
gemini-cli sends maxOutputTokens=131072 but gemini-3-flash only supports up to 65536, causing 400 INVALID_ARGUMENT from v1internal API.

Add model-specific maxOutputTokens cap in wrap_request:
- gemini-3-flash: 65536
- gemini-2.5-flash: 65536
- others: 131072 (default)