### PR TITLE
fix: apply HTTP proxy pool config at runtime without restart

### DIFF
--- a/src-tauri/src/proxy/proxy_pool.rs
+++ b/src-tauri/src/proxy/proxy_pool.rs
@@ -435,6 +435,27 @@ impl ProxyPoolManager {
             .collect()
     }
 
+    /// [HOT-RELOAD] Re-sync the in-memory DashMap from `config.account_bindings`.
+    /// Called after `update_proxy_pool` so that a wholesale ProxyPoolConfig
+    /// replacement (e.g. via `save_config`) does not leave the in-memory
+    /// bindings stale or empty.
+    pub async fn sync_bindings_from_config(&self) {
+        let config = self.config.read().await;
+        let snapshot = config.account_bindings.clone();
+        drop(config);
+
+        // Reset the DashMap: clear old entries, then insert fresh ones.
+        self.account_bindings.clear();
+        for (account_id, proxy_id) in &snapshot {
+            self.account_bindings
+                .insert(account_id.clone(), proxy_id.clone());
+        }
+        tracing::info!(
+            "[ProxyPool] Re-synced {} account bindings from config (hot-reload)",
+            snapshot.len()
+        );
+    }
+
     /// 持久化绑定关系到配置文件
     async fn persist_bindings(&self) {
         // 获取当前绑定快照

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -237,16 +237,30 @@ impl AxumServer {
 
     /// 更新代理配置
     pub async fn update_proxy(&self, new_config: crate::proxy::config::UpstreamProxyConfig) {
-        let mut proxy = self.proxy_state.write().await;
-        *proxy = new_config;
-        tracing::info!("上游代理配置已热更新");
+        {
+            let mut proxy = self.proxy_state.write().await;
+            *proxy = new_config.clone();
+        }
+        // [HOT-RELOAD] Rebuild default HTTP client with new upstream proxy
+        self.upstream
+            .rebuild_default_client(Some(new_config))
+            .await;
+        // Stale per-proxy clients may also be affected (e.g. fallback path)
+        self.upstream.clear_client_cache();
+        tracing::info!("Upstream proxy config hot-reloaded");
     }
 
     /// 更新代理池配置
     pub async fn update_proxy_pool(&self, new_config: crate::proxy::config::ProxyPoolConfig) {
-        let mut pool = self.proxy_pool_state.write().await;
-        *pool = new_config;
-        tracing::info!("代理池配置已热更新");
+        {
+            let mut pool = self.proxy_pool_state.write().await;
+            *pool = new_config;
+        }
+        // [HOT-RELOAD] Re-sync in-memory account↔proxy bindings from the new config
+        self.proxy_pool_manager.sync_bindings_from_config().await;
+        // [HOT-RELOAD] Drop cached per-proxy HTTP clients so they rebuild with new URLs/credentials
+        self.upstream.clear_client_cache();
+        tracing::info!("Proxy pool config hot-reloaded");
     }
 
     pub async fn update_security(&self, config: &crate::proxy::config::ProxyConfig) {

--- a/src-tauri/src/proxy/upstream/client.rs
+++ b/src-tauri/src/proxy/upstream/client.rs
@@ -75,7 +75,7 @@ const V1_INTERNAL_BASE_URL_FALLBACKS: [&str; 3] = [
 ];
 
 pub struct UpstreamClient {
-    default_client: Client,
+    default_client: RwLock<Client>,
     proxy_pool: Option<Arc<crate::proxy::proxy_pool::ProxyPoolManager>>,
     client_cache: DashMap<String, Client>, // proxy_id -> Client
     user_agent_override: RwLock<Option<String>>,
@@ -107,10 +107,52 @@ impl UpstreamClient {
         };
 
         Self {
-            default_client,
+            default_client: RwLock::new(default_client),
             proxy_pool,
             client_cache: DashMap::new(),
             user_agent_override: RwLock::new(None),
+        }
+    }
+
+    /// [HOT-RELOAD] Rebuild the default HTTP client using the supplied upstream
+    /// proxy config. Called from `update_proxy` so changes to the upstream proxy
+    /// take effect without restarting the app.
+    pub async fn rebuild_default_client(
+        &self,
+        proxy_config: Option<crate::proxy::config::UpstreamProxyConfig>,
+    ) {
+        let new_client = match Self::build_client_internal(proxy_config.clone()) {
+            Ok(c) => c,
+            Err(err_with_proxy) => {
+                tracing::error!(
+                    error = %err_with_proxy,
+                    "Hot-reload: failed to rebuild default HTTP client with configured upstream proxy; retrying without proxy"
+                );
+                match Self::build_client_internal(None) {
+                    Ok(c) => c,
+                    Err(err_without_proxy) => {
+                        tracing::error!(
+                            error = %err_without_proxy,
+                            "Hot-reload: failed to rebuild default HTTP client without proxy; keeping previous client"
+                        );
+                        return;
+                    }
+                }
+            }
+        };
+        let mut guard = self.default_client.write().await;
+        *guard = new_client;
+        tracing::info!("UpstreamClient default_client rebuilt (upstream proxy hot-reloaded)");
+    }
+
+    /// [HOT-RELOAD] Drop all per-proxy cached clients. Call after the pool
+    /// configuration changes (proxy URL/credentials edited, proxy removed,
+    /// bindings changed) so the next request rebuilds with fresh settings.
+    pub fn clear_client_cache(&self) {
+        let size = self.client_cache.len();
+        self.client_cache.clear();
+        if size > 0 {
+            tracing::info!("UpstreamClient cleared {} cached per-proxy clients", size);
         }
     }
 
@@ -232,7 +274,7 @@ impl UpstreamClient {
             }
         }
         // Fallback to default client
-        self.default_client.clone()
+        self.default_client.read().await.clone()
     }
 
     /// Build v1internal URL


### PR DESCRIPTION
## Problem

HTTP proxy pool configuration (bindings, proxy URLs, credentials) and upstream proxy settings were not applied at runtime when changed via `save_config`. Changes only took effect after full app restart.

## Root Causes

1. **`UpstreamClient.default_client`** was immutable `Client` — changing upstream proxy config updated the `RwLock<Config>` but never rebuilt the HTTP client
2. **`UpstreamClient.client_cache`** (DashMap `proxy_id → Client`) was never invalidated when pool proxy URLs/credentials changed
3. **`ProxyPoolManager.account_bindings`** (DashMap) was loaded once in `new()` from config but never re-synced when `save_config` wrote a wholesale `ProxyPoolConfig` replacement

## Changes

**`src-tauri/src/proxy/upstream/client.rs`**
- Changed `default_client: Client` → `default_client: RwLock<Client>`
- Added `pub async fn rebuild_default_client(proxy_config)` — rebuilds client with new upstream proxy
- Added `pub fn clear_client_cache()` — drops all cached per-proxy clients
- Updated `get_client()` to read from `RwLock`

**`src-tauri/src/proxy/proxy_pool.rs`**
- Added `pub async fn sync_bindings_from_config()` — reads `config.account_bindings` and resets the in-memory DashMap

**`src-tauri/src/proxy/server.rs`**
- `update_proxy()` now calls `rebuild_default_client` + `clear_client_cache`
- `update_proxy_pool()` now calls `sync_bindings_from_config` + `clear_client_cache`

## Testing

After these changes, proxy pool config (bindings, URLs, credentials) applies immediately via `save_config` without requiring app restart.

## Checklist

- [x] Tested locally — proxy config changes apply without restart
- [x] No breaking changes to existing API
- [x] Code compiles without errors
