### PR TITLE
fix(proxy): avoid Gemini v1internal 400 when functionDeclarations exist

### DIFF
--- a/src-tauri/src/proxy/mappers/common_utils.rs
+++ b/src-tauri/src/proxy/mappers/common_utils.rs
@@ -340,24 +340,17 @@ pub fn inject_google_search_tool(body: &mut Value, mapped_model: Option<&str>) {
     if let Some(obj) = body.as_object_mut() {
         let tools_entry = obj.entry("tools").or_insert_with(|| json!([]));
         if let Some(tools_arr) = tools_entry.as_array_mut() {
-            // [安全校验] Gemini v1internal 对混合工具有严格要求。
-            // 只有 Gemini 2.0+ 及 3.0 系列模型确认支持混合工具 (Function Calling + Google Search)。
-            let mut supports_mixed_tools = false;
-            if let Some(model) = mapped_model {
-                let model_lower = model.to_lowercase();
-                supports_mixed_tools = model_lower.contains("gemini-2.0")
-                    || model_lower.contains("gemini-2.5")
-                    || model_lower.contains("gemini-3");
-            }
-
             let has_functions = tools_arr.iter().any(|t| {
                 t.as_object()
                     .map_or(false, |o| o.contains_key("functionDeclarations"))
             });
 
-            if has_functions && !supports_mixed_tools {
+            // [FIX] v1internal (cloudcode-pa) does NOT support mixing googleSearch
+            // with functionDeclarations — it lacks includeServerSideToolInvocations.
+            // Skip googleSearch injection entirely when function tools are present.
+            if has_functions {
                 tracing::debug!(
-                    "Skipping googleSearch injection due to existing functionDeclarations on older model"
+                    "Skipping googleSearch injection: functionDeclarations present (v1internal incompatible)"
                 );
                 return;
             }


### PR DESCRIPTION
## 背景
在 OpenAI 兼容接口中使用 `gemini-3-flash` 且同时携带 function tools（会映射为 `functionDeclarations`）时，请求会返回 400：

`Please enable tool_config.include_server_side_tool_invocations to use Built-in tools with Function calling.`

## 根因
当前逻辑会在部分 Gemini 请求中自动注入 `googleSearch` built-in tool。  
当请求本身已经包含 `functionDeclarations` 时，这会形成「built-in tool + function calling」混用场景。

但 Antigravity 走的是 `cloudcode-pa.googleapis.com/v1internal` 协议，该协议不支持 `tool_config.includeServerSideToolInvocations`，因此会被上游拒绝。

## 修复
在 `inject_google_search_tool()` 中统一处理：
- 只要请求里已经存在 `functionDeclarations`，就直接跳过 `googleSearch` 注入。
- 保留无 function tools 场景下的 `googleSearch` 注入行为。

## 行为变化
- 有 function tools：不再自动注入 `googleSearch`（避免 400）。
- 无 function tools：维持原有自动注入行为。

## 影响范围
该函数被多条路径复用，因此修复可同时覆盖：
- OpenAI 兼容接口
- Claude 协议接口
- Gemini 原生接口

## 验证
1. 使用 `gemini-3-flash` + function tools 发送请求，不再出现上述 400。
2. 无 function tools 的纯聊天请求，仍可正常使用自动注入的 `googleSearch`。

---

如果维护者更倾向于仅对特定模型或路由生效，我也可以继续提交一个更细粒度开关版本。
