### PR TITLE
Fix Gemini image generation (404) on OpenAI endpoints, tray i18n, and related polish

### DIFF
--- a/src-tauri/src/modules/i18n.rs
+++ b/src-tauri/src/modules/i18n.rs
@@ -17,10 +17,23 @@ pub struct TrayTexts {
 
 /// Load translations from JSON
 fn load_translations(lang: &str) -> HashMap<String, String> {
+    // Map every language the frontend supports (see src/i18n.ts / navbar/constants.ts)
+    // so the tray menu follows the in-app language switch. Unknown codes fall back to
+    // English, matching the frontend's fallbackLng.
     let json_content = match lang {
-        "en" | "en-US" => include_str!("../../../src/locales/en.json"),
+        "zh" | "zh-CN" | "zh-Hans" => include_str!("../../../src/locales/zh.json"),
+        "zh-TW" | "zh-Hant" => include_str!("../../../src/locales/zh-TW.json"),
+        "ja" | "ja-JP" => include_str!("../../../src/locales/ja.json"),
         "tr" | "tr-TR" => include_str!("../../../src/locales/tr.json"),
-        _ => include_str!("../../../src/locales/zh.json"),
+        "vi" | "vi-VN" => include_str!("../../../src/locales/vi.json"),
+        "pt" | "pt-BR" | "pt-PT" => include_str!("../../../src/locales/pt.json"),
+        "ru" | "ru-RU" => include_str!("../../../src/locales/ru.json"),
+        "ko" | "ko-KR" => include_str!("../../../src/locales/ko.json"),
+        "ar" | "ar-SA" => include_str!("../../../src/locales/ar.json"),
+        "es" | "es-ES" | "es-MX" => include_str!("../../../src/locales/es.json"),
+        "my" | "ms" | "ms-MY" => include_str!("../../../src/locales/my.json"),
+        "en" | "en-US" => include_str!("../../../src/locales/en.json"),
+        _ => include_str!("../../../src/locales/en.json"),
     };
 
     let v: Value = serde_json::from_str(json_content).unwrap_or_else(|_| serde_json::json!({}));

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -36,9 +36,17 @@ pub async fn handle_chat_completions(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_lowercase();
-    if model_name.contains("image")
+    // [FIX] Only redirect non-native image aliases (dall-e / midjourney) to the
+    // images-generations shim. Native Gemini image models (gemini-3-pro-image*) must
+    // flow through the normal pipeline (transform_openai_request -> resolve_request_config),
+    // which correctly sets requestType=image_gen, imageConfig (size/aspect ratio), sessionId,
+    // structured requestId and per-account dynamic model resolution — matching the official
+    // Antigravity client. The old shim dropped `size` and built a divergent upstream body,
+    // which caused image generation to silently fail for gemini-3-pro-image.
+    if (model_name.contains("image")
         || model_name.contains("dall-e")
-        || model_name.contains("midjourney")
+        || model_name.contains("midjourney"))
+        && !model_name.contains("gemini")
     {
         tracing::info!(
             "[ChatRedirection] Redirecting model {} to image generations",
@@ -1798,7 +1806,7 @@ async fn intercept_chat_to_image(
                     .into_response())
             }
         }
-        Err(e) => Err(e.into()), // using Err directly is fine since return type handles it
+        Err((status, msg, _email)) => Err((status, msg)),
     }
 }
 
@@ -1816,18 +1824,24 @@ pub async fn handle_images_generations(
             Json(openai_response),
         )
             .into_response()),
