### PR TITLE
fix: auto-detect Antigravity IDE and fix cache/storage paths

### DIFF
--- a/src-tauri/src/modules/cache.rs
+++ b/src-tauri/src/modules/cache.rs
@@ -46,12 +46,16 @@ pub fn get_antigravity_cache_paths() -> Vec<PathBuf> {
             let local_path = PathBuf::from(&local_app_data);
             paths.push(local_path.join("Google\\Antigravity"));
             paths.push(local_path.join("Antigravity\\Cache"));
+            // Standalone Antigravity IDE cache (Electron-based)
+            paths.push(local_path.join("Antigravity IDE\\Cache"));
         }
 
         // AppData cache
         if let Ok(app_data) = std::env::var("APPDATA") {
             let app_path = PathBuf::from(&app_data);
             paths.push(app_path.join("Antigravity\\Cache"));
+            // Standalone Antigravity IDE cache (Electron-based)
+            paths.push(app_path.join("Antigravity IDE\\Cache"));
         }
     }
 

--- a/src-tauri/src/modules/db.rs
+++ b/src-tauri/src/modules/db.rs
@@ -44,19 +44,31 @@ pub fn get_db_path(target_ide: Option<&str>) -> Result<PathBuf, String> {
         }
     }
 
-    let folder_name = if target_ide == Some("ide") {
-        "Antigravity IDE"
+    let folder_names: &[&str] = if target_ide == Some("ide") {
+        &["Antigravity IDE"]
+    } else if target_ide == Some("code") || target_ide == Some("cursor") {
+        &["Antigravity"]
     } else {
-        "Antigravity"
+        &["Antigravity IDE", "Antigravity"]
     };
 
     // Standard mode: use system default path
     #[cfg(target_os = "macos")]
     {
         let home = dirs::home_dir().ok_or("Failed to get home directory")?;
+        for folder_name in folder_names {
+            let path = home.join(format!(
+                "Library/Application Support/{}/User/globalStorage/state.vscdb",
+                folder_name
+            ));
+            if path.exists() {
+                return Ok(path);
+            }
+        }
+        // Fall back to first candidate even if it doesn't exist
         Ok(home.join(format!(
             "Library/Application Support/{}/User/globalStorage/state.vscdb",
-            folder_name
+            folder_names[0]
         )))
     }
 
@@ -64,17 +76,34 @@ pub fn get_db_path(target_ide: Option<&str>) -> Result<PathBuf, String> {
     {
         let appdata = std::env::var("APPDATA")
             .map_err(|_| "Failed to get APPDATA environment variable".to_string())?;
+        for folder_name in folder_names {
+            let path = PathBuf::from(&appdata)
+                .join(folder_name)
+                .join("User\\globalStorage\\state.vscdb");
+            if path.exists() {
+                return Ok(path);
+            }
+        }
         Ok(PathBuf::from(appdata)
-            .join(folder_name)
+            .join(folder_names[0])
             .join("User\\globalStorage\\state.vscdb"))
     }
 
     #[cfg(target_os = "linux")]
     {
         let home = dirs::home_dir().ok_or("Failed to get home directory")?;
+        for folder_name in folder_names {
+            let path = home.join(format!(
+                ".config/{}/User/globalStorage/state.vscdb",
+                folder_name
+            ));
+            if path.exists() {
+                return Ok(path);
+            }
+        }
         Ok(home.join(format!(
             ".config/{}/User/globalStorage/state.vscdb",
-            folder_name
+            folder_names[0]
         )))
     }
 }

--- a/src-tauri/src/modules/device.rs
+++ b/src-tauri/src/modules/device.rs
@@ -48,22 +48,27 @@ pub fn get_storage_path(target_ide: Option<&str>) -> Result<PathBuf, String> {
         }
     }
 
