### PR TITLE
feat(quota): collect weekly quota via retrieveUserQuotaSummary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,10 @@ __pycache__/
 
 # Reference projects (for development only)
 
-DOCKER_DEPLOYMENT.md
+# Temporary quota probing scripts & dumps (one-off debugging artifacts)
+scripts/_*.json
+scripts/dump_quota_raw.py
+scripts/dump_full.py
+scripts/probe_weekly.py
+scripts/probe_quota_summary.pyDOCKER_DEPLOYMENT.md
 pnpm-lock.yaml

--- a/docker/Dockerfile.backend.localdist
+++ b/docker/Dockerfile.backend.localdist
@@ -25,7 +25,17 @@ RUN apt-get update && apt-get install -y \
     librsvg2-dev \
     libsoup-3.0-dev \
     libjavascriptcoregtk-4.1-dev \
+    perl \
+    cmake \
+    golang-go \
+    clang \
+    libclang-dev \
+    git \
+    ninja-build \
     && rm -rf /var/lib/apt/lists/*
+
+# Verify Go installation for BoringSSL build
+RUN which go && go version || (echo "ERROR: Go compiler not found" && exit 1)
 
 # Use Aliyun mirror for Cargo if needed (Sparse Index)
 ENV CARGO_HTTP_MULTIPLEXING=false

--- a/docker/Dockerfile.backend.localdist
+++ b/docker/Dockerfile.backend.localdist
@@ -50,6 +50,8 @@ RUN if [ "$USE_MIRROR" = "true" ] || ( [ "$USE_MIRROR" = "auto" ] && ! timeout 3
 WORKDIR /app
 COPY src-tauri ./src-tauri
 COPY src/locales ./src/locales
+# Copy local dist so tauri::generate_context!() can find frontendDist ("../dist")
+COPY dist ./dist
 
 WORKDIR /app/src-tauri
 RUN --mount=type=cache,target=/root/.cargo/registry \

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -8,5 +8,5 @@ pub use account::{
     DeviceProfileVersion,
 };
 pub use config::{AppConfig, CircuitBreakerConfig, QuotaProtectionConfig};
-pub use quota::QuotaData;
+pub use quota::{QuotaBucket, QuotaData, QuotaGroup};
 pub use token::TokenData;

--- a/src-tauri/src/models/quota.rs
+++ b/src-tauri/src/models/quota.rs
@@ -1,5 +1,31 @@
 use serde::{Deserialize, Serialize};
 
+/// 单个配额桶 (对应 retrieveUserQuotaSummary 里的一个 bucket)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuotaBucket {
+    /// 桶 ID,如 "gemini-weekly" / "gemini-5h" / "3p-weekly" / "3p-5h"
+    pub bucket_id: String,
+    /// 窗口类型: "weekly" / "5h"
+    pub window: String,
+    /// 剩余比例 0.0-1.0
+    pub remaining_fraction: f64,
+    /// 重置时间 (RFC3339)
+    pub reset_time: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// 一个模型组 (如 Gemini Models / Claude and GPT models)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuotaGroup {
+    pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub buckets: Vec<QuotaBucket>,
+}
+
 /// 模型配额信息
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelQuota {
@@ -42,6 +68,9 @@ pub struct QuotaData {
     /// 模型淘汰重定向规则表 (old_model_id -> new_model_id)
     #[serde(default)]
     pub model_forwarding_rules: std::collections::HashMap<String, String>,
+    /// 按模型组的配额摘要 (weekly + 5h 双窗口),来自 retrieveUserQuotaSummary
+    #[serde(default)]
+    pub quota_groups: Option<Vec<QuotaGroup>>,
 }
 
 impl QuotaData {
@@ -53,6 +82,7 @@ impl QuotaData {
             forbidden_reason: None,
             subscription_tier: None,
             model_forwarding_rules: std::collections::HashMap::new(),
+            quota_groups: None,
         }
     }
 

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -1592,6 +1592,7 @@ pub fn mark_account_forbidden(account_id: &str, reason: &str) -> Result<(), Stri
             is_forbidden: true,
             forbidden_reason: Some(reason.to_string()),
             model_forwarding_rules: std::collections::HashMap::new(),
+            quota_groups: None,
         });
     }
 

--- a/src-tauri/src/modules/quota.rs
+++ b/src-tauri/src/modules/quota.rs
@@ -11,6 +11,13 @@ const QUOTA_API_ENDPOINTS: [&str; 3] = [
     "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
 ];
 
+// Quota Summary API endpoints (weekly + 5h grouped quota, fallback order 同上)
+const QUOTA_SUMMARY_ENDPOINTS: [&str; 3] = [
+    "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:retrieveUserQuotaSummary",
+    "https://daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary",
+    "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary",
+];
+
 /// Critical retry threshold: considered near recovery when quota reaches 95%
 const NEAR_READY_THRESHOLD: i32 = 95;
 const MAX_RETRIES: u32 = 3;
@@ -56,6 +63,35 @@ struct QuotaInfo {
     remaining_fraction: Option<f64>,
     #[serde(rename = "resetTime")]
     reset_time: Option<String>,
+}
+
+// ---- retrieveUserQuotaSummary 响应反序列化结构 ----
+
+#[derive(Debug, Deserialize)]
+struct QuotaSummaryResponse {
+    groups: Vec<QuotaSummaryGroup>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QuotaSummaryGroup {
+    #[serde(rename = "displayName")]
+    display_name: Option<String>,
+    description: Option<String>,
+    buckets: Vec<QuotaSummaryBucket>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QuotaSummaryBucket {
+    #[serde(rename = "bucketId")]
+    bucket_id: Option<String>,
+    window: Option<String>,
+    #[serde(rename = "remainingFraction")]
+    remaining_fraction: Option<f64>,
+    #[serde(rename = "resetTime")]
+    reset_time: Option<String>,
+    #[serde(rename = "displayName")]
+    display_name: Option<String>,
+    description: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -370,6 +406,16 @@ pub async fn fetch_quota_with_cache(
                     // Set subscription tier
                     quota_data.subscription_tier = subscription_tier.clone();
 
+                    // Best-effort: fetch grouped quota summary (weekly + 5h windows).
+                    // Failure here must not block the primary quota result.
+                    quota_data.quota_groups = fetch_quota_summary(
+                        access_token,
+                        email,
+                        project_id.as_deref(),
+                        account_id,
+                    )
+                    .await;
+
                     return Ok((quota_data, project_id.clone()));
                 }
                 Err(e) => {
@@ -390,6 +436,103 @@ pub async fn fetch_quota_with_cache(
     Err(last_error.unwrap_or_else(|| {
         AppError::Unknown("Quota fetch failed: all endpoints exhausted".to_string())
     }))
+}
+
+/// Fetch grouped quota summary (weekly + 5h windows) via retrieveUserQuotaSummary.
+///
+/// Best-effort: returns `None` on any failure so that the primary 5h quota fetch
+/// (fetchAvailableModels) is never blocked by this auxiliary endpoint.
+async fn fetch_quota_summary(
+    access_token: &str,
+    email: &str,
+    project_id: Option<&str>,
+    account_id: Option<&str>,
+) -> Option<Vec<crate::models::quota::QuotaGroup>> {
+    let client = create_standard_client(account_id).await;
+    let payload = if let Some(pid) = project_id {
+        json!({ "project": pid })
+    } else {
+        json!({})
+    };
+
+    for ep_url in QUOTA_SUMMARY_ENDPOINTS.iter() {
+        let res = client
+            .post(*ep_url)
+            .bearer_auth(access_token)
+            .header(
+                rquest::header::USER_AGENT,
+                crate::constants::NATIVE_OAUTH_USER_AGENT.as_str(),
+            )
+            .json(&payload)
+            .send()
+            .await;
+
+        match res {
+            Ok(response) => {
+                let status = response.status();
+                if !status.is_success() {
+                    crate::modules::logger::log_warn(&format!(
+                        "QuotaSummary API {} returned {}, trying next endpoint",
+                        ep_url, status
+                    ));
+                    // 4xx (非 429) 通常所有端点行为一致,直接退出避免无谓重试
+                    if status.is_client_error() && status != rquest::StatusCode::TOO_MANY_REQUESTS
+                    {
+                        return None;
+                    }
+                    continue;
+                }
+
+                let summary: QuotaSummaryResponse = match response.json().await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        crate::modules::logger::log_warn(&format!(
+                            "QuotaSummary JSON parse failed for {}: {}",
+                            email, e
+                        ));
+                        return None;
+                    }
+                };
+
+                let groups = summary
+                    .groups
+                    .into_iter()
+                    .map(|g| crate::models::quota::QuotaGroup {
+                        display_name: g.display_name.unwrap_or_default(),
+                        description: g.description,
+                        buckets: g
+                            .buckets
+                            .into_iter()
+                            .map(|b| crate::models::quota::QuotaBucket {
+                                bucket_id: b.bucket_id.unwrap_or_default(),
+                                window: b.window.unwrap_or_default(),
+                                remaining_fraction: b.remaining_fraction.unwrap_or(0.0),
+                                reset_time: b.reset_time.unwrap_or_default(),
+                                display_name: b.display_name,
+                                description: b.description,
+                            })
+                            .collect(),
+                    })
+                    .collect();
+
+                tracing::debug!(
+                    "[{}] QuotaSummary fetched {} groups",
+                    email,
+                    groups.len()
+                );
+                return Some(groups);
+            }
+            Err(e) => {
+                crate::modules::logger::log_warn(&format!(
+                    "QuotaSummary API request failed at {}: {}",
+                    ep_url, e
+                ));
+                continue;
+            }
+        }
+    }
+
+    None
 }
 
 /// Internal fetch quota logic

--- a/src-tauri/src/modules/quota.rs
+++ b/src-tauri/src/modules/quota.rs
@@ -494,7 +494,7 @@ async fn fetch_quota_summary(
                     }
                 };
 
-                let groups = summary
+                let groups: Vec<crate::models::quota::QuotaGroup> = summary
                     .groups
                     .into_iter()
                     .map(|g| crate::models::quota::QuotaGroup {

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -154,6 +154,8 @@ struct QuotaResponse {
     last_updated: i64,
     subscription_tier: Option<String>,
     is_forbidden: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    quota_groups: Option<Vec<QuotaGroupDto>>,
 }
 
 #[derive(Serialize)]
@@ -161,6 +163,46 @@ struct ModelQuota {
     name: String,
     percentage: i32,
     reset_time: String,
+}
+
+#[derive(Serialize)]
+struct QuotaGroupDto {
+    display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    buckets: Vec<QuotaBucketDto>,
+}
+
+#[derive(Serialize)]
+struct QuotaBucketDto {
+    bucket_id: String,
+    window: String,
+    remaining_fraction: f64,
+    reset_time: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+}
+
+/// Map a model-side QuotaGroup to the API DTO.
+fn quota_group_to_dto(g: &crate::models::quota::QuotaGroup) -> QuotaGroupDto {
+    QuotaGroupDto {
+        display_name: g.display_name.clone(),
+        description: g.description.clone(),
+        buckets: g
+            .buckets
+            .iter()
+            .map(|b| QuotaBucketDto {
+                bucket_id: b.bucket_id.clone(),
+                window: b.window.clone(),
+                remaining_fraction: b.remaining_fraction,
+                reset_time: b.reset_time.clone(),
+                display_name: b.display_name.clone(),
+                description: b.description.clone(),
+            })
+            .collect(),
+    }
 }
 
 #[derive(Serialize)]
@@ -198,6 +240,10 @@ fn to_account_response(
             last_updated: q.last_updated,
             subscription_tier: q.subscription_tier.clone(),
             is_forbidden: q.is_forbidden,
+            quota_groups: q
+                .quota_groups
+                .as_ref()
+                .map(|groups| groups.iter().map(quota_group_to_dto).collect()),
         }),
         device_bound: account.device_profile.is_some(),
         last_used: account.last_used,
@@ -874,6 +920,9 @@ async fn admin_list_accounts(
                 last_updated: q.last_updated,
                 subscription_tier: q.subscription_tier,
                 is_forbidden: q.is_forbidden,
+                quota_groups: q
+                    .quota_groups
+                    .map(|groups| groups.iter().map(quota_group_to_dto).collect()),
             });
 
             AccountResponse {
@@ -951,6 +1000,9 @@ async fn admin_get_current_account(
                 last_updated: q.last_updated,
                 subscription_tier: q.subscription_tier,
                 is_forbidden: q.is_forbidden,
+                quota_groups: q
+                    .quota_groups
+                    .map(|groups| groups.iter().map(quota_group_to_dto).collect()),
             });
 
             AccountResponse {

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -38,6 +38,7 @@ export interface QuotaData {
     forbidden_reason?: string;
     subscription_tier?: string;  // 订阅类型: FREE/PRO/ULTRA
     model_forwarding_rules?: Record<string, string>; // 废弃模型转发表
+    quota_groups?: QuotaGroup[]; // 按模型组的配额摘要 (weekly + 5h 双窗口)
 }
 
 export interface ModelQuota {
@@ -52,6 +53,23 @@ export interface ModelQuota {
     max_tokens?: number;
     max_output_tokens?: number;
     supported_mime_types?: Record<string, boolean>;
+}
+
+/** 单个配额桶 (weekly / 5h) */
+export interface QuotaBucket {
+    bucket_id: string;
+    window: string;  // "weekly" | "5h"
+    remaining_fraction: number;
+    reset_time: string;
+    display_name?: string;
+    description?: string;
+}
+
+/** 模型组配额 (如 Gemini Models / Claude and GPT models) */
+export interface QuotaGroup {
+    display_name: string;
+    description?: string;
+    buckets: QuotaBucket[];
 }
 
 export interface DeviceProfile {


### PR DESCRIPTION
> **Note: Backend-only.** This PR implements weekly quota collection, persistence, and API exposure only. The frontend display is **not** implemented in this PR — I couldn't settle on the UI design (the weekly quota is grouped by model family rather than per-model, which doesn't map cleanly onto the existing per-model progress bars), so I'm leaving the UI for a follow-up. The data is fully available via the HTTP API for anyone who wants to consume it now.

