### PR TITLE
fix(schema): sanitize tool-parameter JSON Schema for v1internal (boolean sub-schemas + const)

### DIFF
--- a/src-tauri/src/proxy/common/json_schema.rs
+++ b/src-tauri/src/proxy/common/json_schema.rs
@@ -204,6 +204,34 @@ fn clean_json_schema_recursive(value: &mut Value, is_schema_node: bool, depth: u
             // 0. [NEW] 合并 allOf
             merge_all_of(map);
 
+            // 0.1 [FIX] Normalize JSON Schema `const` (unsupported by Gemini's Schema
+            // proto). Otherwise a standalone node like `{ "const": false }` (common as a
+            // Zod literal in anyOf branches) is mistaken for a shorthand object further
+            // down and rewritten to `properties: { const: false }`, emitting an invalid
+            // boolean property value -> upstream 400. For a leaf node, infer the type and
+            // turn a string const into a single-value enum; `const` itself is dropped by
+            // the whitelist filter later.
+            if map.contains_key("const") {
+                let is_leaf = !map.contains_key("properties") && !map.contains_key("items");
+                if is_leaf {
+                    let c = map.get("const").cloned().unwrap_or(Value::Null);
+                    if !map.contains_key("type") {
+                        let inferred = match &c {
+                            Value::String(_) => Some("string"),
+                            Value::Bool(_) => Some("boolean"),
+                            Value::Number(n) => Some(if n.is_f64() { "number" } else { "integer" }),
+                            _ => None,
+                        };
+                        if let Some(t) = inferred {
+                            map.insert("type".to_string(), Value::String(t.to_string()));
+                        }
+                    }
+                    if let Value::String(s) = &c {
+                        map.entry("enum".to_string()).or_insert_with(|| json!([s]));
+                    }
+                }
+            }
+
             // 0.5 [NEW] 结构归一化 (Normalization)
             // 针对某些 MCP 工具（如 pencil）误用 items 定义对象属性的情况进行修复。
             // 如果 type=object 或包含 properties，但又定义了 items，Gemini 会因为 items 只能出现在 array 中而报错。
@@ -884,6 +912,57 @@ mod tests {
             .cloned()
             .unwrap_or_default();
         assert!(req.iter().all(|r| r.as_str() != Some("forbidden")));
+    }
+    #[test]
+    fn test_const_in_anyof_does_not_emit_boolean_property() {
+        // Mirrors pi's `subagent` tool: a Zod literal `{ "const": false }` appearing as
+        // an anyOf branch. It must not be rewritten into `properties: { const: false }`.
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "acceptance": {
+                                "anyOf": [
+                                    { "type": "string" },
+                                    { "const": false },
+                                    { "type": "object", "properties": { "review": { "anyOf": [ { "const": false }, { "type": "string" } ] } } }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "mode": { "const": "auto" }
+            }
+        });
+        clean_json_schema(&mut schema);
+        let s = serde_json::to_string(&schema).unwrap();
+        assert!(!s.contains("\"const\""), "const keyword must be removed: {s}");
+
+        fn has_bool_prop_value(v: &serde_json::Value) -> bool {
+            match v {
+                serde_json::Value::Object(m) => {
+                    if let Some(serde_json::Value::Object(props)) = m.get("properties") {
+                        if props.values().any(|pv| pv.is_boolean()) {
+                            return true;
+                        }
+                    }
+                    m.values().any(has_bool_prop_value)
+                }
+                serde_json::Value::Array(a) => a.iter().any(has_bool_prop_value),
+                _ => false,
+            }
+        }
+        assert!(
+            !has_bool_prop_value(&schema),
+            "no boolean property values allowed: {s}"
+        );
+
+        // string const -> single-value enum
+        assert_eq!(schema["properties"]["mode"]["enum"], json!(["auto"]));
     }
     #[test]
     fn test_clean_json_schema_draft_2020_12() {

--- a/src-tauri/src/proxy/common/json_schema.rs
+++ b/src-tauri/src/proxy/common/json_schema.rs
@@ -229,19 +229,35 @@ fn clean_json_schema_recursive(value: &mut Value, is_schema_node: bool, depth: u
             // 1. [CRITICAL] 深度递归处理子项
             // 处理 properties (对象)
             if let Some(Value::Object(props)) = map.get_mut("properties") {
+                // [FIX] Drop boolean / non-object sub-schemas. JSON Schema allows
+                // `prop: true|false`, but Gemini's Schema proto requires every property
+                // value to be an object; a bare boolean triggers an upstream 400
+                // ("Invalid value at '...properties[N].value' ... false").
+                let dropped_keys: Vec<String> = props
+                    .iter()
+                    .filter(|(_, v)| !v.is_object())
+                    .map(|(k, _)| k.clone())
+                    .collect();
+                for k in &dropped_keys {
+                    props.remove(k);
+                }
+
                 let mut nullable_keys = std::collections::HashSet::new();
-                for (k, v) in props {
+                for (k, v) in props.iter_mut() {
                     // properties 的每一个值都必须是一个独立的 Schema 节点
                     if clean_json_schema_recursive(v, true, depth + 1) {
                         nullable_keys.insert(k.clone());
                     }
                 }
 
-                if !nullable_keys.is_empty() {
+                if !nullable_keys.is_empty() || !dropped_keys.is_empty() {
                     if let Some(Value::Array(req_arr)) = map.get_mut("required") {
                         req_arr.retain(|r| {
                             r.as_str()
-                                .map(|s| !nullable_keys.contains(s))
+                                .map(|s| {
+                                    !nullable_keys.contains(s)
+                                        && !dropped_keys.iter().any(|d| d == s)
+                                })
                                 .unwrap_or(true)
                         });
                         if req_arr.is_empty() {
@@ -257,6 +273,11 @@ fn clean_json_schema_recursive(value: &mut Value, is_schema_node: bool, depth: u
             }
 
             // 处理 items (数组)
+            // [FIX] items must be a Schema object; drop bare boolean / invalid items
+            // (JSON Schema allows boolean `items`, Gemini's Schema proto rejects it).
+            if map.get("items").map(|i| !i.is_object()).unwrap_or(false) {
+                map.remove("items");
+            }
             if let Some(items) = map.get_mut("items") {
                 // items 的内容必须是一个独立的 Schema 节点
                 clean_json_schema_recursive(items, true, depth + 1);
@@ -813,6 +834,57 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+
+    #[test]
+    fn test_drops_boolean_subschemas() {
+        // JSON Schema permits boolean sub-schemas (`prop: true|false`), but Gemini's
+        // Schema proto rejects a non-object property value with HTTP 400. They must be
+        // stripped at every depth (including inside `items`).
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "outer": {
+                    "type": "object",
+                    "properties": {
+                        "forbidden": false,
+                        "allowed": { "type": "string" }
+                    },
+                    "required": ["forbidden", "allowed"]
+                },
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "nope": false,
+                            "ok": { "type": "number" }
+                        }
+                    }
+                }
+            }
+        });
+        clean_json_schema(&mut schema);
+
+        let outer_props = &schema["properties"]["outer"]["properties"];
+        assert!(
+            outer_props.get("forbidden").is_none(),
+            "boolean sub-schema must be dropped"
+        );
+        assert!(outer_props["allowed"].is_object(), "valid sibling must survive");
+
+        let item_props = &schema["properties"]["list"]["items"]["properties"];
+        assert!(
+            item_props.get("nope").is_none(),
+            "nested boolean sub-schema must be dropped"
+        );
+        assert!(item_props["ok"].is_object());
+
+        let req = schema["properties"]["outer"]["required"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert!(req.iter().all(|r| r.as_str() != Some("forbidden")));
+    }
     #[test]
     fn test_clean_json_schema_draft_2020_12() {
         let mut schema = json!({


### PR DESCRIPTION
# Sanitize tool-parameter JSON Schema for v1internal (boolean sub-schemas + `const`)

Two related `clean_json_schema` gaps make `cloudcode-pa` (`v1internal`) reject tool parameter schemas with HTTP 400 `Invalid value at '...properties[N].value' (...Schema), false`. Real coding clients (pi, opencode) hit this as soon as a tool carries such a schema (e.g. pi's `subagent` tool).

## 1. Boolean sub-schemas

JSON Schema allows boolean sub-schemas (`"prop": true|false`), but Gemini's Schema proto requires each `properties`/`items` value to be an object. The cleaner recursed assuming objects, so a bare boolean passed through.

Fix: drop non-object `properties` values (and their `required` entries) and non-object `items`.

## 2. `const` keyword (the actual real-world trigger)

A standalone node whose only key is `const` — e.g. `{ "const": false }`, common as a Zod literal in `anyOf` branches (`acceptance: { anyOf: [ …, { const: false }, … ] }`) — has no whitelisted keyword, so the cleaner's "shorthand object" heuristic rewrote it to `properties: { const: false }`, **fabricating** an invalid boolean property value.

Fix: normalize `const` *before* that heuristic. For a leaf node, infer `type` from the const value and turn a string const into a single-value `enum`; `const` itself is then removed by the whitelist filter. Object/array nodes keep their structure and just drop `const`.

## Verification

- Unit: `test_drops_boolean_subschemas`, `test_const_in_anyof_does_not_emit_boolean_property`; full `json_schema` suite (27 tests) green.
- **Live, real pi run** (`pi -p --model gemini-3.1-pro-high`, 15 tool declarations incl. `subagent`): previously 400, now **200**. Captured upstream request confirmed: 0 boolean property values remaining, `const` gone.

> Note: pairs with #3192 (don't mix built-in tools with function calling). Both are needed for coding clients that also expose a web-search tool; they are independent and can merge separately.
