### PR TITLE
fix: exclude trailing quotes from URLs in error dialog

### DIFF
--- a/src/components/accounts/AccountErrorDialog.tsx
+++ b/src/components/accounts/AccountErrorDialog.tsx
@@ -107,7 +107,7 @@ export default function AccountErrorDialog({ account, onClose }: AccountErrorDia
     };
 
     const renderMessageWithLinks = (text: string) => {
-        const urlRegex = /(https?:\/\/[^\s]+)/g;
+        const urlRegex = /(https?:\/\/[^\s"'}\]>]+)/g;
         const parts = text.split(urlRegex);
         return parts.map((part, i) => {
             if (part.match(urlRegex)) {


### PR DESCRIPTION
## Summary
- Fix URL regex in `renderMessageWithLinks` that captured trailing `"`, `'`, `}`, `]`, `>` from JSON-embedded URLs
- Google API 403 responses include appeal URLs wrapped in JSON (e.g. `"appeal_url":"https://..."`), and the old regex `/(https?:\/\/[^\s]+)/g` would include the trailing quote, producing invalid links

## Changes
- `AccountErrorDialog.tsx`: Changed regex to `/(https?:\/\/[^\s"'}\]>]+)/g`

## Test plan
- [ ] Trigger 403 with appeal URL → link in error dialog should be clickable without trailing `"`
- [ ] Verify "Invalid Dynamic Link" error no longer occurs when clicking appeal link