### PR TITLE
fix: prevent TransferEncodingError in Gemini/Claude SSE streams

### DIFF
--- a/src-tauri/src/proxy/handlers/gemini.rs
+++ b/src-tauri/src/proxy/handlers/gemini.rs
@@ -343,7 +343,9 @@ pub async fn handle_generate(
                             Some(Ok(b)) => b,
                             Some(Err(e)) => {
                                 error!("[Gemini-SSE] Connection error: {}", e);
-                                yield Err(format!("Stream error: {}", e));
+                                // Yield error as SSE content to prevent hyper aborting chunked encoding (TransferEncodingError)
+                                let error_msg = format!("{}", e).replace('"', "'");
+                                yield Ok(Bytes::from(format!("data: {{\"error\":{{\"message\":\"{}\",\"type\":\"stream_error\"}}}}\n\n", error_msg)));
                                 break;
                             }
                             None => break,

--- a/src-tauri/src/proxy/mappers/claude/mod.rs
+++ b/src-tauri/src/proxy/mappers/claude/mod.rs
@@ -82,7 +82,9 @@ where
                             }
                         }
                         Err(e) => {
-                            yield Err(format!("Stream error: {}", e));
+                            // Yield error as SSE content to prevent hyper aborting chunked encoding (TransferEncodingError)
+                            let error_msg = format!("{}", e).replace('"', "'");
+                            yield Ok(Bytes::from(format!("event: error\ndata: {{\"error\":{{\"message\":\"{}\",\"type\":\"stream_error\"}}}}\n\n", error_msg)));
                             break;
                         }
                     }


### PR DESCRIPTION
## Problem

HTTP clients using aiohttp/httpx (e.g. OpenWebUI) receive:
```
TransferEncodingError: 400, message='Not enough data to satisfy transfer length header.'
```

## Root Cause

When SSE streams encounter upstream errors (connection drop, timeout), the Gemini handler and Claude SSE mapper use `yield Err(...)` inside `async_stream::stream!`. This `Err` propagates through `Body::from_stream()`, causing hyper to **abort HTTP/1.1 chunked transfer encoding** without sending the final `0\r\n\r\n` terminator chunk.

HTTP clients that validate chunked encoding integrity then throw `TransferEncodingError`.

## Fix

Convert stream errors from `Err(...)` to `Ok(Bytes)` containing SSE-formatted error content. This matches the pattern **already used by the OpenAI streaming handler** (line ~282 in `streaming.rs`), which correctly wraps errors as `Ok(error_json_bytes)`.

The stream terminates cleanly with `None`, hyper sends the proper `0\r\n\r\n` terminator, and the client receives a well-formed HTTP response with error details.

## Changes

| File | Before | After |
|------|--------|-------|
| `handlers/gemini.rs` | `yield Err(format!("Stream error: {}", e))` | `yield Ok(Bytes::from(error_json_sse))` |
| `mappers/claude/mod.rs` | `yield Err(format!("Stream error: {}", e))` | `yield Ok(Bytes::from(error_event_sse))` |

**Already correct:** OpenAI handler wraps errors as `Ok(Bytes)` with JSON error payload + `[DONE]`.