### PR TITLE
Fix idle account recovery and add default prompt toggle

### DIFF
--- a/src-tauri/src/proxy/config.rs
+++ b/src-tauri/src/proxy/config.rs
@@ -78,8 +78,9 @@ pub fn update_global_system_prompt_config(config: GlobalSystemPromptConfig) {
         if let Ok(mut cfg) = lock.write() {
             *cfg = config.clone();
             tracing::info!(
-                "[Global-System-Prompt] Config updated: enabled={}, content_len={}",
+                "[Global-System-Prompt] Config updated: enabled={}, include_default_prompt={}, content_len={}",
                 config.enabled,
+                config.include_default_prompt,
                 config.content.len()
             );
         }
@@ -87,8 +88,9 @@ pub fn update_global_system_prompt_config(config: GlobalSystemPromptConfig) {
         // 首次初始化
         let _ = GLOBAL_SYSTEM_PROMPT_CONFIG.set(RwLock::new(config.clone()));
         tracing::info!(
-            "[Global-System-Prompt] Config initialized: enabled={}, content_len={}",
+            "[Global-System-Prompt] Config initialized: enabled={}, include_default_prompt={}, content_len={}",
             config.enabled,
+            config.include_default_prompt,
             config.content.len()
         );
     }
@@ -130,6 +132,13 @@ pub struct GlobalSystemPromptConfig {
     /// 系统提示词内容
     #[serde(default)]
     pub content: String,
+    /// 是否注入内置 Antigravity 身份提示词
+    #[serde(default = "default_include_default_prompt")]
+    pub include_default_prompt: bool,
+}
+
+fn default_include_default_prompt() -> bool {
+    true
 }
 
 impl Default for GlobalSystemPromptConfig {
@@ -137,6 +146,7 @@ impl Default for GlobalSystemPromptConfig {
         Self {
             enabled: false,
             content: String::new(),
+            include_default_prompt: true,
         }
     }
 }

--- a/src-tauri/src/proxy/handlers/claude.rs
+++ b/src-tauri/src/proxy/handlers/claude.rs
@@ -911,7 +911,7 @@ pub async fn handle_messages(
         // 成功
         if status.is_success() {
             // [智能限流] 请求成功，重置该账号的连续失败计数
-            token_manager.mark_account_success(&email);
+            token_manager.mark_account_success(&account_id);
             
                 // Determine context limit based on model
                 let context_limit = crate::proxy::mappers::claude::utils::get_context_limit_for_model(&request_with_mapped.model);

--- a/src-tauri/src/proxy/handlers/gemini.rs
+++ b/src-tauri/src/proxy/handlers/gemini.rs
@@ -269,6 +269,8 @@ pub async fn handle_generate(
             .map(|s| s.to_string());
 
         if status.is_success() {
+            token_manager.mark_account_success(&account_id);
+
             // 6. 响应处理
             if is_stream {
                 use axum::body::Body;

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -1286,7 +1286,7 @@ pub async fn handle_completions(
         let status = response.status();
         if status.is_success() {
             // [智能限流] 请求成功，重置该账号的连续失败计数
-            token_manager.mark_account_success(&email);
+            token_manager.mark_account_success(&account_id);
 
             if list_response {
                 use axum::body::Body;

--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -841,13 +841,16 @@ fn build_system_instruction(
         }
     }
 
-    // 如果用户没有提供 Antigravity 身份,则注入
-    if !user_has_antigravity {
+    let global_prompt_config = crate::proxy::config::get_global_system_prompt();
+    let should_inject_default_prompt =
+        global_prompt_config.include_default_prompt && !user_has_antigravity;
+
+    // 如果用户没有提供 Antigravity 身份,且配置允许,则注入
+    if should_inject_default_prompt {
         parts.push(json!({"text": antigravity_identity}));
     }
 
     // [NEW] 注入全局系统提示词 (紧跟 Antigravity 身份之后)
-    let global_prompt_config = crate::proxy::config::get_global_system_prompt();
     if global_prompt_config.enabled && !global_prompt_config.content.trim().is_empty() {
         parts.push(json!({"text": global_prompt_config.content}));
     }
@@ -884,15 +887,19 @@ fn build_system_instruction(
         parts.push(json!({"text": mcp_xml_prompt}));
     }
 
-    // 如果用户没有提供任何系统提示词,添加结束标记
-    if !user_has_antigravity {
+    // 只有注入了内置默认提示词时才添加结束标记
+    if should_inject_default_prompt {
         parts.push(json!({"text": "\n--- [SYSTEM_PROMPT_END] ---"}));
     }
 
-    Some(json!({
-        "role": "user",
-        "parts": parts
-    }))
+    if parts.is_empty() {
+        None
+    } else {
+        Some(json!({
+            "role": "user",
+            "parts": parts
+        }))
+    }
 }
 
 /// 构建 Contents (Messages)
@@ -2053,7 +2060,9 @@ fn is_model_compatible(cached: &str, target: &str) -> bool {
 mod tests {
     use super::*;
     use crate::proxy::common::json_schema::clean_json_schema;
-    use crate::proxy::config::{ThinkingBudgetConfig, update_thinking_budget_config};
+    use crate::proxy::config::{
+        update_global_system_prompt_config, GlobalSystemPromptConfig, ThinkingBudgetConfig,
+    };
 
     #[test]
     fn test_ephemeral_injection_debug() {
@@ -2121,6 +2130,53 @@ mod tests {
         let body = result.unwrap();
         assert_eq!(body["project"], "test-project");
         assert!(body["requestId"].as_str().unwrap().starts_with("agent/"));
+    }
+
+    #[test]
+    fn test_default_system_prompt_can_be_disabled() {
+        update_global_system_prompt_config(GlobalSystemPromptConfig {
+            enabled: false,
+            content: String::new(),
+            include_default_prompt: false,
+        });
+
+        let req = ClaudeRequest {
+            model: "claude-sonnet-4-6".to_string(),
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: MessageContent::String("Hello".to_string()),
+            }],
+            system: Some(SystemPrompt::String("Custom system only".to_string())),
+            tools: None,
+            stream: false,
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            thinking: None,
+            metadata: None,
+            output_config: None,
+            size: None,
+            quality: None,
+        };
+
+        let body =
+            transform_claude_request_in(&req, "test-project", false, None, "test_session", None)
+                .unwrap();
+        let parts = body["request"]["systemInstruction"]["parts"]
+            .as_array()
+            .unwrap();
+        let system_text = parts
+            .iter()
+            .filter_map(|part| part.get("text").and_then(|text| text.as_str()))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(!system_text.contains("You are Antigravity"));
+        assert!(!system_text.contains("SYSTEM_PROMPT_END"));
+        assert!(system_text.contains("Custom system only"));
+
+        update_global_system_prompt_config(GlobalSystemPromptConfig::default());
     }
 
     #[test]

--- a/src-tauri/src/proxy/mappers/gemini/wrapper.rs
+++ b/src-tauri/src/proxy/mappers/gemini/wrapper.rs
@@ -468,6 +468,8 @@ pub fn wrap_request(
             **Proactiveness**"
         };
 
+        let global_prompt_config = crate::proxy::config::get_global_system_prompt();
+
         // [HYBRID] 检查是否已有 systemInstruction
         if let Some(system_instruction) = inner_request.get_mut("systemInstruction") {
             // [NEW] 补全 role: user
@@ -487,18 +489,24 @@ pub fn wrap_request(
                         .map(|s| s.contains("You are Antigravity"))
                         .unwrap_or(false);
 
-                    if !has_antigravity {
+                    let should_inject_default_prompt =
+                        global_prompt_config.include_default_prompt && !has_antigravity;
+
+                    if should_inject_default_prompt {
                         // 在前面插入 Antigravity 身份
                         parts_array.insert(0, json!({"text": antigravity_identity}));
                     }
 
                     // [NEW] 注入全局系统提示词 (紧跟 Antigravity 身份之后，用户指令之前)
-                    let global_prompt_config = crate::proxy::config::get_global_system_prompt();
                     if global_prompt_config.enabled
                         && !global_prompt_config.content.trim().is_empty()
                     {
-                        // 插入位置：Antigravity 身份之后 (index 1)
-                        let insert_pos = if has_antigravity { 1 } else { 1 };
+                        // 插入位置：内置或用户已有 Antigravity 身份之后，否则放在最前
+                        let insert_pos = if should_inject_default_prompt || has_antigravity {
+                            1
+                        } else {
+                            0
+                        };
                         if insert_pos <= parts_array.len() {
                             parts_array
                                 .insert(insert_pos, json!({"text": global_prompt_config.content}));
@@ -510,16 +518,20 @@ pub fn wrap_request(
             }
         } else {
             // 没有 systemInstruction,创建一个新的
-            let mut parts = vec![json!({"text": antigravity_identity})];
+            let mut parts = Vec::new();
+            if global_prompt_config.include_default_prompt {
+                parts.push(json!({"text": antigravity_identity}));
+            }
             // [NEW] 注入全局系统提示词
-            let global_prompt_config = crate::proxy::config::get_global_system_prompt();
             if global_prompt_config.enabled && !global_prompt_config.content.trim().is_empty() {
                 parts.push(json!({"text": global_prompt_config.content}));
             }
-            inner_request["systemInstruction"] = json!({
-                "role": "user",
-                "parts": parts
-            });
+            if !parts.is_empty() {
+                inner_request["systemInstruction"] = json!({
+                    "role": "user",
+                    "parts": parts
+                });
+            }
         }
     }
 
@@ -673,6 +685,7 @@ pub fn inject_ids_to_response(response: &mut Value, model_name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::proxy::config::{update_global_system_prompt_config, GlobalSystemPromptConfig};
     use serde_json::json;
 
     #[test]
@@ -716,6 +729,38 @@ mod tests {
             .unwrap()
             .get("systemInstruction")
             .unwrap();
+    }
+
+    #[test]
+    fn test_default_system_prompt_can_be_disabled_gemini_native() {
+        update_global_system_prompt_config(GlobalSystemPromptConfig {
+            enabled: false,
+            content: String::new(),
+            include_default_prompt: false,
+        });
+
+        let body = json!({
+            "model": "gemini-pro",
+            "systemInstruction": {
+                "parts": [{"text": "Custom system only"}]
+            },
+            "contents": [{"role": "user", "parts": [{"text": "Hello"}]}]
+        });
+
+        let result = wrap_request(&body, "test-proj", "gemini-pro", None, None, None);
+        let parts = result["request"]["systemInstruction"]["parts"]
+            .as_array()
+            .unwrap();
+        let system_text = parts
+            .iter()
+            .filter_map(|part| part.get("text").and_then(|text| text.as_str()))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(!system_text.contains("You are Antigravity"));
+        assert!(system_text.contains("Custom system only"));
+
+        update_global_system_prompt_config(GlobalSystemPromptConfig::default());
     }
 
     #[test]

--- a/src-tauri/src/proxy/mappers/openai/request.rs
+++ b/src-tauri/src/proxy/mappers/openai/request.rs
@@ -682,14 +682,16 @@ pub fn transform_openai_request(
         .any(|s| s.contains("You are Antigravity"));
 
     let mut parts = Vec::new();
+    let global_prompt_config = crate::proxy::config::get_global_system_prompt();
+    let should_inject_default_prompt =
+        global_prompt_config.include_default_prompt && !user_has_antigravity;
 
     // 1. Antigravity 身份 (如果需要, 作为独立 Part 插入)
-    if !user_has_antigravity {
+    if should_inject_default_prompt {
         parts.push(json!({"text": antigravity_identity}));
     }
 
     // 2. [NEW] 注入全局系统提示词 (紧跟 Antigravity 身份之后)
-    let global_prompt_config = crate::proxy::config::get_global_system_prompt();
     if global_prompt_config.enabled && !global_prompt_config.content.trim().is_empty() {
         parts.push(json!({"text": global_prompt_config.content}));
     }
@@ -699,10 +701,12 @@ pub fn transform_openai_request(
         parts.push(json!({"text": inst}));
     }
 
-    inner_request["systemInstruction"] = json!({
-        "role": "user",
-        "parts": parts
-    });
+    if !parts.is_empty() {
+        inner_request["systemInstruction"] = json!({
+            "role": "user",
+            "parts": parts
+        });
+    }
 
     if config.inject_google_search {
         crate::proxy::mappers::common_utils::inject_google_search_tool(&mut inner_request, Some(mapped_model));
@@ -769,9 +773,56 @@ fn enforce_uppercase_types(value: &mut Value) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proxy::mappers::openai::models::*;
+    use crate::proxy::config::{update_global_system_prompt_config, GlobalSystemPromptConfig};
 
     #[test]
+    fn test_default_system_prompt_can_be_disabled_openai() {
+        update_global_system_prompt_config(GlobalSystemPromptConfig {
+            enabled: false,
+            content: String::new(),
+            include_default_prompt: false,
+        });
+
+        let req = OpenAIRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![
+                OpenAIMessage {
+                    role: "system".to_string(),
+                    content: Some(OpenAIContent::String("Custom system only".to_string())),
+                    reasoning_content: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                    name: None,
+                },
+                OpenAIMessage {
+                    role: "user".to_string(),
+                    content: Some(OpenAIContent::String("Hello".to_string())),
+                    reasoning_content: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                    name: None,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let (result, _, _) =
+            transform_openai_request(&req, "test-project", "gemini-2.0-flash", None);
+        let parts = result["request"]["systemInstruction"]["parts"]
+            .as_array()
+            .unwrap();
+        let system_text = parts
+            .iter()
+            .filter_map(|part| part.get("text").and_then(|text| text.as_str()))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(!system_text.contains("You are Antigravity"));
+        assert!(system_text.contains("Custom system only"));
+
+        update_global_system_prompt_config(GlobalSystemPromptConfig::default());
+    }
+
     #[test]
     fn test_issue_1592_gemini_3_pro_budget_capping() {
         // [FIX #1592] Regression test for gemini-3-pro thinking budget capping

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -1104,17 +1104,56 @@ impl TokenManager {
 
         // 【优化 Issue #284】添加 5 秒超时，防止死锁
         let timeout_duration = std::time::Duration::from_secs(5);
-        match tokio::time::timeout(
+        let first_result = match tokio::time::timeout(
             timeout_duration,
             self.get_token_internal(quota_group, force_rotate, session_id, target_model),
         )
         .await
         {
             Ok(result) => result,
-            Err(_) => Err(
-                "Token acquisition timeout (5s) - system too busy or deadlock detected".to_string(),
-            ),
+            Err(_) => {
+                return Err(
+                    "Token acquisition timeout (5s) - system too busy or deadlock detected".to_string(),
+                )
+            }
+        };
+
+        if let Err(error) = &first_result {
+            if Self::should_reload_after_token_error(error) {
+                tracing::warn!(
+                    "[Token Recovery] {} Reloading account cache once before failing.",
+                    error
+                );
+                self.reload_all_accounts()
+                    .await
+                    .map_err(|reload_err| {
+                        format!("{} (account cache reload failed: {})", error, reload_err)
+                    })?;
+
+                return match tokio::time::timeout(
+                    timeout_duration,
+                    self.get_token_internal(quota_group, force_rotate, session_id, target_model),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => Err(
+                        "Token acquisition timeout (5s) after account cache reload".to_string(),
+                    ),
+                };
+            }
         }
+
+        first_result
+    }
+
+    fn should_reload_after_token_error(error: &str) -> bool {
+        matches!(
+            error,
+            "All accounts failed or unhealthy."
+                | "All accounts failed"
+                | "All accounts failed after optimistic reset."
+        )
     }
 
     /// 内部实现：获取 Token 的核心逻辑
@@ -2001,6 +2040,7 @@ impl TokenManager {
 
         // 【替代方案】转换 email -> account_id
         let key = self.email_to_account_id(email).unwrap_or_else(|| email.to_string());
+        self.record_failure(&key);
 
         self.rate_limit_tracker.parse_from_error(
             &key,
@@ -2067,8 +2107,12 @@ impl TokenManager {
     ///
     /// 在请求成功完成后调用，将该账号的失败计数归零，
     /// 下次失败时从最短的锁定时间开始（智能限流）。
-    pub fn mark_account_success(&self, account_id: &str) {
-        self.rate_limit_tracker.mark_success(account_id);
+    pub fn mark_account_success(&self, account_id_or_email: &str) {
+        let account_id = self
+            .email_to_account_id(account_id_or_email)
+            .unwrap_or_else(|| account_id_or_email.to_string());
+        self.rate_limit_tracker.mark_success(&account_id);
+        self.record_success(&account_id);
     }
 
     /// 检查是否有可用的 Google 账号
@@ -2301,6 +2345,7 @@ impl TokenManager {
 
         // [FIX] Convert email to account_id for consistent tracking
         let account_id = self.email_to_account_id(email).unwrap_or_else(|| email.to_string());
+        self.record_failure(&account_id);
 
         // 检查 API 是否返回了精确的重试时间
         let has_explicit_retry_time = retry_after_header.is_some() ||
@@ -2505,19 +2550,33 @@ impl TokenManager {
 
     /// 记录请求成功，增加健康分
     pub fn record_success(&self, account_id: &str) {
-        self.health_scores
+        let score = self
+            .health_scores
             .entry(account_id.to_string())
             .and_modify(|s| *s = (*s + 0.05).min(1.0))
             .or_insert(1.0);
+        let updated_score = *score;
+        drop(score);
+
+        if let Some(mut token) = self.tokens.get_mut(account_id) {
+            token.health_score = updated_score;
+        }
         tracing::debug!("📈 Health score increased for account {}", account_id);
     }
 
     /// 记录请求失败，降低健康分
     pub fn record_failure(&self, account_id: &str) {
-        self.health_scores
+        let score = self
+            .health_scores
             .entry(account_id.to_string())
             .and_modify(|s| *s = (*s - 0.2).max(0.0))
             .or_insert(0.8);
+        let updated_score = *score;
+        drop(score);
+
+        if let Some(mut token) = self.tokens.get_mut(account_id) {
+            token.health_score = updated_score;
+        }
         tracing::warn!("📉 Health score decreased for account {}", account_id);
     }
 
@@ -2955,6 +3014,41 @@ mod tests {
             model_quotas: HashMap::new(),
             model_limits: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn test_mark_account_success_accepts_email() {
+        let manager = TokenManager::new(PathBuf::from("/tmp/test"));
+        let mut token = create_test_token("user@example.com", Some("PRO"), 0.8, None, Some(50));
+        token.account_id = "acc1".to_string();
+        manager.tokens.insert(token.account_id.clone(), token);
+
+        manager.rate_limit_tracker.parse_from_error(
+            "acc1",
+            429,
+            Some("60"),
+            "quota exhausted",
+            None,
+            &[60],
+        );
+        assert!(manager.rate_limit_tracker.is_rate_limited("acc1", None));
+
+        manager.mark_account_success("user@example.com");
+
+        assert!(!manager.rate_limit_tracker.is_rate_limited("acc1", None));
+    }
+
+    #[test]
+    fn test_stale_token_pool_errors_trigger_reload() {
+        assert!(TokenManager::should_reload_after_token_error(
+            "All accounts failed or unhealthy."
+        ));
+        assert!(TokenManager::should_reload_after_token_error(
+            "All accounts failed"
+        ));
+        assert!(!TokenManager::should_reload_after_token_error(
+            "All accounts limited. Wait 60s."
+        ));
     }
 
     /// 测试排序比较函数（与 get_token_internal 中的逻辑一致）

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -1121,14 +1121,12 @@ impl TokenManager {
         if let Err(error) = &first_result {
             if Self::should_reload_after_token_error(error) {
                 tracing::warn!(
-                    "[Token Recovery] {} Reloading account cache once before failing.",
+                    "[Token Recovery] {} Refreshing account cache once before failing; preserving rate limits.",
                     error
                 );
-                self.reload_all_accounts()
-                    .await
-                    .map_err(|reload_err| {
-                        format!("{} (account cache reload failed: {})", error, reload_err)
-                    })?;
+                self.load_accounts().await.map_err(|reload_err| {
+                    format!("{} (account cache reload failed: {})", error, reload_err)
+                })?;
 
                 return match tokio::time::timeout(
                     timeout_duration,
@@ -1467,8 +1465,9 @@ impl TokenManager {
                         let key = self
                             .email_to_account_id(&bound_token.email)
                             .unwrap_or_else(|| bound_token.account_id.clone());
-                        // [FIX] Pass None for specific model wait time if not applicable
-                        let reset_sec = self.rate_limit_tracker.get_remaining_wait(&key, None);
+                        let reset_sec = self
+                            .rate_limit_tracker
+                            .get_remaining_wait(&key, Some(&normalized_target));
                         if reset_sec > 0 {
                             // 【修复 Issue #284】立即解绑并切换账号，不再阻塞等待
                             // 原因：阻塞等待会导致并发请求时客户端 socket 超时 (UND_ERR_SOCKET)
@@ -1605,10 +1604,14 @@ impl TokenManager {
                 Some(t) => t,
                 None => {
                     // 乐观重置策略: 双层防护机制
-                    // 计算最短等待时间
+                    // 计算最短等待时间，必须包含模型级限流。
                     let min_wait = tokens_snapshot
                         .iter()
-                        .filter_map(|t| self.rate_limit_tracker.get_reset_seconds(&t.account_id))
+                        .map(|t| {
+                            self.rate_limit_tracker
+                                .get_remaining_wait(&t.account_id, Some(&normalized_target))
+                        })
+                        .filter(|wait_sec| *wait_sec > 0)
                         .min();
 
                     // Layer 1: 如果最短等待时间 <= 2秒,执行缓冲延迟
@@ -3049,6 +3052,191 @@ mod tests {
         assert!(!TokenManager::should_reload_after_token_error(
             "All accounts limited. Wait 60s."
         ));
+    }
+
+    #[tokio::test]
+    async fn test_model_level_rate_limits_are_reported_as_limited() {
+        let tmp_root = std::env::temp_dir().join(format!(
+            "antigravity-token-manager-test-model-limit-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let accounts_dir = tmp_root.join("accounts");
+        std::fs::create_dir_all(&accounts_dir).unwrap();
+
+        let now = chrono::Utc::now().timestamp();
+        let write_account = |id: &str, email: &str, percentage: i64| {
+            let account_path = accounts_dir.join(format!("{}.json", id));
+            let json = serde_json::json!({
+                "id": id,
+                "email": email,
+                "token": {
+                    "access_token": format!("atk-{}", id),
+                    "refresh_token": format!("rtk-{}", id),
+                    "expires_in": 3600,
+                    "expiry_timestamp": now + 3600,
+                    "project_id": format!("pid-{}", id)
+                },
+                "quota": {
+                    "models": [
+                        { "name": "gemini-1.5-flash", "percentage": percentage }
+                    ]
+                },
+                "disabled": false,
+                "proxy_disabled": false,
+                "created_at": now,
+                "last_used": now
+            });
+            std::fs::write(&account_path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+        };
+
+        write_account("acc1", "a@test.com", 80);
+        write_account("acc2", "b@test.com", 70);
+
+        let manager = TokenManager::new(tmp_root.clone());
+        manager.load_accounts().await.unwrap();
+        let normalized_model = "gemini-3-flash";
+
+        let reset_time =
+            std::time::SystemTime::now() + std::time::Duration::from_secs(60);
+        manager.rate_limit_tracker.set_lockout_until(
+            "acc1",
+            reset_time,
+            crate::proxy::rate_limit::RateLimitReason::QuotaExhausted,
+            Some(normalized_model.to_string()),
+        );
+        manager.rate_limit_tracker.set_lockout_until(
+            "acc2",
+            reset_time,
+            crate::proxy::rate_limit::RateLimitReason::QuotaExhausted,
+            Some(normalized_model.to_string()),
+        );
+
+        let err = manager
+            .get_token("gemini", false, None, "gemini-1.5-flash")
+            .await
+            .unwrap_err();
+
+        assert!(err.starts_with("All accounts limited. Wait "), "{err}");
+        assert!(!TokenManager::should_reload_after_token_error(&err));
+        assert!(manager
+            .rate_limit_tracker
+            .is_rate_limited("acc1", Some(normalized_model)));
+        assert!(manager
+            .rate_limit_tracker
+            .is_rate_limited("acc2", Some(normalized_model)));
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
+    }
+
+    #[tokio::test]
+    async fn test_sticky_session_skips_model_level_limited_bound_account() {
+        let tmp_root = std::env::temp_dir().join(format!(
+            "antigravity-token-manager-test-sticky-model-limit-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let accounts_dir = tmp_root.join("accounts");
+        std::fs::create_dir_all(&accounts_dir).unwrap();
+
+        let now = chrono::Utc::now().timestamp();
+        let write_account = |id: &str, email: &str, percentage: i64| {
+            let account_path = accounts_dir.join(format!("{}.json", id));
+            let json = serde_json::json!({
+                "id": id,
+                "email": email,
+                "token": {
+                    "access_token": format!("atk-{}", id),
+                    "refresh_token": format!("rtk-{}", id),
+                    "expires_in": 3600,
+                    "expiry_timestamp": now + 3600,
+                    "project_id": format!("pid-{}", id)
+                },
+                "quota": {
+                    "models": [
+                        { "name": "gemini-1.5-flash", "percentage": percentage }
+                    ]
+                },
+                "disabled": false,
+                "proxy_disabled": false,
+                "created_at": now,
+                "last_used": now
+            });
+            std::fs::write(&account_path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+        };
+
+        write_account("acc1", "a@test.com", 90);
+        write_account("acc2", "b@test.com", 10);
+
+        let manager = TokenManager::new(tmp_root.clone());
+        manager.load_accounts().await.unwrap();
+
+        let (_token, _project_id, _email, account_id, _wait_ms) = manager
+            .get_token("gemini", false, Some("sid1"), "gemini-1.5-flash")
+            .await
+            .unwrap();
+        assert_eq!(account_id, "acc1");
+
+        manager.rate_limit_tracker.set_lockout_until(
+            "acc1",
+            std::time::SystemTime::now() + std::time::Duration::from_secs(60),
+            crate::proxy::rate_limit::RateLimitReason::QuotaExhausted,
+            Some("gemini-3-flash".to_string()),
+        );
+
+        let (_token, _project_id, email, account_id, _wait_ms) = manager
+            .get_token("gemini", false, Some("sid1"), "gemini-1.5-flash")
+            .await
+            .unwrap();
+
+        assert_eq!(account_id, "acc2");
+        assert_eq!(email, "b@test.com");
+        assert_eq!(
+            manager.session_accounts.get("sid1").map(|v| v.clone()),
+            Some("acc2".to_string())
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
+    }
+
+    #[tokio::test]
+    async fn test_token_recovery_preserves_existing_rate_limits() {
+        let tmp_root = std::env::temp_dir().join(format!(
+            "antigravity-token-manager-test-recovery-preserves-limits-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(tmp_root.join("accounts")).unwrap();
+
+        let manager = TokenManager::new(tmp_root.clone());
+        let mut stale_token = create_test_token("stale@test.com", Some("PRO"), 1.0, None, Some(80));
+        stale_token.account_id = "stale-acc".to_string();
+        stale_token.account_path = tmp_root.join("accounts").join("missing.json");
+        stale_token.project_id = Some("pid-stale".to_string());
+        stale_token
+            .model_quotas
+            .insert("gemini-3-flash".to_string(), 80);
+        manager
+            .tokens
+            .insert(stale_token.account_id.clone(), stale_token);
+
+        let reset_time =
+            std::time::SystemTime::now() + std::time::Duration::from_secs(60);
+        manager.rate_limit_tracker.set_lockout_until(
+            "limited-acc",
+            reset_time,
+            crate::proxy::rate_limit::RateLimitReason::QuotaExhausted,
+            Some("gemini-3-flash".to_string()),
+        );
+
+        let err = manager
+            .get_token("gemini", false, None, "gemini-1.5-flash")
+            .await
+            .unwrap_err();
+
+        assert_eq!(err, "Token pool is empty");
+        assert!(manager
+            .rate_limit_tracker
+            .is_rate_limited("limited-acc", Some("gemini-3-flash")));
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
     }
 
     /// 测试排序比较函数（与 get_token_internal 中的逻辑一致）

--- a/src/components/settings/AdvancedThinking.tsx
+++ b/src/components/settings/AdvancedThinking.tsx
@@ -53,7 +53,7 @@ export default function AdvancedThinking({
                     {/* 3. 全局系统提示词 (Global System Prompt) */}
                     <div className="pt-4">
                         <GlobalSystemPrompt
-                            config={config.global_system_prompt || { enabled: false, content: '' }}
+                            config={config.global_system_prompt || { enabled: false, content: '', include_default_prompt: true }}
                             onChange={(newConfig) => onChange({ ...config, global_system_prompt: newConfig })}
                         />
                     </div>

--- a/src/components/settings/GlobalSystemPrompt.tsx
+++ b/src/components/settings/GlobalSystemPrompt.tsx
@@ -9,6 +9,7 @@ interface GlobalSystemPromptProps {
 const DEFAULT_CONFIG: GlobalSystemPromptConfig = {
     enabled: false,
     content: '',
+    include_default_prompt: true,
 };
 
 export default function GlobalSystemPrompt({
@@ -16,6 +17,7 @@ export default function GlobalSystemPrompt({
     onChange,
 }: GlobalSystemPromptProps) {
     const { t } = useTranslation();
+    const effectiveConfig = { ...DEFAULT_CONFIG, ...config };
 
     return (
         <div className="space-y-3">
@@ -31,14 +33,14 @@ export default function GlobalSystemPrompt({
                 </div>
 
                 <div className="flex items-center gap-3">
-                    <span className={`text-[10px] font-medium ${config.enabled ? 'text-purple-600 dark:text-purple-400' : 'text-gray-400'}`}>
-                        {config.enabled ? t("common.enabled", { defaultValue: "已启用" }) : t("common.disabled", { defaultValue: "已禁用" })}
+                    <span className={`text-[10px] font-medium ${effectiveConfig.enabled ? 'text-purple-600 dark:text-purple-400' : 'text-gray-400'}`}>
+                        {effectiveConfig.enabled ? t("common.enabled", { defaultValue: "已启用" }) : t("common.disabled", { defaultValue: "已禁用" })}
                     </span>
                     <label className="relative inline-flex items-center cursor-pointer shrink-0">
                         <input
                             type="checkbox"
-                            checked={config.enabled}
-                            onChange={(e) => onChange({ ...config, enabled: e.target.checked })}
+                            checked={effectiveConfig.enabled}
+                            onChange={(e) => onChange({ ...effectiveConfig, enabled: e.target.checked })}
                             className="sr-only peer"
                         />
                         <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:after:border-gray-600 peer-checked:bg-purple-600"></div>
@@ -46,12 +48,32 @@ export default function GlobalSystemPrompt({
                 </div>
             </div>
 
+            <div className="flex items-center justify-between gap-3 bg-white dark:bg-base-100 border border-gray-200 dark:border-gray-700 rounded-lg px-4 py-3">
+                <div className="space-y-0.5">
+                    <h5 className="font-semibold text-xs text-gray-800 dark:text-gray-200">
+                        {t("settings.global_system_prompt.default_prompt_label", { defaultValue: "内置 Antigravity 身份提示词" })}
+                    </h5>
+                    <p className="text-[10px] text-gray-500 dark:text-gray-400">
+                        {t("settings.global_system_prompt.default_prompt_hint", { defaultValue: "控制是否自动注入默认编码助手身份" })}
+                    </p>
+                </div>
+                <label className="relative inline-flex items-center cursor-pointer shrink-0">
+                    <input
+                        type="checkbox"
+                        checked={effectiveConfig.include_default_prompt}
+                        onChange={(e) => onChange({ ...effectiveConfig, include_default_prompt: e.target.checked })}
+                        className="sr-only peer"
+                    />
+                    <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:after:border-gray-600 peer-checked:bg-purple-600"></div>
+                </label>
+            </div>
+
             {/* 编辑区域 (仅在启用时显示) */}
-            {config.enabled && (
+            {effectiveConfig.enabled && (
                 <div className="space-y-3">
                     <textarea
-                        value={config.content}
-                        onChange={(e) => onChange({ ...config, content: e.target.value })}
+                        value={effectiveConfig.content}
+                        onChange={(e) => onChange({ ...effectiveConfig, content: e.target.value })}
                         placeholder={t("settings.global_system_prompt.placeholder", {
                             defaultValue: "输入全局系统提示词...\n例如：你是一位资深的全栈开发工程师，擅长 React 和 Rust。请使用简体中文回复。",
                         })}
@@ -62,11 +84,11 @@ export default function GlobalSystemPrompt({
                         <p className="text-xs text-gray-400 dark:text-gray-500">
                             {t("settings.global_system_prompt.char_count", {
                                 defaultValue: "{{count}} 字符",
-                                count: config.content.length,
+                                count: effectiveConfig.content.length,
                             })}
                         </p>
                     </div>
-                    {config.content.length > 2000 && (
+                    {effectiveConfig.content.length > 2000 && (
                         <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700/30 rounded-lg p-3">
                             <p className="text-xs text-amber-700 dark:text-amber-400">
                                 {t("settings.global_system_prompt.long_prompt_warning", {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -604,6 +604,8 @@
             "hint": "Automatically injected into all systemInstructions",
             "placeholder": "Enter global system prompt...\nExample: You are a senior full-stack developer. Please respond in English.",
             "char_count": "{{count}} characters",
+            "default_prompt_label": "Built-in Antigravity identity prompt",
+            "default_prompt_hint": "Controls whether the default coding assistant identity is injected",
             "long_prompt_warning": "Prompt is quite long (over 2000 chars) and may consume significant context space."
         },
         "branding": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -604,6 +604,8 @@
             "hint": "自动注入所有请求的 systemInstruction",
             "placeholder": "输入全局系统提示词...\n例如：你是一位资深的全栈开发工程师，擅长 React 和 Rust。请使用简体中文回复。",
             "char_count": "{{count}} 字符",
+            "default_prompt_label": "内置 Antigravity 身份提示词",
+            "default_prompt_hint": "控制是否自动注入默认编码助手身份",
             "long_prompt_warning": "提示词较长（超过 2000 字符），可能会占用较多的上下文窗口空间。"
         }
     },

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -57,6 +57,8 @@ export interface GlobalSystemPromptConfig {
     enabled: boolean;
     /** 提示词内容 */
     content: string;
+    /** 是否注入内置 Antigravity 身份提示词 */
+    include_default_prompt: boolean;
 }
 
 export interface DebugLoggingConfig {


### PR DESCRIPTION
## Summary
- add a Global System Prompt option to disable the built-in Antigravity identity prompt while keeping custom global prompts available
- apply the default prompt toggle across Claude, OpenAI, and Gemini-native request mappers
- reset account health/rate-limit state using account_id on successful requests and reload the account cache once before returning stale "All accounts failed or unhealthy" errors

Fixes #3082
Fixes #945

## Tests
- cargo test --manifest-path src-tauri/Cargo.toml -p antigravity_tools test_default_system_prompt_can_be_disabled -- --test-threads=1 --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml -p antigravity_tools test_mark_account_success_accepts_email -- --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml -p antigravity_tools test_stale_token_pool_errors_trigger_reload -- --nocapture
- npm run build