-        Err(e) => Err(e),
+        // Attach the attempted account to error responses too, so the traffic log shows
+        // which account the failed (e.g. 502/503) image request used.
+        Err((status, msg, email_opt)) => {
+            let email = email_opt.unwrap_or_default();
+            Ok((status, [("X-Account-Email", email)], msg).into_response())
+        }
     }
 }
 
 pub async fn handle_images_generations_internal(
     state: AppState,
     body: Value,
-) -> Result<(String, Value), (StatusCode, String)> {
+) -> Result<(String, Value), (StatusCode, String, Option<String>)> {
     // 1. 解析请求参数
     let prompt = body.get("prompt").and_then(|v| v.as_str()).ok_or((
         StatusCode::BAD_REQUEST,
         "Missing 'prompt' field".to_string(),
+        None,
     ))?;
 
     let model = body
@@ -1894,6 +1908,10 @@ pub async fn handle_images_generations_internal(
 
     let mut tasks = Vec::new();
 
+    // Track the last account actually attempted, so error responses (502/503) can be
+    // attributed to an account in the traffic log instead of showing "(none)".
+    let attempted_account = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+
     for _ in 0..n {
         let upstream = upstream.clone();
         let token_manager = token_manager.clone();
@@ -1902,6 +1920,7 @@ pub async fn handle_images_generations_internal(
         let _response_format = response_format.to_string();
 
         let model_to_use = clean_model_name.clone();
+        let attempted_account = attempted_account.clone();
 
         tasks.push(tokio::spawn(async move {
             let mut last_error = String::new();
@@ -1922,11 +1941,22 @@ pub async fn handle_images_generations_internal(
                         break;
                     }
                 };
+                if let Ok(mut g) = attempted_account.lock() {
+                    *g = Some(email.clone());
+                }
+
+                // [FIX] Resolve to the account-specific dynamic image model, exactly like the
+                // chat (openai.rs:232) and gemini (gemini.rs:155) handlers do. Sending the static
+                // alias (e.g. "gemini-3-pro-image") made upstream return 404 "Requested entity was
+                // not found" because each account exposes its own concrete image model id.
+                let resolved_model = token_manager
+                    .resolve_dynamic_model_for_account(&account_id, &model_to_use)
+                    .await;
 
                 let gemini_body = json!({
                     "project": project_id,
                     "requestId": format!("agent-{}", uuid::Uuid::new_v4()),
-                    "model": model_to_use,
+                    "model": resolved_model,
                     "userAgent": "antigravity",
                     "requestType": "image_gen",
                     "request": {
@@ -1966,7 +1996,7 @@ pub async fn handle_images_generations_internal(
                             let status_code = status.as_u16();
                             last_error = format!("Upstream error {}: {}", status, err_text);
 
-                            // 429/500/503 等错误进行标记和重试
+                            // 429/500/503: mark limited and rotate to another account
                             if status_code == 429 || status_code == 503 || status_code == 500 {
                                 tracing::warn!(
                                     "[Images] Account {} rate limited/error ({}), rotating...",
@@ -1979,13 +2009,29 @@ pub async fn handle_images_generations_internal(
                                         status_code,
                                         None,
                                         &err_text,
-                                        Some("dall-e-3"),
+                                        Some(model_to_use.as_str()),
                                     )
                                     .await;
+                                force_rotate = true;
                                 continue; // Retry loop
                             }
 
-                            // 其他错误直接返回
+                            // [FIX] 403/404 usually mean THIS account lacks the image model or
+                            // project access. Rotate to another account instead of failing the
+                            // whole request, so an image-capable account can serve it.
+                            if (status_code == 403 || status_code == 404)
+                                && attempt < max_attempts - 1
+                            {
+                                tracing::warn!(
+                                    "[Images] Account {} returned {} for image gen, rotating to another account",
+                                    email,
+                                    status_code
+                                );
+                                force_rotate = true;
+                                continue;
+                            }
+
+                            // Other errors: return
                             return Err(last_error);
                         }
                         match response.json::<Value>().await {
@@ -2079,7 +2125,10 @@ pub async fn handle_images_generations_internal(
             StatusCode::BAD_GATEWAY
         };
 
-        return Err((status, error_msg));
+        let attempted = used_email
+            .clone()
+            .or_else(|| attempted_account.lock().ok().and_then(|g| g.clone()));
+        return Err((status, error_msg, attempted));
     }
 
     // 部分成功时记录警告

--- a/src-tauri/src/proxy/mappers/common_utils.rs
+++ b/src-tauri/src/proxy/mappers/common_utils.rs
@@ -26,7 +26,9 @@ pub fn resolve_request_config(
     body: Option<&Value>,     // [NEW] Request body for Gemini native imageConfig
 ) -> RequestConfig {
     // 1. Image Generation Check (Priority)
-    if mapped_model.starts_with("gemini-3-pro-image") {
+    // Detect via the original requested alias OR the account-resolved model name, because the
+    // dynamic model rewrite may turn "gemini-3-pro-image" into e.g. "gemini-3.1-flash-image".
+    if original_model.to_lowercase().contains("-image") || mapped_model.contains("-image") {
         // [RESOLVE #1694] Improved priority logic:
         // 1. First parse inferred config from model suffix and OpenAI parameters
         let (mut inferred_config, parsed_base_model) =
@@ -68,10 +70,17 @@ pub fn resolve_request_config(
             inferred_config
         );
 
+        // Prefer the account-resolved concrete image model (mapped_model) for the upstream
+        // call; fall back to the parsed base of the requested alias if it wasn't resolved.
+        let upstream_model = if mapped_model.contains("-image") {
+            mapped_model.to_string()
+        } else {
+            parsed_base_model
+        };
         return RequestConfig {
             request_type: "image_gen".to_string(),
             inject_google_search: false,
-            final_model: parsed_base_model,
+            final_model: upstream_model,
             image_config: Some(inferred_config),
         };
     }

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -787,6 +787,35 @@ impl TokenManager {
             return None;
         }
 
+        // Image models: drift ONLY across versions within the SAME tier
+        // (pro-image ↔ pro-image, flash-image ↔ flash-image). Never silently downgrade
+        // pro→flash. If the account has no model in the requested tier, the name is left
+        // unchanged and upstream returns 404 — which is honest (the account lacks that model).
+        // To alias e.g. gemini-3-pro-image to a flash model, use the app's Model Routing Center.
+        let pro_image = ["gemini-3-pro-image", "gemini-3.1-pro-image"];
+        let flash_image = ["gemini-3-flash-image", "gemini-3.1-flash-image"];
+        let is_pro_image = pro_image.contains(&model.as_str());
+        let is_flash_image = flash_image.contains(&model.as_str());
+        if is_pro_image || is_flash_image {
+            let mut out = Vec::new();
+            let mut seen = HashSet::new();
+            let mut push = |candidate: &str| {
+                let c = candidate.to_string();
+                if seen.insert(c.clone()) {
+                    out.push(c);
+                }
+            };
+            push(&model); // requested first
+            if is_pro_image {
+                push("gemini-3.1-pro-image");
+                push("gemini-3-pro-image");
+            } else {
+                push("gemini-3.1-flash-image");
+                push("gemini-3-flash-image");
+            }
+            return Some(out);
+        }
+
         let pro_family = [
             "gemini-3-pro",
             "gemini-3-pro-preview",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -76,7 +76,9 @@
     "switch_to_spanish_short": "ES",
     "switch_to_malay": "말레이어로 전환",
     "switch_to_malay_short": "MY",
-    "user_token": "사용자 토큰"
+    "user_token": "사용자 토큰",
+    "apikey_fun": "API 중계소",
+    "logout": "로그아웃"
   },
   "dashboard": {
     "hello": "안녕하세요, 사용자님 👋",
@@ -346,11 +348,11 @@
       "refresh_interval": "새로고침 간격 (분)",
       "auto_sync": "현재 계정 자동 동기화",
       "auto_sync_desc": "현재 활성 계정 정보를 주기적으로 자동 동기화",
-      "sync_interval": "동기화 간격 (초)"
+      "sync_interval": "동기화 간격 (분)"
     },
     "warmup": {
       "title": "스마트 웜업",
-      "desc": "모든 모델을 자동으로 모니터링하고 할당량이 100%에 도달하면 즉시 웜업을 트리거하여 모델을 따뜻하게 유지합니다."
+      "desc": "모든 모델을 자동으로 모니터링하고 할당량이 100%에 도달하면 즉시 웜업을 실행하여 모델을 활성 상태로 유지합니다."
     },
     "quota_protection": {
       "title": "할당량 보호",
@@ -442,12 +444,12 @@
       "antigravity_ide_path_desc": "Antigravity IDE(코드 편집기)의 실행 파일 경로를 지정합니다. 설정하면 계정 전환 시 이 경로의 프로세스가 실수로 종료되지 않도록 보호합니다.",
       "antigravity_ide_path_select": "Antigravity IDE 실행 파일 선택",
       "detect_btn": "감지",
-      "antigravity_args": "Antigravity 시작 인수",
+      "antigravity_args": "Antigravity 시작 인자",
       "antigravity_args_placeholder": "--user-data-dir=/path/to/data --some-other-flag",
-      "antigravity_args_desc": "Antigravity 시작 인수를 지정하세요. 예: 사용자 데이터 디렉토리를 지정하려면 --user-data-dir 사용",
+      "antigravity_args_desc": "Antigravity 시작 인자를 지정하세요. 예: 사용자 데이터 디렉토리를 지정하려면 --user-data-dir 사용",
       "detect_args_btn": "감지",
-      "antigravity_args_detected": "시작 인수가 업데이트되었습니다",
-      "antigravity_args_detect_error": "시작 인수를 감지하지 못했습니다",
+      "antigravity_args_detected": "시작 인자가 업데이트되었습니다",
+      "antigravity_args_detect_error": "시작 인자를 감지하지 못했습니다",
       "accounts_page_size": "계정 페이지 크기",
       "page_size_auto": "자동 계산 (권장)",
       "page_size_desc": "페이지 당 표시되는 계정 수를 설정합니다. '자동 계산'을 선택하면 창 크기에 따라 동적으로 조정됩니다.",
@@ -704,7 +706,7 @@
         "modes": {
           "CacheFirst": "캐시 우선",
           "Balance": "균형",
-          "PerformanceFirst": "성능"
+          "PerformanceFirst": "성능 우선"
         },
         "modes_desc": {
           "CacheFirst": "세션을 계정에 바인딩하고, 제한 시 정확히 대기합니다 (프롬프트 캐시 적중 극대화).",
@@ -812,7 +814,7 @@
       "flash": "빠른 응답 (Flash)",
       "flash_preview": "Flash 미리보기",
       "flash_lite": "가볍고 빠름 (Lite)",
-      "flash_thinking": "생각 능력 (Thinking)",
+      "flash_thinking": "추론 기능 (Thinking)",
       "pro_legacy": "레거시 Pro",
       "pro_low": "고성능",
       "pro_high": "최고의 추론",
@@ -824,7 +826,7 @@
       "pro_image_1_1": "이미지 생성 (1:1)",
       "claude_sonnet": "코드 추론 (Sonnet)",
       "claude_sonnet_thinking": "생각의 사슬 (Thinking)",
-      "claude_opus_thinking": "가장 강력한 생각 (Opus Thinking)"
+      "claude_opus_thinking": "가장 강력한 추론 (Opus Thinking)"
     },
     "mapping": {
       "title": "Claude Code 모델 매핑",
@@ -1218,45 +1220,45 @@
     "hint_curfew": "비워두면 비활성화됩니다. 서버 시간 기준."
   },
   "apiKeyFun": {
-    "title": "APIKEY.FUN Hub",
-    "eyebrow": "Hub",
-    "description": "The official Antigravity Tools API Hub, providing stable, open, and cost-effective large model API services. Supports mainstream models like Claude, OpenAI, and Gemini. Ideal for unified configuration in Codex, Gemini CLI, Claude Code, and other development tools.",
-    "viewNow": "View Now",
+    "title": "APIKEY.FUN 허브",
+    "eyebrow": "허브",
+    "description": "Antigravity Tools 공식 API 허브로, 안정적이고 개방적이며 가성비 높은 대형 모델 API 서비스를 제공합니다. Claude, OpenAI, Gemini 등 주요 모델을 지원하며 Codex, Gemini CLI, Claude Code 등 개발 도구에서 통합 설정해 사용하기 좋습니다.",
+    "viewNow": "지금 보기",
     "usage": {
-      "remainingAmount": "Remaining",
-      "usedAmount": "Used",
-      "todayRequests": "Today's Requests",
-      "todayTokens": "Today's Tokens",
-      "totalRequests": "Total Requests",
-      "totalTokens": "Total Tokens"
+      "remainingAmount": "잔액",
+      "usedAmount": "사용액",
+      "todayRequests": "오늘 요청 수",
+      "todayTokens": "오늘 토큰 수",
+      "totalRequests": "총 요청 수",
+      "totalTokens": "총 토큰 수"
     },
     "keyManager": {
-      "title": "Key Management",
-      "desc": "Save frequently used API Keys. Click to switch and query balance automatically.",
-      "lastRemainingLabel": "Last Balance",
+      "title": "키 관리",
+      "desc": "자주 쓰는 API Key를 저장하세요. 클릭하면 전환되고 잔액을 자동으로 조회합니다.",
+      "lastRemainingLabel": "최근 잔액",
       "lastRemaining": "${{value}}",
-      "notQueried": "Not queried",
-      "addedAt": "Added at",
-      "empty": "No saved keys."
+      "notQueried": "조회 안 됨",
+      "addedAt": "추가일",
+      "empty": "저장된 키가 없습니다."
     },
-    "queryTitle": "Key Quota Query",
+    "queryTitle": "키 잔액 조회",
     "apiKeyLabel": "API Key",
-    "apiKeyPlaceholder": "Paste your API Key...",
-    "queryButton": "Refresh",
+    "apiKeyPlaceholder": "API Key를 붙여넣으세요...",
+    "queryButton": "새로고침",
     "cli": {
-      "quickConfig": "One-Click Local Dev Setup",
-      "syncDesc": "Sync to official standard configuration",
-      "codexTooltip": "Sync API Key & BaseURL to Antigravity Codex",
-      "claudeTooltip": "Sync API Key & BaseURL to Claude Code"
+      "quickConfig": "원클릭 로컬 개발 설정",
+      "syncDesc": "공식 표준 설정으로 동기화",
+      "codexTooltip": "API Key와 BaseURL을 Antigravity Codex에 동기화",
+      "claudeTooltip": "API Key와 BaseURL을 Claude Code에 동기화"
     },
     "models": {
-      "title": "Available Models",
-      "empty": "No models returned for current API Key."
+      "title": "사용 가능한 모델",
+      "empty": "현재 API Key로 반환된 모델이 없습니다."
     },
     "errors": {
-      "parseFormat": "Parse format error: {{err}}",
-      "fetchFailed": "Fetch failed: {{err}}",
-      "queryFailed": "Failed to get valid quota or models. Please check if the API Key and Base URL are correct."
+      "parseFormat": "형식 파싱 오류: {{err}}",
+      "fetchFailed": "가져오기 실패: {{err}}",
+      "queryFailed": "유효한 잔액 또는 모델을 가져오지 못했습니다. API Key와 Base URL이 올바른지 확인하세요."
     }
   }
 }

--- a/src/pages/ApiProxy.tsx
+++ b/src/pages/ApiProxy.tsx
@@ -961,12 +961,12 @@ export default function ApiProxy() {
             return `from anthropic import Anthropic
 
 client = Anthropic(
-    # 推荐使用 127.0.0.1
+    # Recommended: use 127.0.0.1
     base_url="${`http://127.0.0.1:${port}`}",
     api_key="${apiKey}"
 )
 
-# 注意: Antigravity 支持使用 Anthropic SDK 调用任意模型
+# Note: Antigravity lets you call any model via the Anthropic SDK
 response = client.messages.create(
     model="${modelId}",
     max_tokens=1024,
@@ -979,10 +979,10 @@ print(response.content[0].text)`;
         // 2. Gemini Protocol (Native)
         if (selectedProtocol === 'gemini') {
             const rawBaseUrl = `http://127.0.0.1:${port}`;
-            return `# 需要安装: pip install google-generativeai
+            return `# Requires: pip install google-generativeai
 import google.generativeai as genai
 
-# 使用 Antigravity 代理地址 (推荐 127.0.0.1)
+# Use the Antigravity proxy address (recommended: 127.0.0.1)
 genai.configure(
     api_key="${apiKey}",
     transport='rest',
@@ -994,8 +994,8 @@ response = model.generate_content("Hello")
 print(response.text)`;
         }
 
-        // 3. OpenAI Protocol
-        if (modelId.startsWith('gemini-3-pro-image')) {
+        // 3. OpenAI Protocol — image generation models (any *-image model)
+        if (modelId.toLowerCase().includes('-image')) {
             return `from openai import OpenAI
 
 client = OpenAI(
@@ -1003,21 +1003,33 @@ client = OpenAI(
     api_key="${apiKey}"
 )
 
+# IMPORTANT — model availability:
+#   "${modelId}" must be an image model your selected account actually has.
+#   Check the model list on the left: not every account exposes every image model
+#   (e.g. some accounts only have gemini-3.1-flash-image, not gemini-3-pro-image).
+#   Requesting a model the account lacks fails with:
+#     404 "Requested entity was not found"
+#   To keep using a different name, add an explicit mapping in the Model Routing Center.
+
 response = client.chat.completions.create(
     model="${modelId}",
-    # 方式 1: 使用 size 参数 (推荐)
-    # 支持: "1024x1024" (1:1), "1280x720" (16:9), "720x1280" (9:16), "1216x896" (4:3)
+
+    # Aspect ratio — Option 1: the size parameter (recommended)
+    #   "1024x1024" = 1:1   |   "1280x720" = 16:9
+    #   "720x1280"  = 9:16  |   "1216x896" = 4:3
     extra_body={ "size": "1024x1024" },
-    
-    # 方式 2: 使用模型后缀
-    # 例如: gemini-3-pro-image-16-9, gemini-3-pro-image-4-3
-    # model="gemini-3-pro-image-16-9",
+
+    # Aspect ratio — Option 2: a model-name suffix instead of size
+    #   model="${modelId}-16-9"   (also: -9-16, -4-3, -3-4)
     messages=[{
         "role": "user",
         "content": "Draw a futuristic city"
     }]
 )
 
+# The generated image is returned INSIDE the message content
+# (as a base64 data URL / markdown image), not as a hosted URL.
+# Extract the base64 payload from here to save the file.
 print(response.choices[0].message.content)`;
         }
 


### PR DESCRIPTION
## Summary

A few fixes found while self-hosting the proxy. Each section is independent — feel free to cherry-pick.

1. **Fix Gemini image generation** failing with upstream `404 "Requested entity was not found"` on the OpenAI-compatible endpoints (main fix).
2. **Tray menu i18n** — follow all UI languages (was `zh`/`en`/`tr` only).
3. **Attribute the account on image-gen error responses** so the traffic log shows which account a failed (502/503) request used.
4. **Quick-start image example** shown for any image model + a model-availability note.
5. **Korean (`ko.json`)** fixes, including a unit mistranslation.

---

### 1. Gemini image generation 404 (main fix)

Requesting an image model (e.g. `gemini-3-pro-image`) via `POST /v1/chat/completions` or `/v1/images/generations` returned upstream `404 "Requested entity was not found"`, even though the same account generates images in the official client.

Root causes & fixes:

- **OpenAI chat handler intercepted every model containing `image`** into a separate images shim that dropped parameters and built a divergent upstream body. Native Gemini image models now flow through the normal pipeline. (`src-tauri/src/proxy/handlers/openai.rs`)
- **Image detection only matched `gemini-3-pro-image`.** `resolve_request_config` now detects any `*-image` model and forwards the account‑resolved model upstream. (`src-tauri/src/proxy/mappers/common_utils.rs`)
- **`build_dynamic_model_candidates` produced no candidates for image models,** so an image alias was never resolved to the model the account actually exposes (e.g. an account may have `gemini-3.1-flash-image` but not `gemini-3-pro-image`). Image families are now resolved **within the same tier only** (pro‑image ↔ pro‑image, flash‑image ↔ flash‑image) — never a silent pro→flash downgrade. If the account has no model in the requested tier, the name is left unchanged and upstream returns 404 honestly. (`src-tauri/src/proxy/token_manager.rs`)
- **The `/v1/images/generations` handler** did not resolve the per-account model and failed 403/404 without rotating. It now resolves the model and rotates accounts on 403/404. (`src-tauri/src/proxy/handlers/openai.rs`)

### 2. Tray menu i18n

`src-tauri/src/modules/i18n.rs` mapped only `en`/`tr`/`zh`; every other language (`ko`, `ja`, `ru`, …) fell back to Chinese. It now maps all 12 supported languages (plus common region variants) and falls back to English.

### 3. Account attribution on image-gen errors

Image-gen failures returned no `X-Account-Email`, so the traffic log recorded `(none)` for 502/503 rows. The last attempted account is now attached to error responses, making failures attributable. (`src-tauri/src/proxy/handlers/openai.rs`)

### 4. Quick-start image example (`src/pages/ApiProxy.tsx`)

The example was only shown for `gemini-3-pro-image`. It now appears for any `*-image` model, notes that the model must exist on the selected account, and documents the size vs model-suffix aspect-ratio options. (Example comments are in English.)

### 5. Korean strings (`src/locales/ko.json`)

- `settings.account.sync_interval`: `(초)` → `(분)` — the stored value is in minutes (matches `config.rs` / `BackgroundTaskRunner`).
- Fixed a few literal/awkward phrasings; added missing `nav.apikey_fun` / `nav.logout`; translated the `apiKeyFun` page.

---

I can split this into separate PRs if you prefer a tighter scope.