## Summary

Antigravity now exposes a **weekly quota** alongside the existing 5-hour quota per model group (e.g. "Gemini Models", "Claude and GPT models"). This PR collects that data from the upstream `retrieveUserQuotaSummary` endpoint, persists it to account files, and exposes it through the HTTP API.

## Background

The `fetchAvailableModels` endpoint only returns a single per-model 5h quota window. The weekly quota is served by a **separate** endpoint discovered via network inspection of the official client:

```
POST /v1internal:retrieveUserQuotaSummary
Body: { "project": "<project_id>" }
```

It returns grouped buckets, each carrying both a `weekly` and a `5h` window. The 5h values returned here are consistent with `fetchAvailableModels` (e.g. Gemini 0.9545 → 95%, Claude/GPT 0.7015 → 70%), confirming they are complementary rather than conflicting.

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/models/quota.rs` | Add `QuotaBucket`, `QuotaGroup` structs; add optional `quota_groups` field to `QuotaData` (`#[serde(default)]` for backward compat) |
| `src-tauri/src/models/mod.rs` | Re-export the new types |
| `src-tauri/src/modules/quota.rs` | Add `fetch_quota_summary()` calling `retrieveUserQuotaSummary` (3-endpoint fallback, best-effort — returns `None` on failure so the primary 5h quota is never blocked); embed it in `fetch_quota_with_cache` so all 10+ callers benefit automatically |
| `src-tauri/src/proxy/server.rs` | Expose `quota_groups` through `GET /accounts` and `GET /accounts/:id` via `QuotaGroupDto`/`QuotaBucketDto` |
| `src/types/account.ts` | Sync TypeScript types (`QuotaBucket`, `QuotaGroup`) |
| `docker/Dockerfile.backend.localdist` | Fix: add missing BoringSSL build deps (cmake, golang-go, clang, ninja-build, etc.) and `COPY dist` to the backend-builder stage |

