### PR TITLE
fix(brew): auto-clear quarantine attribute in Cask for out-of-the-box experience

### DIFF
--- a/Casks/antigravity-tools.rb
+++ b/Casks/antigravity-tools.rb
@@ -11,6 +11,13 @@ cask "antigravity-tools" do
 
     app "Antigravity Tools.app"
 
+    postflight do
+      system_command "xattr",
+                     args:         ["-rd", "com.apple.quarantine", "#{appdir}/Antigravity Tools.app"],
+                     sudo:         false,
+                     must_succeed: false
+    end
+
     zap trash: [
       "~/Library/Application Support/com.lbjlaq.antigravity-tools",
       "~/Library/Caches/com.lbjlaq.antigravity-tools",
@@ -18,13 +25,7 @@ cask "antigravity-tools" do
       "~/Library/Saved Application State/com.lbjlaq.antigravity-tools.savedState",
     ]
 
-    caveats <<~EOS
-      If you encounter the "App is damaged" error, please run the following command:
-        sudo xattr -rd com.apple.quarantine "/Applications/Antigravity Tools.app"
 
-      Or install with the --no-quarantine flag:
-        brew install --cask --no-quarantine antigravity-tools
-    EOS
   end
 
   on_linux do

--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ brew tap lbjlaq/antigravity-manager https://github.com/lbjlaq/Antigravity-Manage
 # 2. 安装应用
 brew install --cask antigravity-tools
 ```
-> **提示**: 如果遇到权限问题，建议添加 `--no-quarantine` 参数。
 
 #### Arch Linux
 您可以选择通过一键安装脚本或 Homebrew 进行安装：
@@ -244,11 +243,8 @@ Copyright © 2024-2026 [lbjlaq](https://github.com/lbjlaq)
     ```bash
     sudo xattr -rd com.apple.quarantine "/Applications/Antigravity Tools.app"
     ```
-2.  **Homebrew 安装技巧**:
-    如果您使用 brew 安装，可以添加 `--no-quarantine` 参数来规避此问题：
-    ```bash
-    brew install --cask --no-quarantine antigravity-tools
-    ```
+2.  **Homebrew 安装优势**:
+    现在通过 Homebrew (`brew install --cask antigravity-tools`) 安装时，系统会在安装末尾自动执行清理属性的操作，**真正实现开箱即用**。
 
 ## 🔌 快速接入示例
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -155,7 +155,6 @@ brew tap lbjlaq/antigravity-manager https://github.com/lbjlaq/Antigravity-Manage
 # 2. Install the app
 brew install --cask antigravity-tools
 ```
-> **Tip**: If you encounter permission issues, add the `--no-quarantine` flag.
 
 #### Arch Linux
 You can choose to install via the one-click script or Homebrew:

--- a/web_site/qa.html
+++ b/web_site/qa.html
@@ -162,14 +162,14 @@
                         <code class="block bg-black/50 p-3 rounded-lg border border-emerald-900/30 text-emerald-400 font-mono mb-4 text-xs">
                             sudo xattr -rd com.apple.quarantine "/Applications/Antigravity Tools.app"
                         </code>
-                        <p>如果您使用 Homebrew 安装，建议添加 <code class="text-emerald-500">--no-quarantine</code> 参数。</p>
+                        <p>如果您使用 Homebrew (<code class="text-emerald-500">brew install --cask antigravity-tools</code>) 安装，系统会自动处理此属性，实现开箱即用。</p>
                     `,
                     en: `
                         <p class="mb-4">Due to macOS security mechanisms, apps not from the App Store may trigger this. Fix it with this command:</p>
                         <code class="block bg-black/50 p-3 rounded-lg border border-emerald-900/30 text-emerald-400 font-mono mb-4 text-xs">
                             sudo xattr -rd com.apple.quarantine "/Applications/Antigravity Tools.app"
                         </code>
-                        <p>If using Homebrew, try adding the <code class="text-emerald-500">--no-quarantine</code> flag.</p>
+                        <p>If using Homebrew (<code class="text-emerald-500">brew install --cask antigravity-tools</code>), the system automatically handles this attribute for out-of-the-box usage.</p>
                     `
                 }
             },


### PR DESCRIPTION
#### 🎯 What does this PR do?
This PR adds a `postflight` hook to the Homebrew Cask configuration to automatically remove the `com.apple.quarantine` attribute during installation. This entirely eliminates the `"App is damaged and can't be opened"` error on macOS Ventura and later, providing a true out-of-the-box experience without requiring the user to run any terminal commands or manually pass the `--no-quarantine` flag.

#### 🛠️ Changes
1. **`Casks/antigravity-tools.rb`**: 
   - Added `postflight` block with `system_command "xattr", args: ["-rd", "com.apple.quarantine", ...]` (with `must_succeed: false` to ensure installation won't break on edge cases).
   - Removed the outdated `caveats` section regarding `--no-quarantine`.
2. **`README.md` & `README_EN.md`**: 
   - Removed all instructions and tips telling users to use the `--no-quarantine` flag.
   - Updated the Homebrew installation section to highlight the new out-of-the-box advantage.
3. **`web_site/qa.html`**: 
   - Updated the FAQ section to reflect that Homebrew installation now automatically handles the quarantine attribute.

#### 🧪 How to test?
1. Uninstall existing app: `brew uninstall --cask antigravity-tools`
2. Install from local Cask file: `brew install --cask ./Casks/antigravity-tools.rb`
3. Verify quarantine attribute is removed: `xattr -p com.apple.quarantine "/Applications/Antigravity Tools.app"`
   *(Expected output: `No such xattr: com.apple.quarantine`)*
