### PR TITLE
Fix duplicate token usage recording

### DIFF
--- a/src-tauri/src/proxy/monitor.rs
+++ b/src-tauri/src/proxy/monitor.rs
@@ -146,17 +146,6 @@ impl ProxyMonitor {
                 }
             }
 
-            // Record token stats if available
-            if let (Some(account), Some(input), Some(output)) = (
-                &log_to_save.account_email,
-                log_to_save.input_tokens,
-                log_to_save.output_tokens,
-            ) {
-                let model = log_to_save.model.clone().unwrap_or_else(|| "unknown".to_string());
-                if let Err(e) = crate::modules::token_stats::record_usage(account, &model, input, output) {
-                    tracing::debug!("Failed to record token stats: {}", e);
-                }
-            }
         });
 
         // Emit event (send summary only, without body to reduce memory)


### PR DESCRIPTION
## Summary
- remove the second token usage recording call from the async log persistence path
- keep the original usage recording in place so each completed request is counted once
- preserve existing proxy log saving and event emission behavior

## Verification
- built and deployed the patched app locally
- verified a new request increases token usage rows by 1 instead of 2