-    let folder_name = if target_ide == Some("ide") {
-        "Antigravity IDE"
+    let folder_names: &[&str] = if target_ide == Some("ide") {
+        &["Antigravity IDE"]
+    } else if target_ide == Some("code") || target_ide == Some("cursor") {
+        &["Antigravity"]
     } else {
-        "Antigravity"
+        // target_ide = None: try IDE folder first, fall back to classic name
+        &["Antigravity IDE", "Antigravity"]
     };
 
     // 3) Standard installation location
     #[cfg(target_os = "macos")]
     {
         let home = dirs::home_dir().ok_or("failed_to_get_home_dir")?;
-        let path = home.join(format!(
-            "Library/Application Support/{}/User/globalStorage/storage.json",
-            folder_name
-        ));
-        if path.exists() {
-            return Ok(path);
+        for folder_name in folder_names {
+            let path = home.join(format!(
+                "Library/Application Support/{}/User/globalStorage/storage.json",
+                folder_name
+            ));
+            if path.exists() {
+                return Ok(path);
+            }
         }
     }
 
@@ -71,23 +76,27 @@ pub fn get_storage_path(target_ide: Option<&str>) -> Result<PathBuf, String> {
     {
         let appdata =
             std::env::var("APPDATA").map_err(|_| "failed_to_get_appdata_env".to_string())?;
-        let path = PathBuf::from(appdata)
-            .join(folder_name)
-            .join("User\\globalStorage\\storage.json");
-        if path.exists() {
-            return Ok(path);
+        for folder_name in folder_names {
+            let path = PathBuf::from(&appdata)
+                .join(folder_name)
+                .join("User\\globalStorage\\storage.json");
+            if path.exists() {
+                return Ok(path);
+            }
         }
     }
 
     #[cfg(target_os = "linux")]
     {
         let home = dirs::home_dir().ok_or("failed_to_get_home_dir")?;
-        let path = home.join(format!(
-            ".config/{}/User/globalStorage/storage.json",
-            folder_name
-        ));
-        if path.exists() {
-            return Ok(path);
+        for folder_name in folder_names {
+            let path = home.join(format!(
+                ".config/{}/User/globalStorage/storage.json",
+                folder_name
+            ));
+            if path.exists() {
+                return Ok(path);
+            }
         }
     }
 

--- a/src-tauri/src/modules/integration.rs
+++ b/src-tauri/src/modules/integration.rs
@@ -67,7 +67,21 @@ impl SystemIntegration for DesktopIntegration {
         }
 
         // 2. 智能决策：是否使用最新的系统 Keychain 凭据管理器方式存储 Token
-        let is_ide = target_ide == Some("ide");
+        let mut is_ide = target_ide == Some("ide");
+
+        // Auto-detect IDE: if the located executable is the IDE, treat as IDE mode
+        if !is_ide {
+            if let Some(exe_path) = process::get_antigravity_executable_path(target_ide) {
+                let path_lower = exe_path.to_string_lossy().to_lowercase();
+                if path_lower.contains("antigravity ide") || path_lower.contains("antigravity-ide") {
+                    is_ide = true;
+                    crate::modules::logger::log_info(
+                        "[Desktop] Auto-detected Antigravity IDE executable, using IDE account switch logic.",
+                    );
+                }
+            }
+        }
+
         let mut use_keyring = false;
 
         if !is_ide {

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -1106,23 +1106,57 @@ pub fn get_antigravity_executable_path(target_ide: Option<&str>) -> Option<std::
         return Some(path);
     }
 
-    // Strategy 2: Check standard installation locations
+    // Strategy 2: Check config paths (supports user-configured locations)
+    if let Ok(config) = crate::modules::config::load_app_config() {
+        match target_ide {
+            Some("ide") => {
+                if let Some(ref p) = config.antigravity_ide_executable {
+                    let path = std::path::PathBuf::from(p);
+                    if path.exists() {
+                        return Some(path);
+                    }
+                }
+            }
+            _ => {
+                // Try antigravity_executable first (closest match for target_ide=None)
+                if let Some(ref p) = config.antigravity_executable {
+                    let path = std::path::PathBuf::from(p);
+                    if path.exists() {
+                        return Some(path);
+                    }
+                }
+                // Fall back to IDE executable if the other wasn't set or found
+                if let Some(ref p) = config.antigravity_ide_executable {
+                    let path = std::path::PathBuf::from(p);
+                    if path.exists() {
+                        return Some(path);
+                    }
+                }
+            }
+        }
+    }
+
+    // Strategy 3: Check standard installation locations
     check_standard_locations(target_ide)
 }
 
 /// Check standard installation locations
 fn check_standard_locations(target_ide: Option<&str>) -> Option<std::path::PathBuf> {
-    let folder_name = if target_ide == Some("ide") {
-        "Antigravity IDE"
+    let folder_names: &[&str] = if target_ide == Some("ide") {
+        &["Antigravity IDE"]
+    } else if target_ide == Some("code") || target_ide == Some("cursor") {
+        &["Antigravity"]
     } else {
-        "Antigravity"
+        &["Antigravity IDE", "Antigravity"]
     };
 
     #[cfg(target_os = "macos")]
     {
-        let path = std::path::PathBuf::from(format!("/Applications/{}.app", folder_name));
-        if path.exists() {
-            return Some(path);
+        for folder_name in folder_names {
+            let path = std::path::PathBuf::from(format!("/Applications/{}.app", folder_name));
+            if path.exists() {
+                return Some(path);
+            }
         }
     }
 
@@ -1137,64 +1171,69 @@ fn check_standard_locations(target_ide: Option<&str>) -> Option<std::path::PathB
         let program_files_x86 =
             env::var("ProgramFiles(x86)").unwrap_or_else(|_| "C:\\Program Files (x86)".to_string());
 
-        let mut possible_paths = Vec::new();
+        for folder_name in folder_names {
+            let mut possible_paths = Vec::new();
 
-        // User installation location (preferred)
-        if let Some(local) = local_appdata {
+            // User installation location (preferred)
+            if let Some(local) = &local_appdata {
+                possible_paths.push(
+                    std::path::PathBuf::from(local)
+                        .join("Programs")
+                        .join(folder_name)
+                        .join(format!("{}.exe", folder_name)),
+                );
+            }
+
+            // System installation location
             possible_paths.push(
-                std::path::PathBuf::from(&local)
-                    .join("Programs")
+                std::path::PathBuf::from(&program_files)
                     .join(folder_name)
                     .join(format!("{}.exe", folder_name)),
             );
-        }
 
-        // System installation location
-        possible_paths.push(
-            std::path::PathBuf::from(&program_files)
-                .join(folder_name)
-                .join(format!("{}.exe", folder_name)),
-        );
+            // 32-bit compatibility location
+            possible_paths.push(
+                std::path::PathBuf::from(&program_files_x86)
+                    .join(folder_name)
+                    .join(format!("{}.exe", folder_name)),
+            );
 
-        // 32-bit compatibility location
-        possible_paths.push(
-            std::path::PathBuf::from(&program_files_x86)
-                .join(folder_name)
-                .join(format!("{}.exe", folder_name)),
-        );
-
-        // Return the first existing path
-        for path in possible_paths {
-            if path.exists() {
-                return Some(path);
+            // Return the first existing path
+            for path in possible_paths {
+                if path.exists() {
+                    return Some(path);
+                }
             }
         }
     }
 
     #[cfg(target_os = "linux")]
     {
-        let exe_name = if target_ide == Some("ide") {
-            "antigravity-ide"
-        } else {
-            "antigravity"
-        };
-        let possible_paths = vec![
-            std::path::PathBuf::from(format!("/usr/bin/{}", exe_name)),
-            std::path::PathBuf::from(format!("/opt/{}/{}", folder_name, exe_name)),
-            std::path::PathBuf::from(format!("/usr/share/{}/{}", folder_name, exe_name)),
-        ];
+        for folder_name in folder_names {
+            let exe_name = if folder_name == "Antigravity IDE" {
+                "antigravity-ide"
+            } else {
+                "antigravity"
+            };
 
-        // User local installation
-        if let Some(home) = dirs::home_dir() {
-            let user_local = home.join(format!(".local/bin/{}", exe_name));
-            if user_local.exists() {
-                return Some(user_local);
+            let possible_paths = vec![
+                std::path::PathBuf::from(format!("/usr/bin/{}", exe_name)),
+                std::path::PathBuf::from(format!("/opt/{}/{}", folder_name, exe_name)),
+                std::path::PathBuf::from(format!("/usr/share/{}/{}", folder_name, exe_name)),
+            ];
+
+            // User local installation
+            if let Some(home) = dirs::home_dir() {
+                let user_local = home.join(format!(".local/bin/{}", exe_name));
+                if user_local.exists() {
+                    return Some(user_local);
+                }
             }
-        }
 
-        for path in possible_paths {
-            if path.exists() {
-                return Some(path);
+            for path in possible_paths {
+                if path.exists() {
+                    return Some(path);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes account switching with standalone Antigravity IDE (non-Google-agent version) and cache path detection.

## Changes

### 1. Auto-detect IDE executable (integration.rs)
When 	arget_ide is None, the code now checks if the located executable contains "Antigravity IDE". If so, it uses the SQLite injection path (which the IDE needs) instead of the system keyring path.

### 2. Add IDE cache paths (cache.rs)
Added %LOCALAPPDATA%\Antigravity IDE\Cache and %APPDATA%\Antigravity IDE\Cache to the cache-clearing routine (was only checking old Google agent paths).

### 3. Try both folder names (device.rs, db.rs)
Storage and DB path resolution now tries Antigravity IDE first, then falls back to Antigravity, so the correct paths are found for either installation type.

### 4. Config path fallback (process.rs)
get_antigravity_executable_path now checks ntigravity_executable and ntigravity_ide_executable from config before resorting to standard installation locations.