### Design decisions

- **Best-effort**: if the weekly endpoint fails, the 5h quota is still returned normally. `quota_groups` is simply `None` and omitted from the JSON via `#[serde(skip_serializing_if = "Option::is_none")]`.
- **Zero-intrusion**: no changes to `fetch_quota_with_retry`, persistence logic, or any UI component. No new Tauri command.
- **Backward compatible**: old account files without `quota_groups` deserialize fine (`serde(default)`).

## Proof it works

`GET /api/accounts/:id/quota` on a Docker build from this branch:

<details>
<summary>Response (truncated, click to expand)</summary>

```json
{
  "models": [
    { "name": "gemini-2.5-pro", "percentage": 95, "reset_time": "2026-06-16T07:43:38Z", "display_name": "Gemini 2.5 Pro", "..." : "..." },
    { "name": "claude-sonnet-4-6", "percentage": 70, "reset_time": "2026-06-16T07:26:50Z", "display_name": "Claude Sonnet 4.6 (Thinking)", "..." : "..." },
    { "name": "gpt-oss-120b-medium", "percentage": 70, "reset_time": "2026-06-16T07:26:50Z", "display_name": "GPT-OSS 120B (Medium)", "..." : "..." }
  ],
  "last_updated": 1781592425,
  "subscription_tier": "Google AI Pro",
  "model_forwarding_rules": { "gemini-3.1-pro-high": "gemini-pro-agent" },
  "quota_groups": [
    {
      "display_name": "Gemini Models",
      "description": "Models within this group: Gemini Flash, Gemini Pro",
      "buckets": [
        {
          "bucket_id": "gemini-weekly",
          "window": "weekly",
          "remaining_fraction": 0.99242574,
          "reset_time": "2026-06-23T02:43:38Z",
          "display_name": "Weekly Limit",
          "description": "You have used some of your weekly limit, it will fully refresh in 6 days, 19 hours."
        },
        {
          "bucket_id": "gemini-5h",
          "window": "5h",
          "remaining_fraction": 0.9545545,
          "reset_time": "2026-06-16T07:43:38Z",
          "display_name": "Five Hour Limit",
          "description": "You have used some of your 5-hour limit, it will fully refresh in 56 minutes."
        }
      ]
    },
    {
      "display_name": "Claude and GPT models",
      "description": "Models within this group: Claude Opus, Claude Sonnet, GPT-OSS",
      "buckets": [
        {
          "bucket_id": "3p-weekly",
          "window": "weekly",
          "remaining_fraction": 0.6558833,
          "reset_time": "2026-06-18T03:29:41Z",
          "display_name": "Weekly Limit",
          "description": "You have used some of your weekly limit, it will fully refresh in 1 day, 20 hours."
        },
        {
          "bucket_id": "3p-5h",
          "window": "5h",
          "remaining_fraction": 0.7015412,
          "reset_time": "2026-06-16T07:26:50Z",
          "display_name": "Five Hour Limit",
          "description": "You have used some of your 5-hour limit, it will fully refresh in 39 minutes."
        }
      ]
    }
  ]
}
```

</details>

**Data consistency check** — the 5h values from `quota_groups` match the per-model percentages in `models`:

| Group | `quota_groups` 5h `remaining_fraction` | `models` percentage |
|-------|----------------------------------------|---------------------|
| Gemini | `0.9545545` | `95%` ✅ |
| Claude & GPT | `0.7015412` | `70%` ✅ |

The weekly reset times (6d19h, 1d20h) are sliding windows, matching the behavior shown in the official Antigravity client.

<img width="1055" height="848" alt="图片" src="https://github.com/user-attachments/assets/c6084767-70c4-4e5e-9057-f2d08bf8a248" />


## Commits

- `feat(quota): add weekly quota collection via retrieveUserQuotaSummary`
- `fix(docker): add missing build deps for BoringSSL in localdist Dockerfile`
- `fix: resolve compile errors and missing dist in localdist Dockerfile`
