### PR TITLE
fix: prevent TransferEncodingError in Gemini SSE stream

### DIFF
--- a/src-tauri/src/proxy/handlers/gemini.rs
+++ b/src-tauri/src/proxy/handlers/gemini.rs
@@ -343,7 +343,13 @@ pub async fn handle_generate(
                             Some(Ok(b)) => b,
                             Some(Err(e)) => {
                                 error!("[Gemini-SSE] Connection error: {}", e);
-                                yield Err(format!("Stream error: {}", e));
+                                let error_json = serde_json::json!({
+                                    "error": {
+                                        "message": format!("Stream error: {}", e),
+                                        "type": "stream_error"
+                                    }
+                                });
+                                yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", error_json)));
                                 break;
                             }
                             None => break,

--- a/src-tauri/src/proxy/mappers/claude/mod.rs
+++ b/src-tauri/src/proxy/mappers/claude/mod.rs
@@ -82,7 +82,13 @@ where
                             }
                         }
                         Err(e) => {
-                            yield Err(format!("Stream error: {}", e));
+                            let error_json = serde_json::json!({
+                                "error": {
+                                    "message": format!("Stream error: {}", e),
+                                    "type": "stream_error"
+                                }
+                            });
+                            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", error_json)));
                             break;
                         }
                     }


### PR DESCRIPTION
## Problem

When upstream returns an error during Gemini SSE streaming, the handler yields `Err(String)` into `Body::from_stream()`. Axum/hyper interprets this as a transport-level failure and aborts the HTTP response with a `TransferEncoding` error instead of delivering the error as a valid SSE `data:` frame.

**Impact:** HTTP clients (aiohttp, httpx, curl) see a broken chunked transfer instead of a parseable error event. This is the root cause of `TransferEncodingError` / `ClientPayloadError` reports.

## Fix

Convert `yield Err(...)` to `yield Ok(Bytes::from(...))` with a properly formatted SSE error event (`data: {"error": ...}\n\n`). This ensures error information reaches the client as valid SSE data rather than corrupting the HTTP transport layer.

**Files changed:**
- `src-tauri/src/proxy/handlers/gemini.rs` — primary fix (stream error yield)
- `src-tauri/src/proxy/mappers/claude/mod.rs` — defense-in-depth (same pattern)

## Verification

- OpenAI handler already uses the correct `Ok(Bytes)` pattern — this PR aligns Gemini and Claude mappers to the same contract
- Minimal diff: 2 files, 16 insertions, 2 deletions — no formatting or unrelated changes