### PR TITLE
修复gemini-pro-agent模型无法注入思考程度，新增codex思考过程原生显示

### DIFF
--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -3849,6 +3849,9 @@ async fn handle_websocket_session(mut socket: WebSocket, headers: HeaderMap, sta
         let mut translation_state = TranslationState {
             response_id: format!("resp-{}", &Uuid::new_v4().to_string()[..24]),
             item_id: format!("item-{}", &Uuid::new_v4().to_string()[..16]),
+            message_output_index: None,
+            next_output_index: 0,
+            tool_output_indices: std::collections::HashMap::new(),
             message_item_added: false,
             content_part_added: false,
             accumulated_text: String::new(),
@@ -4573,6 +4576,9 @@ fn convert_codex_to_openai_request(mut body: Value) -> Value {
 struct TranslationState {
     response_id: String,
     item_id: String,
+    message_output_index: Option<u32>,
+    next_output_index: u32,
+    tool_output_indices: std::collections::HashMap<u32, u32>,
     message_item_added: bool,
     content_part_added: bool,
     accumulated_text: String,
@@ -4596,11 +4602,20 @@ async fn translate_openai_chunk_to_ws(
             if let Some(delta) = choice.get("delta") {
                 if let Some(reasoning) = delta.get("reasoning_content").and_then(|v| v.as_str()) {
                     if !reasoning.is_empty() {
+                        let message_output_index = match state.message_output_index {
+                            Some(idx) => idx,
+                            None => {
+                                let idx = state.next_output_index;
+                                state.next_output_index += 1;
+                                state.message_output_index = Some(idx);
+                                idx
+                            }
+                        };
                         let reasoning_ev = json!({
                             "type": "response.reasoning_summary_text.delta",
                             "sequence_number": 0,
                             "item_id": &state.item_id,
-                            "output_index": 0,
+                            "output_index": message_output_index,
                             "summary_index": 0,
                             "delta": reasoning
                         });
@@ -4609,11 +4624,12 @@ async fn translate_openai_chunk_to_ws(
                         if !state.message_item_added {
                             let item_added = json!({
                                 "type": "response.output_item.added",
-                                "output_index": 0,
+                                "output_index": message_output_index,
                                 "item": {
                                     "id": &state.item_id,
                                     "type": "message",
                                     "role": "assistant",
+                                    "phase": "commentary",
                                     "status": "in_progress",
                                     "content": []
                                 }
@@ -4623,7 +4639,7 @@ async fn translate_openai_chunk_to_ws(
                             let part_added = json!({
                                 "type": "response.content_part.added",
                                 "item_id": &state.item_id,
-                                "output_index": 0,
+                                "output_index": message_output_index,
                                 "content_index": 0,
                                 "part": {
                                     "type": "output_text",
@@ -4638,7 +4654,7 @@ async fn translate_openai_chunk_to_ws(
                         let delta_ev = json!({
                             "type": "response.output_text.delta",
                             "item_id": &state.item_id,
-                            "output_index": 0,
+                            "output_index": message_output_index,
                             "content_index": 0,
                             "delta": reasoning
                         });
@@ -4649,14 +4665,24 @@ async fn translate_openai_chunk_to_ws(
 
                 if let Some(content) = delta.get("content").and_then(|v| v.as_str()) {
                     if !content.is_empty() {
+                        let message_output_index = match state.message_output_index {
+                            Some(idx) => idx,
+                            None => {
+                                let idx = state.next_output_index;
+                                state.next_output_index += 1;
+                                state.message_output_index = Some(idx);
+                                idx
+                            }
+                        };
                         if !state.message_item_added {
                             let item_added = json!({
                                 "type": "response.output_item.added",
-                                "output_index": 0,
+                                "output_index": message_output_index,
                                 "item": {
                                     "id": &state.item_id,
                                     "type": "message",
                                     "role": "assistant",
+                                    "phase": "commentary",
                                     "status": "in_progress",
                                     "content": []
                                 }
@@ -4666,7 +4692,7 @@ async fn translate_openai_chunk_to_ws(
                             let part_added = json!({
                                 "type": "response.content_part.added",
                                 "item_id": &state.item_id,
-                                "output_index": 0,
+                                "output_index": message_output_index,
                                 "content_index": 0,
                                 "part": {
                                     "type": "output_text",
@@ -4681,7 +4707,7 @@ async fn translate_openai_chunk_to_ws(
                         let delta_ev = json!({
                             "type": "response.output_text.delta",
                             "item_id": &state.item_id,
-                            "output_index": 0,
+                            "output_index": message_output_index,
                             "content_index": 0,
                             "delta": content
                         });
@@ -4732,6 +4758,15 @@ async fn translate_openai_chunk_to_ws(
                             state.tool_calls.get_mut(&tc_idx)
                         {
                             args.push_str(tc_args);
+                            let tool_output_index = match state.tool_output_indices.get(&tc_idx) {
+                                Some(idx) => *idx,
+                                None => {
+                                    let idx = state.next_output_index;
+                                    state.next_output_index += 1;
+                                    state.tool_output_indices.insert(tc_idx, idx);
+                                    idx
+                                }
+                            };
 
                             if !state.tool_calls_added.contains(&tc_idx) {
                                 let (actual_name, namespace) = split_namespace_tool_name(name);
@@ -4748,7 +4783,7 @@ async fn translate_openai_chunk_to_ws(
                                 }
                                 let tool_added = json!({
                                     "type": "response.output_item.added",
-                                    "output_index": 0,
+                                    "output_index": tool_output_index,
                                     "item": item_obj
                                 });
                                 send_ws_event(socket, ws_events, &tool_added).await;
@@ -4759,7 +4794,7 @@ async fn translate_openai_chunk_to_ws(
                                 let args_delta = json!({
                                     "type": "response.function_call_arguments.delta",
                                     "item_id": tool_item_id,
-                                    "output_index": 0,
+                                    "output_index": tool_output_index,
                                     "delta": tc_args
                                 });
                                 send_ws_event(socket, ws_events, &args_delta).await;
@@ -4784,10 +4819,19 @@ async fn finalize_ws_events(
 
     for tc_idx in tool_keys {
         if let Some((tool_item_id, call_id, name, args)) = state.tool_calls.get(&tc_idx) {
+            let tool_output_index = match state.tool_output_indices.get(&tc_idx) {
+                Some(idx) => *idx,
+                None => {
+                    let idx = state.next_output_index;
+                    state.next_output_index += 1;
+                    state.tool_output_indices.insert(tc_idx, idx);
+                    idx
+                }
+            };
             let args_done = json!({
                 "type": "response.function_call_arguments.done",
                 "item_id": tool_item_id,
-                "output_index": 0,
+                "output_index": tool_output_index,
                 "arguments": args
             });
             send_ws_event(socket, ws_events, &args_done).await;
@@ -4807,7 +4851,7 @@ async fn finalize_ws_events(
 
             let tool_done = json!({
                 "type": "response.output_item.done",
-                "output_index": 0,
+                "output_index": tool_output_index,
                 "item": item_obj
             });
             send_ws_event(socket, ws_events, &tool_done).await;
@@ -4823,10 +4867,11 @@ async fn finalize_ws_events(
     }
 
     if state.message_item_added {
+        let message_output_index = state.message_output_index.unwrap_or(0);
         let text_done = json!({
             "type": "response.output_text.done",
             "item_id": &state.item_id,
-            "output_index": 0,
+            "output_index": message_output_index,
             "content_index": 0,
             "text": &state.accumulated_text
         });
@@ -4835,7 +4880,7 @@ async fn finalize_ws_events(
         let part_done = json!({
             "type": "response.content_part.done",
             "item_id": &state.item_id,
-            "output_index": 0,
+            "output_index": message_output_index,
             "content_index": 0,
             "part": {
                 "type": "output_text",
@@ -4846,11 +4891,12 @@ async fn finalize_ws_events(
 
         let message_done = json!({
             "type": "response.output_item.done",
-            "output_index": 0,
+            "output_index": message_output_index,
             "item": {
                 "id": &state.item_id,
                 "type": "message",
                 "role": "assistant",
+                "phase": "final_answer",
                 "status": "completed",
                 "content": [{
                     "type": "output_text",
@@ -4864,6 +4910,7 @@ async fn finalize_ws_events(
             "id": &state.item_id,
             "type": "message",
             "role": "assistant",
+            "phase": "final_answer",
             "status": "completed",
             "content": [{
                 "type": "output_text",

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -48,60 +48,29 @@ fn stream_chunk_has_error_event(bytes: &[u8]) -> bool {
     })
 }
 
-/// Synthetic commentary messages mirror Gemini `thought=true` parts into the
-/// Codex transcript. They are merged back into the following assistant/tool
-/// item as `reasoning_content` on the next request so the upstream model does
-/// not receive the same thought twice as ordinary assistant prose.
-fn is_codex_visible_thought_message(item: &Value) -> bool {
-    item.get("type").and_then(Value::as_str) == Some("message")
-        && item.get("role").and_then(Value::as_str) == Some("assistant")
-        && item.get("phase").and_then(Value::as_str) == Some("commentary")
-        && item
+/// Visible Codex commentary is part of the local transcript, not Gemini
+/// conversation history. Codex omits output item IDs when it replays a task, so
+/// `phase=commentary` is the durable discriminator. The text-prefix fallback
+/// heals tasks written by builds that accidentally finalized a thought blob as
+/// a normal answer.
+fn is_codex_transcript_only_assistant_message(item: &Value, text: &str) -> bool {
+    if item.get("type").and_then(Value::as_str) != Some("message")
+        || item.get("role").and_then(Value::as_str) != Some("assistant")
+    {
+        return false;
+    }
+
+    item.get("phase").and_then(Value::as_str) == Some("commentary")
+        || item
             .get("id")
             .and_then(Value::as_str)
             .is_some_and(|id| id.starts_with(CODEX_VISIBLE_THOUGHT_MESSAGE_PREFIX))
-}
-
-fn append_pending_reasoning(pending: &mut String, text: &str) {
-    if text.trim().is_empty() {
-        return;
-    }
-    if !pending.is_empty() && !pending.ends_with('\n') {
-        pending.push('\n');
-    }
-    pending.push_str(text);
-}
-
-fn take_pending_reasoning(pending: &mut String) -> Option<String> {
-    if pending.trim().is_empty() {
-        pending.clear();
-        None
-    } else {
-        Some(std::mem::take(pending))
-    }
-}
-
-fn attach_pending_reasoning_content(message: &mut Value, pending: &mut String) {
-    if let Some(reasoning_content) = take_pending_reasoning(pending) {
-        message["reasoning_content"] = json!(reasoning_content);
-    }
-}
-
-fn flush_pending_reasoning_message(messages: &mut Vec<Value>, pending: &mut String) {
-    if let Some(reasoning_content) = take_pending_reasoning(pending) {
-        messages.push(json!({
-            "role": "assistant",
-            "content": "",
-            "reasoning_content": reasoning_content,
-        }));
-    }
+        || text.trim_start().starts_with("**Thinking**")
 }
 
 #[cfg(test)]
 mod stream_peek_tests {
-    use super::append_pending_reasoning;
-    use super::attach_pending_reasoning_content;
-    use super::is_codex_visible_thought_message;
+    use super::is_codex_transcript_only_assistant_message;
     use super::stream_chunk_has_error_event;
     use serde_json::json;
 
@@ -140,7 +109,7 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
     }
 
     #[test]
-    fn identifies_only_synthetic_visible_thought_commentary() {
+    fn identifies_codex_transcript_only_assistant_messages() {
         let thought = json!({
             "type": "message",
             "id": "msg_thought_abc_0",
@@ -150,34 +119,38 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
         });
         let normal_commentary = json!({
             "type": "message",
-            "id": "msg_abc",
             "role": "assistant",
             "phase": "commentary",
             "content": [{"type": "output_text", "text": "progress"}],
         });
-
-        assert!(is_codex_visible_thought_message(&thought));
-        assert!(!is_codex_visible_thought_message(&normal_commentary));
-    }
-
-    #[test]
-    fn visible_thought_is_reattached_as_reasoning_content() {
-        let mut pending = String::new();
-        append_pending_reasoning(&mut pending, "first thought");
-        append_pending_reasoning(&mut pending, "second thought");
-        let mut assistant_tool_call = json!({
+        let contaminated_final = json!({
+            "type": "message",
             "role": "assistant",
-            "content": "",
-            "tool_calls": [{"id": "call_1"}],
+            "phase": "final_answer",
+            "content": [{"type": "output_text", "text": "**Thinking**\n\nlegacy thought"}],
+        });
+        let clean_final = json!({
+            "type": "message",
+            "role": "assistant",
+            "phase": "final_answer",
+            "content": [{"type": "output_text", "text": "done"}],
         });
 
-        attach_pending_reasoning_content(&mut assistant_tool_call, &mut pending);
-
-        assert_eq!(
-            assistant_tool_call["reasoning_content"],
-            "first thought\nsecond thought"
-        );
-        assert!(pending.is_empty());
+        assert!(is_codex_transcript_only_assistant_message(
+            &thought, "thinking"
+        ));
+        assert!(is_codex_transcript_only_assistant_message(
+            &normal_commentary,
+            "progress"
+        ));
+        assert!(is_codex_transcript_only_assistant_message(
+            &contaminated_final,
+            "**Thinking**\n\nlegacy thought"
+        ));
+        assert!(!is_codex_transcript_only_assistant_message(
+            &clean_final,
+            "done"
+        ));
     }
 }
 
@@ -1409,11 +1382,9 @@ pub async fn handle_completions(
         let mut seen_apply_patch_failures = std::collections::HashSet::new();
         let mut apply_patch_failure_distinct_count = 0usize;
 
-        // Pass 2: Map Input Items to Messages. Synthetic `msg_thought_*`
-        // commentary items are visible transcript mirrors, not independent
-        // assistant turns. Fold them into the next assistant/tool item as
-        // reasoning_content to preserve both Codex replay and Gemini history.
-        let mut pending_synthetic_reasoning = String::new();
+        // Pass 2: Map durable conversation items to Gemini messages. Visible
+        // assistant commentary stays in Codex's local transcript and must not
+        // be replayed as model history.
         if let Some(items) = input_items {
             for item in items {
                 let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
@@ -1465,34 +1436,17 @@ pub async fn handle_completions(
                         }
 
                         let joined_text = text_parts.join("\n");
-                        if is_codex_visible_thought_message(item) {
-                            append_pending_reasoning(
-                                &mut pending_synthetic_reasoning,
-                                &joined_text,
-                            );
+                        if is_codex_transcript_only_assistant_message(item, &joined_text) {
                             continue;
                         }
-
-                        let reasoning_content = if role == "assistant" {
-                            take_pending_reasoning(&mut pending_synthetic_reasoning)
-                        } else {
-                            flush_pending_reasoning_message(
-                                &mut messages,
-                                &mut pending_synthetic_reasoning,
-                            );
-                            None
-                        };
 
                         // 构造消息内容：如果有图像则使用数组格式
                         if image_parts.is_empty() {
                             let content = prefix_with_step_marker(step_marker, joined_text);
-                            let mut message = json!({
+                            let message = json!({
                                 "role": role,
                                 "content": content
                             });
-                            if let Some(reasoning) = reasoning_content {
-                                message["reasoning_content"] = json!(reasoning);
-                            }
                             messages.push(message);
                         } else {
                             let mut content_blocks: Vec<Value> = Vec::new();
@@ -1504,13 +1458,10 @@ pub async fn handle_completions(
                                 }));
                             }
                             content_blocks.extend(image_parts);
-                            let mut message = json!({
+                            let message = json!({
                                 "role": role,
                                 "content": content_blocks
                             });
-                            if let Some(reasoning) = reasoning_content {
-                                message["reasoning_content"] = json!(reasoning);
-                            }
                             messages.push(message);
                         }
                     }
@@ -1575,7 +1526,7 @@ pub async fn handle_completions(
                             }
                         }
 
-                        let mut message = json!({
+                        let message = json!({
                             "role": "assistant",
                             "content": "",
                             "tool_calls": [
@@ -1589,17 +1540,9 @@ pub async fn handle_completions(
                                 }
                             ]
                         });
-                        attach_pending_reasoning_content(
-                            &mut message,
-                            &mut pending_synthetic_reasoning,
-                        );
                         messages.push(message);
                     }
                     "function_call_output" | "custom_tool_call_output" => {
-                        flush_pending_reasoning_message(
-                            &mut messages,
-                            &mut pending_synthetic_reasoning,
-                        );
                         let call_id = item
                             .get("call_id")
                             .and_then(|v| v.as_str())
@@ -1663,8 +1606,6 @@ pub async fn handle_completions(
                 }
             }
         }
-        flush_pending_reasoning_message(&mut messages, &mut pending_synthetic_reasoning);
-
         if let Some(obj) = body.as_object_mut() {
             obj.insert("messages".to_string(), json!(messages));
             if let Some(ledger) = interaction_ledger {

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -26,6 +26,66 @@ use axum::http::HeaderMap;
 use std::collections::VecDeque;
 use tokio::time::Duration;
 
+/// Return true only when a streamed chunk contains an actual error event.
+///
+/// Responses lifecycle envelopes legitimately contain `"error": null`, and
+/// assistant text may also mention the word "error". A substring search would
+/// misclassify both as failures and rotate otherwise healthy accounts.
+fn stream_chunk_has_error_event(bytes: &[u8]) -> bool {
+    String::from_utf8_lossy(bytes).lines().any(|line| {
+        let Some(data) = line.trim_start().strip_prefix("data:") else {
+            return false;
+        };
+        let Ok(payload) = serde_json::from_str::<Value>(data.trim()) else {
+            return false;
+        };
+
+        matches!(
+            payload.get("type").and_then(Value::as_str),
+            Some("error" | "response.failed")
+        ) || payload.get("error").is_some_and(|error| !error.is_null())
+    })
+}
+
+#[cfg(test)]
+mod stream_peek_tests {
+    use super::stream_chunk_has_error_event;
+
+    #[test]
+    fn responses_created_with_null_error_is_not_an_error_event() {
+        let chunk = br#"event: response.created
+data: {"type":"response.created","response":{"status":"in_progress","error":null}}
+
+"#;
+        assert!(!stream_chunk_has_error_event(chunk));
+    }
+
+    #[test]
+    fn response_failed_is_an_error_event() {
+        let chunk = br#"event: response.failed
+data: {"type":"response.failed","response":{"status":"failed","error":{"code":"upstream_error"}}}
+
+"#;
+        assert!(stream_chunk_has_error_event(chunk));
+    }
+
+    #[test]
+    fn legacy_top_level_error_is_an_error_event() {
+        let chunk = br#"data: {"error":{"message":"quota exceeded"}}
+
+"#;
+        assert!(stream_chunk_has_error_event(chunk));
+    }
+
+    #[test]
+    fn normal_text_containing_error_is_not_an_error_event() {
+        let chunk = br#"data: {"type":"response.output_text.delta","delta":"The JSON key is called \"error\"."}
+
+"#;
+        assert!(!stream_chunk_has_error_event(chunk));
+    }
+}
+
 fn compact_apply_patch_failure_output(
     output: String,
     seen: &mut std::collections::HashSet<String>,
@@ -527,7 +587,7 @@ pub async fn handle_chat_completions(
                             }
 
                             // Check for error events
-                            if text.contains("\"error\"") {
+                            if stream_chunk_has_error_event(&bytes) {
                                 tracing::warn!("[OpenAI] Error detected during peek, retrying...");
                                 last_error = "Error event during peek".to_string();
                                 retry_this_account = true;
@@ -2168,7 +2228,7 @@ pub async fn handle_completions(
                                 {
                                     continue;
                                 }
-                                if text.contains("\"error\"") {
+                                if stream_chunk_has_error_event(&bytes) {
                                     last_error = "Error event during peek".to_string();
                                     retry_this_account = true;
                                     break;
@@ -2283,7 +2343,7 @@ pub async fn handle_completions(
                                 {
                                     continue;
                                 }
-                                if text.contains("\"error\"") {
+                                if stream_chunk_has_error_event(&bytes) {
                                     last_error = "Error event in internal stream".to_string();
                                     retry_this_account = true;
                                     break;

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -16,6 +16,7 @@ use crate::proxy::server::AppState;
 use crate::proxy::upstream::client::mask_email;
 
 const MAX_RETRY_ATTEMPTS: usize = 3;
+const CODEX_VISIBLE_THOUGHT_MESSAGE_PREFIX: &str = "msg_thought_";
 use super::common::{
     apply_retry_strategy, determine_retry_strategy, should_rotate_account, RetryStrategy,
 };
@@ -47,9 +48,62 @@ fn stream_chunk_has_error_event(bytes: &[u8]) -> bool {
     })
 }
 
+/// Synthetic commentary messages mirror Gemini `thought=true` parts into the
+/// Codex transcript. They are merged back into the following assistant/tool
+/// item as `reasoning_content` on the next request so the upstream model does
+/// not receive the same thought twice as ordinary assistant prose.
+fn is_codex_visible_thought_message(item: &Value) -> bool {
+    item.get("type").and_then(Value::as_str) == Some("message")
+        && item.get("role").and_then(Value::as_str) == Some("assistant")
+        && item.get("phase").and_then(Value::as_str) == Some("commentary")
+        && item
+            .get("id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| id.starts_with(CODEX_VISIBLE_THOUGHT_MESSAGE_PREFIX))
+}
+
+fn append_pending_reasoning(pending: &mut String, text: &str) {
+    if text.trim().is_empty() {
+        return;
+    }
+    if !pending.is_empty() && !pending.ends_with('\n') {
+        pending.push('\n');
+    }
+    pending.push_str(text);
+}
+
+fn take_pending_reasoning(pending: &mut String) -> Option<String> {
+    if pending.trim().is_empty() {
+        pending.clear();
+        None
+    } else {
+        Some(std::mem::take(pending))
+    }
+}
+
+fn attach_pending_reasoning_content(message: &mut Value, pending: &mut String) {
+    if let Some(reasoning_content) = take_pending_reasoning(pending) {
+        message["reasoning_content"] = json!(reasoning_content);
+    }
+}
+
+fn flush_pending_reasoning_message(messages: &mut Vec<Value>, pending: &mut String) {
+    if let Some(reasoning_content) = take_pending_reasoning(pending) {
+        messages.push(json!({
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": reasoning_content,
+        }));
+    }
+}
+
 #[cfg(test)]
 mod stream_peek_tests {
+    use super::append_pending_reasoning;
+    use super::attach_pending_reasoning_content;
+    use super::is_codex_visible_thought_message;
     use super::stream_chunk_has_error_event;
+    use serde_json::json;
 
     #[test]
     fn responses_created_with_null_error_is_not_an_error_event() {
@@ -83,6 +137,47 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
 
 "#;
         assert!(!stream_chunk_has_error_event(chunk));
+    }
+
+    #[test]
+    fn identifies_only_synthetic_visible_thought_commentary() {
+        let thought = json!({
+            "type": "message",
+            "id": "msg_thought_abc_0",
+            "role": "assistant",
+            "phase": "commentary",
+            "content": [{"type": "output_text", "text": "thinking"}],
+        });
+        let normal_commentary = json!({
+            "type": "message",
+            "id": "msg_abc",
+            "role": "assistant",
+            "phase": "commentary",
+            "content": [{"type": "output_text", "text": "progress"}],
+        });
+
+        assert!(is_codex_visible_thought_message(&thought));
+        assert!(!is_codex_visible_thought_message(&normal_commentary));
+    }
+
+    #[test]
+    fn visible_thought_is_reattached_as_reasoning_content() {
+        let mut pending = String::new();
+        append_pending_reasoning(&mut pending, "first thought");
+        append_pending_reasoning(&mut pending, "second thought");
+        let mut assistant_tool_call = json!({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_1"}],
+        });
+
+        attach_pending_reasoning_content(&mut assistant_tool_call, &mut pending);
+
+        assert_eq!(
+            assistant_tool_call["reasoning_content"],
+            "first thought\nsecond thought"
+        );
+        assert!(pending.is_empty());
     }
 }
 
@@ -1314,7 +1409,11 @@ pub async fn handle_completions(
         let mut seen_apply_patch_failures = std::collections::HashSet::new();
         let mut apply_patch_failure_distinct_count = 0usize;
 
-        // Pass 2: Map Input Items to Messages
+        // Pass 2: Map Input Items to Messages. Synthetic `msg_thought_*`
+        // commentary items are visible transcript mirrors, not independent
+        // assistant turns. Fold them into the next assistant/tool item as
+        // reasoning_content to preserve both Codex replay and Gemini history.
+        let mut pending_synthetic_reasoning = String::new();
         if let Some(items) = input_items {
             for item in items {
                 let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
@@ -1365,18 +1464,39 @@ pub async fn handle_completions(
                             }
                         }
 
+                        let joined_text = text_parts.join("\n");
+                        if is_codex_visible_thought_message(item) {
+                            append_pending_reasoning(
+                                &mut pending_synthetic_reasoning,
+                                &joined_text,
+                            );
+                            continue;
+                        }
+
+                        let reasoning_content = if role == "assistant" {
+                            take_pending_reasoning(&mut pending_synthetic_reasoning)
+                        } else {
+                            flush_pending_reasoning_message(
+                                &mut messages,
+                                &mut pending_synthetic_reasoning,
+                            );
+                            None
+                        };
+
                         // 构造消息内容：如果有图像则使用数组格式
                         if image_parts.is_empty() {
-                            let content =
-                                prefix_with_step_marker(step_marker, text_parts.join("\n"));
-                            messages.push(json!({
+                            let content = prefix_with_step_marker(step_marker, joined_text);
+                            let mut message = json!({
                                 "role": role,
                                 "content": content
-                            }));
+                            });
+                            if let Some(reasoning) = reasoning_content {
+                                message["reasoning_content"] = json!(reasoning);
+                            }
+                            messages.push(message);
                         } else {
                             let mut content_blocks: Vec<Value> = Vec::new();
-                            let marker_text =
-                                prefix_with_step_marker(step_marker, text_parts.join("\n"));
+                            let marker_text = prefix_with_step_marker(step_marker, joined_text);
                             if !marker_text.is_empty() {
                                 content_blocks.push(json!({
                                     "type": "text",
@@ -1384,10 +1504,14 @@ pub async fn handle_completions(
                                 }));
                             }
                             content_blocks.extend(image_parts);
-                            messages.push(json!({
+                            let mut message = json!({
                                 "role": role,
                                 "content": content_blocks
-                            }));
+                            });
+                            if let Some(reasoning) = reasoning_content {
+                                message["reasoning_content"] = json!(reasoning);
+                            }
+                            messages.push(message);
                         }
                     }
                     "function_call" | "custom_tool_call" | "local_shell_call"
@@ -1451,7 +1575,7 @@ pub async fn handle_completions(
                             }
                         }
 
-                        messages.push(json!({
+                        let mut message = json!({
                             "role": "assistant",
                             "content": "",
                             "tool_calls": [
@@ -1464,9 +1588,18 @@ pub async fn handle_completions(
                                     }
                                 }
                             ]
-                        }));
+                        });
+                        attach_pending_reasoning_content(
+                            &mut message,
+                            &mut pending_synthetic_reasoning,
+                        );
+                        messages.push(message);
                     }
                     "function_call_output" | "custom_tool_call_output" => {
+                        flush_pending_reasoning_message(
+                            &mut messages,
+                            &mut pending_synthetic_reasoning,
+                        );
                         let call_id = item
                             .get("call_id")
                             .and_then(|v| v.as_str())
@@ -1530,6 +1663,7 @@ pub async fn handle_completions(
                 }
             }
         }
+        flush_pending_reasoning_message(&mut messages, &mut pending_synthetic_reasoning);
 
         if let Some(obj) = body.as_object_mut() {
             obj.insert("messages".to_string(), json!(messages));

--- a/src-tauri/src/proxy/mappers/openai/request.rs
+++ b/src-tauri/src/proxy/mappers/openai/request.rs
@@ -221,12 +221,16 @@ pub fn transform_openai_request(
         && (mapped_model_lower.contains("-thinking")
             || mapped_model_lower.contains("gemini-2.0-pro")
             || mapped_model_lower.contains("gemini-3-pro")
-            || mapped_model_lower.contains("gemini-3.1-pro"))
+            || mapped_model_lower.contains("gemini-3.1-pro")
+            || mapped_model_lower.contains("gemini-pro")
+            || mapped_model_lower.contains("-pro-agent"))
         && !mapped_model_lower.contains("claude");
     // [FIX #2167] gemini-*-flash 支持 thinking，functionCall 必须携带 thoughtSignature
     // [FEATURE] 同时注入 includeThoughts:true 使 Gemini 返回 thought:true chunk，客户端可显示思维链
     let is_gemini_flash_thinking = mapped_model_lower.contains("gemini")
-        && (mapped_model_lower.contains("flash") || mapped_model_lower.contains("-flash-"))
+        && (mapped_model_lower.contains("flash") 
+        || mapped_model_lower.contains("-flash-") 
+        || mapped_model_lower.contains("-flash-agent"))
         && !mapped_model_lower.contains("claude");
     let is_claude_thinking = mapped_model_lower.ends_with("-thinking");
     let is_thinking_model = is_gemini_3_thinking || is_claude_thinking || is_gemini_flash_thinking;

--- a/src-tauri/src/proxy/mappers/openai/streaming.rs
+++ b/src-tauri/src/proxy/mappers/openai/streaming.rs
@@ -599,7 +599,7 @@ where
                                                                     message_item_emitted = true;
                                                                     message_output_index = next_output_index;
                                                                     next_output_index += 1;
-                                                                    let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "status": "in_progress", "content": []}});
+                                                                    let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "phase": "commentary", "status": "in_progress", "content": []}});
                                                                     yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
                                                                     let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": ""}});
                                                                     yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_added).unwrap())));
@@ -842,7 +842,7 @@ where
                                                             message_item_emitted = true;
                                                             message_output_index = next_output_index;
                                                             next_output_index += 1;
-                                                            let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "status": "in_progress", "content": []}});
+                                                            let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "phase": "commentary", "status": "in_progress", "content": []}});
                                                             yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
                                                             let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": ""}});
                                                             yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_added).unwrap())));
@@ -876,7 +876,7 @@ where
         if !message_item_emitted && final_outputs_map.is_empty() {
             emit_empty = true;
             message_output_index = next_output_index;
-            let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "status": "in_progress", "content": []}});
+            let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "phase": "commentary", "status": "in_progress", "content": []}});
             yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
             let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": ""}});
             yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_added).unwrap())));
@@ -908,6 +908,7 @@ where
                 "id": &message_item_id,
                 "type": "message",
                 "role": "assistant",
+                "phase": "final_answer",
                 "status": "completed",
                 "content": [{
                     "type": "output_text",

--- a/src-tauri/src/proxy/mappers/openai/streaming.rs
+++ b/src-tauri/src/proxy/mappers/openai/streaming.rs
@@ -520,6 +520,14 @@ fn extract_apply_patch_input(args: &Value) -> String {
         .unwrap_or_else(|| serde_json::to_string(args).unwrap_or_default())
 }
 
+fn inject_seq(mut event: Value, seq: &mut u64) -> Value {
+    if let Some(obj) = event.as_object_mut() {
+        obj.insert("sequence_number".to_string(), json!(*seq));
+    }
+    *seq += 1;
+    event
+}
+
 pub fn create_codex_sse_stream<S, E>(
     mut gemini_stream: Pin<Box<S>>,
     _model: String,
@@ -542,15 +550,18 @@ where
         .collect();
     let response_id = format!("resp-{}", random_str);
     let message_item_id = format!("msg_{}_0", &random_str[..16]);
-
     let stream = async_stream::stream! {
+        let mut sequence_number: u64 = 0;
+
         // 1. response.created
         let created_ev = json!({ "type": "response.created", "response": { "id": &response_id, "object": "response", "status": "in_progress", "output": [] } });
+        let created_ev = inject_seq(created_ev, &mut sequence_number);
         yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&created_ev).unwrap())));
 
         let mut message_item_emitted = false;
-        let mut in_thought_block = false;
-        let mut emitted_thought_header = false;
+        let mut reasoning_open = false;
+        let mut current_summary_index: u32 = 0;
+        let mut active_reasoning_item_id = String::new();
 
         let mut emitted_tool_calls = std::collections::HashSet::new();
         let mut accumulated_text = String::new();
@@ -559,6 +570,7 @@ where
         let mut final_outputs_map: std::collections::BTreeMap<u32, serde_json::Value> = std::collections::BTreeMap::new();
         let mut next_output_index: u32 = 0;
         let mut message_output_index: u32 = 0;
+        let mut reasoning_output_index: u32 = 0;
         let mut final_usage: Option<super::models::OpenAIUsage> = None;
         let mut heartbeat_interval = tokio::time::interval(std::time::Duration::from_secs(15));
         heartbeat_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -592,50 +604,123 @@ where
                                                 if let Some(parts) = candidate.get("content").and_then(|c| c.get("parts")).and_then(|p| p.as_array()) {
                                                     for part in parts {
                                                         let is_thought = part.get("thought").and_then(|v| v.as_bool()).unwrap_or(false);
+                                                        
+                                                        // 切换到正文或工具时，若思考区开着，则先闭合思考区
+                                                        let is_text_or_tool = part.get("text").is_some() || part.get("functionCall").is_some() || part.get("inlineData").is_some();
+                                                        if is_text_or_tool && !is_thought && reasoning_open {
+                                                            let text_done = json!({
+                                                                "type": "response.reasoning_summary_text.done",
+                                                                "item_id": &active_reasoning_item_id,
+                                                                "output_index": reasoning_output_index,
+                                                                "summary_index": current_summary_index,
+                                                                "text": &accumulated_thinking
+                                                            });
+                                                            let text_done = inject_seq(text_done, &mut sequence_number);
+                                                            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&text_done).unwrap())));
+
+                                                            let part_done = json!({
+                                                                "type": "response.reasoning_summary_part.done",
+                                                                "item_id": &active_reasoning_item_id,
+                                                                "output_index": reasoning_output_index,
+                                                                "summary_index": current_summary_index,
+                                                                "part": {
+                                                                    "type": "summary_text",
+                                                                    "text": &accumulated_thinking
+                                                                }
+                                                            });
+                                                            let part_done = inject_seq(part_done, &mut sequence_number);
+                                                            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&part_done).unwrap())));
+
+                                                            let reasoning_item = json!({
+                                                                "type": "reasoning",
+                                                                "status": "completed",
+                                                                "id": &active_reasoning_item_id,
+                                                                "summary": [{
+                                                                    "type": "summary_text",
+                                                                    "text": &accumulated_thinking
+                                                                }]
+                                                            });
+
+                                                            let done_ev = json!({
+                                                                "type": "response.output_item.done",
+                                                                "output_index": reasoning_output_index,
+                                                                "item": &reasoning_item
+                                                            });
+                                                            let done_ev = inject_seq(done_ev, &mut sequence_number);
+                                                            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&done_ev).unwrap())));
+
+                                                            final_outputs_map.insert(reasoning_output_index, reasoning_item);
+                                                            reasoning_open = false;
+                                                            current_summary_index += 1;
+                                                        }
+
                                                         if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
                                                             let clean_text = text.replace("<think>\n", "").replace("<think>", "").replace("\n</think>", "").replace("</think>", "");
                                                             if !clean_text.is_empty() {
-                                                                if !message_item_emitted {
-                                                                    message_item_emitted = true;
-                                                                    message_output_index = next_output_index;
-                                                                    next_output_index += 1;
-                                                                    let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "phase": "commentary", "status": "in_progress", "content": []}});
-                                                                    yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
-                                                                    let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": ""}});
-                                                                    yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_added).unwrap())));
-                                                                }
-
-                                                                let mut chunk_to_emit = String::new();
-
                                                                 if is_thought {
+                                                                    if !reasoning_open {
+                                                                        reasoning_output_index = next_output_index;
+                                                                        next_output_index += 1;
+                                                                        active_reasoning_item_id = format!("item-{}-{}", &random_str[..16], current_summary_index);
+                                                                        accumulated_thinking.clear();
+
+                                                                        let output_item_added = json!({"type": "response.output_item.added", "output_index": reasoning_output_index, "item": {"id": &active_reasoning_item_id, "type": "reasoning", "status": "in_progress", "summary": []}});
+                                                                        let output_item_added = inject_seq(output_item_added, &mut sequence_number);
+                                                                        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
+
+                                                                        let part_added = json!({"type": "response.reasoning_summary_part.added", "item_id": &active_reasoning_item_id, "output_index": reasoning_output_index, "summary_index": current_summary_index, "part": {"type": "summary_text", "text": ""}});
+                                                                        let part_added = inject_seq(part_added, &mut sequence_number);
+                                                                        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&part_added).unwrap())));
+
+                                                                        reasoning_open = true;
+
+                                                                        let prefix = "**Thinking**\n\n";
+                                                                        accumulated_thinking.push_str(prefix);
+                                                                        let prefix_ev = json!({
+                                                                            "type": "response.reasoning_summary_text.delta",
+                                                                            "item_id": &active_reasoning_item_id,
+                                                                            "output_index": reasoning_output_index,
+                                                                            "summary_index": current_summary_index,
+                                                                            "delta": prefix
+                                                                        });
+                                                                        let prefix_ev = inject_seq(prefix_ev, &mut sequence_number);
+                                                                        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&prefix_ev).unwrap())));
+                                                                    }
+
                                                                     accumulated_thinking.push_str(&clean_text);
-                                                                    if !in_thought_block {
-                                                                        in_thought_block = true;
-                                                                        if !emitted_thought_header {
-                                                                            emitted_thought_header = true;
-                                                                        } else {
-                                                                            chunk_to_emit.push_str("\n> ");
-                                                                        }
-                                                                    }
-                                                                    chunk_to_emit.push_str(&clean_text.replace("\n", "\n> "));
+                                                                    let delta_ev = json!({
+                                                                        "type": "response.reasoning_summary_text.delta",
+                                                                        "item_id": &active_reasoning_item_id,
+                                                                        "output_index": reasoning_output_index,
+                                                                        "summary_index": current_summary_index,
+                                                                        "delta": clean_text
+                                                                    });
+                                                                    let delta_ev = inject_seq(delta_ev, &mut sequence_number);
+                                                                    yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&delta_ev).unwrap())));
                                                                 } else {
-                                                                    if in_thought_block {
-                                                                        in_thought_block = false;
-                                                                        chunk_to_emit.push_str("\n\n");
+                                                                    if !message_item_emitted {
+                                                                        message_item_emitted = true;
+                                                                        message_output_index = next_output_index;
+                                                                        next_output_index += 1;
+                                                                        let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "phase": "commentary", "status": "in_progress", "content": []}});
+                                                                        let output_item_added = inject_seq(output_item_added, &mut sequence_number);
+                                                                        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
+                                                                        let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": ""}});
+                                                                        let content_part_added = inject_seq(content_part_added, &mut sequence_number);
+                                                                        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_added).unwrap())));
                                                                     }
-                                                                    chunk_to_emit.push_str(&clean_text);
+
+                                                                    accumulated_text.push_str(&clean_text);
+                                                                    let delta_ev = json!({
+                                                                        "type": "response.output_text.delta",
+                                                                        "item_id": &message_item_id,
+                                                                        "output_index": message_output_index,
+                                                                        "content_index": 0,
+                                                                        "delta": clean_text
+                                                                    });
+                                                                    let delta_ev = inject_seq(delta_ev, &mut sequence_number);
+                                                                    yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&delta_ev).unwrap())));
                                                                 }
-
-                                                                accumulated_text.push_str(&chunk_to_emit);
-
-                                                                let delta_ev = json!({
-                                                                    "type": "response.output_text.delta",
-                                                                    "item_id": &message_item_id,
-                                                                    "output_index": message_output_index,
-                                                                    "content_index": 0,
-                                                                    "delta": chunk_to_emit
-                                                                });
-                                                                yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&delta_ev).unwrap())));
                                                             }
                                                         }
                                                         if let Some(sig) = part.get("thoughtSignature").or(part.get("thought_signature")).and_then(|s| s.as_str()) {
@@ -752,6 +837,7 @@ where
                                                                     "output_index": tool_output_index,
                                                                     "item": added_item
                                                                 });
+                                                                let added_ev = inject_seq(added_ev, &mut sequence_number);
                                                                 yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&added_ev).unwrap())));
 
                                                                 let mut delta_ev = json!({
@@ -763,6 +849,7 @@ where
                                                                 if is_custom_tool {
                                                                     delta_ev["call_id"] = json!(&call_id);
                                                                 }
+                                                                let delta_ev = inject_seq(delta_ev, &mut sequence_number);
                                                                 yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&delta_ev).unwrap())));
 
                                                                 let mut args_done_ev = json!({
@@ -776,6 +863,7 @@ where
                                                                 } else {
                                                                     args_done_ev["arguments"] = json!(&final_args_str);
                                                                 }
+                                                                let args_done_ev = inject_seq(args_done_ev, &mut sequence_number);
                                                                 yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&args_done_ev).unwrap())));
 
                                                                 let done_ev = json!({
@@ -783,6 +871,7 @@ where
                                                                     "output_index": tool_output_index,
                                                                     "item": item_obj
                                                                 });
+                                                                let done_ev = inject_seq(done_ev, &mut sequence_number);
                                                                 yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&done_ev).unwrap())));
 
                                                                 let tc_val = item_obj.clone();
@@ -805,12 +894,10 @@ where
                                                                         },
                                                                     );
                                                                 }
-                                                                // [FIX] 按发出顺序追踪输出项
                                                                 final_outputs_map.insert(tool_output_index, tc_val);
                                                             }
                                                         }
                                                     }
-
                                                 }
 
                                                 // 处理 groundingMetadata (搜索引文)
@@ -843,8 +930,10 @@ where
                                                             message_output_index = next_output_index;
                                                             next_output_index += 1;
                                                             let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "phase": "commentary", "status": "in_progress", "content": []}});
+                                                            let output_item_added = inject_seq(output_item_added, &mut sequence_number);
                                                             yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
                                                             let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": ""}});
+                                                            let content_part_added = inject_seq(content_part_added, &mut sequence_number);
                                                             yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_added).unwrap())));
                                                         }
                                                         accumulated_text.push_str(&grounding_text);
@@ -855,6 +944,7 @@ where
                                                             "content_index": 0,
                                                             "delta": grounding_text
                                                         });
+                                                        let delta_ev = inject_seq(delta_ev, &mut sequence_number);
                                                         yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&delta_ev).unwrap())));
                                                     }
                                                 }
@@ -868,17 +958,68 @@ where
                         None => break,
                     }
                 }
-                _ = heartbeat_interval.tick() => { yield Ok::<Bytes, String>(Bytes::from(": ping\n\n")); }
+                _ = heartbeat_interval.tick() => {
+                    yield Ok::<Bytes, String>(Bytes::from(": ping\n\n"));
+                }
             }
+        }
+
+        // 最终收尾时，若思考区还开着，则先闭合思考区
+        if reasoning_open {
+            let text_done = json!({
+                "type": "response.reasoning_summary_text.done",
+                "item_id": &active_reasoning_item_id,
+                "output_index": reasoning_output_index,
+                "summary_index": current_summary_index,
+                "text": &accumulated_thinking
+            });
+            let text_done = inject_seq(text_done, &mut sequence_number);
+            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&text_done).unwrap())));
+
+            let part_done = json!({
+                "type": "response.reasoning_summary_part.done",
+                "item_id": &active_reasoning_item_id,
+                "output_index": reasoning_output_index,
+                "summary_index": current_summary_index,
+                "part": {
+                    "type": "summary_text",
+                    "text": &accumulated_thinking
+                }
+            });
+            let part_done = inject_seq(part_done, &mut sequence_number);
+            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&part_done).unwrap())));
+
+            let reasoning_item = json!({
+                "type": "reasoning",
+                "status": "completed",
+                "id": &active_reasoning_item_id,
+                "summary": [{
+                    "type": "summary_text",
+                    "text": &accumulated_thinking
+                }]
+            });
+
+            let done_ev = json!({
+                "type": "response.output_item.done",
+                "output_index": reasoning_output_index,
+                "item": &reasoning_item
+            });
+            let done_ev = inject_seq(done_ev, &mut sequence_number);
+            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&done_ev).unwrap())));
+
+            final_outputs_map.insert(reasoning_output_index, reasoning_item);
+            reasoning_open = false;
         }
 
         let mut emit_empty = false;
         if !message_item_emitted && final_outputs_map.is_empty() {
             emit_empty = true;
-            message_output_index = next_output_index;
+            message_output_index = message_output_index;
             let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "phase": "commentary", "status": "in_progress", "content": []}});
+            let output_item_added = inject_seq(output_item_added, &mut sequence_number);
             yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
             let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": ""}});
+            let content_part_added = inject_seq(content_part_added, &mut sequence_number);
             yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_added).unwrap())));
         }
 
@@ -890,6 +1031,7 @@ where
                 "content_index": 0,
                 "text": &accumulated_text
             });
+            let text_done = inject_seq(text_done, &mut sequence_number);
             yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&text_done).unwrap())));
 
             let content_part_done = json!({
@@ -902,6 +1044,7 @@ where
                     "text": &accumulated_text
                 }
             });
+            let content_part_done = inject_seq(content_part_done, &mut sequence_number);
             yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_done).unwrap())));
 
             let message_item = json!({
@@ -921,6 +1064,7 @@ where
                 "output_index": message_output_index,
                 "item": message_item.clone()
             });
+            let output_item_done = inject_seq(output_item_done, &mut sequence_number);
             yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_done).unwrap())));
 
             final_outputs_map.insert(message_output_index, message_item);
@@ -968,6 +1112,7 @@ where
             }
         }
 
+        let completed_ev = inject_seq(completed_ev, &mut sequence_number);
         yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&completed_ev).unwrap())));
     };
     Box::pin(stream)

--- a/src-tauri/src/proxy/mappers/openai/streaming.rs
+++ b/src-tauri/src/proxy/mappers/openai/streaming.rs
@@ -547,7 +547,7 @@ pub fn create_codex_sse_stream<S, E>(
     model: String,
     session_id: String,
     message_count: usize,
-    assistant_turn_index: usize,
+    _assistant_turn_index: usize,
 ) -> Pin<Box<dyn Stream<Item = Result<Bytes, String>> + Send>>
 where
     S: Stream<Item = Result<Bytes, E>> + Send + ?Sized + 'static,
@@ -598,7 +598,6 @@ where
         let mut emitted_tool_calls = std::collections::HashSet::new();
         let mut accumulated_text = String::new();
         let mut accumulated_thinking = String::new();
-        let mut all_reasoning_text = String::new();
         let mut has_seen_tool_calls = false;
         let mut final_finish_reason: Option<String> = None;
 
@@ -696,14 +695,19 @@ where
                                                             yield Ok::<Bytes, String>(codex_sse_frame(&done_ev));
 
                                                             final_outputs_map.insert(reasoning_output_index, reasoning_item);
-                                                            all_reasoning_text.push_str(&accumulated_thinking);
                                                             reasoning_open = false;
                                                         }
 
                                                         if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
                                                             let clean_text = text.replace("<think>\n", "").replace("<think>", "").replace("\n</think>", "").replace("</think>", "");
                                                             if !clean_text.is_empty() {
-                                                                if is_thought {
+                                                                if is_thought && message_item_emitted {
+                                                                    // Once ordinary assistant text has started, it is the
+                                                                    // authoritative result for this response. A late thought
+                                                                    // delta must not be appended to it or open an overlapping
+                                                                    // commentary item.
+                                                                    tracing::warn!("[Codex-Stream] Dropping late thought delta after assistant text started");
+                                                                } else if is_thought {
                                                                     if !reasoning_open {
                                                                         reasoning_output_index = next_output_index;
                                                                         next_output_index += 1;
@@ -720,18 +724,6 @@ where
                                                                         yield Ok::<Bytes, String>(codex_sse_frame(&part_added));
 
                                                                         reasoning_open = true;
-
-                                                                        let prefix = "**Thinking**\n\n";
-                                                                        accumulated_thinking.push_str(prefix);
-                                                                        let prefix_ev = json!({
-                                                                            "type": "response.output_text.delta",
-                                                                            "item_id": &active_reasoning_item_id,
-                                                                            "output_index": reasoning_output_index,
-                                                                            "content_index": 0,
-                                                                            "delta": prefix
-                                                                        });
-                                                                        let prefix_ev = inject_seq(prefix_ev, &mut sequence_number);
-                                                                        yield Ok::<Bytes, String>(codex_sse_frame(&prefix_ev));
                                                                     }
 
                                                                     accumulated_thinking.push_str(&clean_text);
@@ -1061,7 +1053,6 @@ where
             yield Ok::<Bytes, String>(codex_sse_frame(&done_ev));
 
             final_outputs_map.insert(reasoning_output_index, reasoning_item);
-            all_reasoning_text.push_str(&accumulated_thinking);
         }
 
         // A proxy-generated diagnostic (for example an invalid apply_patch) may
@@ -1128,15 +1119,6 @@ where
             yield Ok::<Bytes, String>(codex_sse_frame(&output_item_done));
 
             final_outputs_map.insert(message_output_index, message_item);
-        }
-
-        // Cache the reasoning text for next turn
-        if !all_reasoning_text.is_empty() {
-            crate::proxy::SignatureCache::global().cache_session_reasoning(
-                &session_id,
-                all_reasoning_text,
-                assistant_turn_index,
-            );
         }
 
         let final_outputs: Vec<serde_json::Value> = final_outputs_map.into_values().collect();
@@ -1337,9 +1319,8 @@ mod tests {
         assert_eq!(output.len(), 2);
         assert_eq!(output[0]["type"], "message");
         assert_eq!(output[0]["phase"], "commentary");
-        assert!(output[0]["content"][0]["text"]
-            .as_str()
-            .is_some_and(|text| text.contains("Inspecting the workspace.")));
+        assert_eq!(output[0]["content"][0]["text"], "Inspecting the workspace.");
+        assert!(!raw.contains("**Thinking**"));
         assert_eq!(output[1]["type"], "function_call");
     }
 
@@ -1382,6 +1363,43 @@ mod tests {
         assert_eq!(terminal["type"], "response.completed");
         assert_eq!(terminal["response"]["status"], "completed");
         assert_eq!(terminal["response"]["output"][0]["phase"], "final_answer");
+        assert_eq!(
+            terminal["response"]["output"][0]["content"][0]["text"],
+            "The task is complete."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_codex_late_thought_does_not_mix_into_final_answer() {
+        let (raw, events) = collect_codex_stream(vec![
+            json!({
+                "candidates": [{
+                    "content": {"parts": [{"text": "The task is complete."}]}
+                }]
+            }),
+            json!({
+                "candidates": [{
+                    "content": {"parts": [{"text": "late private thought", "thought": true}]}
+                }]
+            }),
+            json!({
+                "candidates": [{
+                    "finishReason": "STOP",
+                    "content": {"parts": [{"text": ""}]}
+                }]
+            }),
+        ])
+        .await;
+
+        assert!(!raw.contains("late private thought"));
+        assert!(events.iter().all(|event| {
+            !(event["type"] == "response.output_item.added"
+                && event["item"]["id"]
+                    .as_str()
+                    .is_some_and(|id| id.starts_with("msg_thought_")))
+        }));
+        let terminal = events.last().expect("terminal event");
+        assert_eq!(terminal["type"], "response.completed");
         assert_eq!(
             terminal["response"]["output"][0]["content"][0]["text"],
             "The task is complete."

--- a/src-tauri/src/proxy/mappers/openai/streaming.rs
+++ b/src-tauri/src/proxy/mappers/openai/streaming.rs
@@ -528,9 +528,23 @@ fn inject_seq(mut event: Value, seq: &mut u64) -> Value {
     event
 }
 
+/// Serialize one named Responses API SSE frame.
+///
+/// Codex Desktop consumes the SSE `event` field as well as the JSON payload's
+/// `type`. Keeping both in sync matches the native Responses stream and avoids
+/// reasoning/tool lifecycle events being treated as anonymous data messages.
+fn codex_sse_frame(event: &Value) -> Bytes {
+    let event_name = event
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("message");
+    let payload = serde_json::to_string(event).unwrap_or_else(|_| "{}".to_string());
+    Bytes::from(format!("event: {event_name}\ndata: {payload}\n\n"))
+}
+
 pub fn create_codex_sse_stream<S, E>(
     mut gemini_stream: Pin<Box<S>>,
-    _model: String,
+    model: String,
     session_id: String,
     message_count: usize,
     assistant_turn_index: usize,
@@ -550,22 +564,43 @@ where
         .collect();
     let response_id = format!("resp-{}", random_str);
     let message_item_id = format!("msg_{}_0", &random_str[..16]);
+    let created_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
     let stream = async_stream::stream! {
         let mut sequence_number: u64 = 0;
 
-        // 1. response.created
-        let created_ev = json!({ "type": "response.created", "response": { "id": &response_id, "object": "response", "status": "in_progress", "output": [] } });
+        // Native Responses lifecycle: created must be followed by in_progress.
+        let lifecycle_response = json!({
+            "id": &response_id,
+            "object": "response",
+            "created_at": created_at,
+            "status": "in_progress",
+            "model": &model,
+            "output": [],
+            "error": null,
+            "incomplete_details": null,
+            "usage": null
+        });
+        let created_ev = json!({ "type": "response.created", "response": lifecycle_response.clone() });
         let created_ev = inject_seq(created_ev, &mut sequence_number);
-        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&created_ev).unwrap())));
+        yield Ok::<Bytes, String>(codex_sse_frame(&created_ev));
+        let in_progress_ev = json!({ "type": "response.in_progress", "response": lifecycle_response });
+        let in_progress_ev = inject_seq(in_progress_ev, &mut sequence_number);
+        yield Ok::<Bytes, String>(codex_sse_frame(&in_progress_ev));
 
         let mut message_item_emitted = false;
         let mut reasoning_open = false;
-        let mut current_summary_index: u32 = 0;
+        let mut reasoning_item_seq: u32 = 0;
         let mut active_reasoning_item_id = String::new();
 
         let mut emitted_tool_calls = std::collections::HashSet::new();
         let mut accumulated_text = String::new();
         let mut accumulated_thinking = String::new();
+        let mut all_reasoning_text = String::new();
+        let mut has_seen_tool_calls = false;
+        let mut final_finish_reason: Option<String> = None;
 
         let mut final_outputs_map: std::collections::BTreeMap<u32, serde_json::Value> = std::collections::BTreeMap::new();
         let mut next_output_index: u32 = 0;
@@ -601,10 +636,13 @@ where
                                                 tracing::debug!("[Codex-Stream-Debug] Raw Candidate: {:?}", candidates[0]);
                                             }
                                             if let Some(candidate) = candidates.get(0) {
+                                                if let Some(reason) = candidate.get("finishReason").and_then(Value::as_str) {
+                                                    final_finish_reason = Some(reason.to_string());
+                                                }
                                                 if let Some(parts) = candidate.get("content").and_then(|c| c.get("parts")).and_then(|p| p.as_array()) {
                                                     for part in parts {
                                                         let is_thought = part.get("thought").and_then(|v| v.as_bool()).unwrap_or(false);
-                                                        
+
                                                         // 切换到正文或工具时，若思考区开着，则先闭合思考区
                                                         let is_text_or_tool = part.get("text").is_some() || part.get("functionCall").is_some() || part.get("inlineData").is_some();
                                                         if is_text_or_tool && !is_thought && reasoning_open {
@@ -612,24 +650,24 @@ where
                                                                 "type": "response.reasoning_summary_text.done",
                                                                 "item_id": &active_reasoning_item_id,
                                                                 "output_index": reasoning_output_index,
-                                                                "summary_index": current_summary_index,
+                                                                "summary_index": 0,
                                                                 "text": &accumulated_thinking
                                                             });
                                                             let text_done = inject_seq(text_done, &mut sequence_number);
-                                                            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&text_done).unwrap())));
+                                                            yield Ok::<Bytes, String>(codex_sse_frame(&text_done));
 
                                                             let part_done = json!({
                                                                 "type": "response.reasoning_summary_part.done",
                                                                 "item_id": &active_reasoning_item_id,
                                                                 "output_index": reasoning_output_index,
-                                                                "summary_index": current_summary_index,
+                                                                "summary_index": 0,
                                                                 "part": {
                                                                     "type": "summary_text",
                                                                     "text": &accumulated_thinking
                                                                 }
                                                             });
                                                             let part_done = inject_seq(part_done, &mut sequence_number);
-                                                            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&part_done).unwrap())));
+                                                            yield Ok::<Bytes, String>(codex_sse_frame(&part_done));
 
                                                             let reasoning_item = json!({
                                                                 "type": "reasoning",
@@ -647,11 +685,11 @@ where
                                                                 "item": &reasoning_item
                                                             });
                                                             let done_ev = inject_seq(done_ev, &mut sequence_number);
-                                                            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&done_ev).unwrap())));
+                                                            yield Ok::<Bytes, String>(codex_sse_frame(&done_ev));
 
                                                             final_outputs_map.insert(reasoning_output_index, reasoning_item);
+                                                            all_reasoning_text.push_str(&accumulated_thinking);
                                                             reasoning_open = false;
-                                                            current_summary_index += 1;
                                                         }
 
                                                         if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
@@ -661,16 +699,17 @@ where
                                                                     if !reasoning_open {
                                                                         reasoning_output_index = next_output_index;
                                                                         next_output_index += 1;
-                                                                        active_reasoning_item_id = format!("item-{}-{}", &random_str[..16], current_summary_index);
+                                                                        active_reasoning_item_id = format!("rs_{}_{}", &random_str[..16], reasoning_item_seq);
+                                                                        reasoning_item_seq += 1;
                                                                         accumulated_thinking.clear();
 
                                                                         let output_item_added = json!({"type": "response.output_item.added", "output_index": reasoning_output_index, "item": {"id": &active_reasoning_item_id, "type": "reasoning", "status": "in_progress", "summary": []}});
                                                                         let output_item_added = inject_seq(output_item_added, &mut sequence_number);
-                                                                        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
+                                                                        yield Ok::<Bytes, String>(codex_sse_frame(&output_item_added));
 
-                                                                        let part_added = json!({"type": "response.reasoning_summary_part.added", "item_id": &active_reasoning_item_id, "output_index": reasoning_output_index, "summary_index": current_summary_index, "part": {"type": "summary_text", "text": ""}});
+                                                                        let part_added = json!({"type": "response.reasoning_summary_part.added", "item_id": &active_reasoning_item_id, "output_index": reasoning_output_index, "summary_index": 0, "part": {"type": "summary_text", "text": ""}});
                                                                         let part_added = inject_seq(part_added, &mut sequence_number);
-                                                                        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&part_added).unwrap())));
+                                                                        yield Ok::<Bytes, String>(codex_sse_frame(&part_added));
 
                                                                         reasoning_open = true;
 
@@ -680,11 +719,11 @@ where
                                                                             "type": "response.reasoning_summary_text.delta",
                                                                             "item_id": &active_reasoning_item_id,
                                                                             "output_index": reasoning_output_index,
-                                                                            "summary_index": current_summary_index,
+                                                                            "summary_index": 0,
                                                                             "delta": prefix
                                                                         });
                                                                         let prefix_ev = inject_seq(prefix_ev, &mut sequence_number);
-                                                                        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&prefix_ev).unwrap())));
+                                                                        yield Ok::<Bytes, String>(codex_sse_frame(&prefix_ev));
                                                                     }
 
                                                                     accumulated_thinking.push_str(&clean_text);
@@ -692,11 +731,11 @@ where
                                                                         "type": "response.reasoning_summary_text.delta",
                                                                         "item_id": &active_reasoning_item_id,
                                                                         "output_index": reasoning_output_index,
-                                                                        "summary_index": current_summary_index,
+                                                                        "summary_index": 0,
                                                                         "delta": clean_text
                                                                     });
                                                                     let delta_ev = inject_seq(delta_ev, &mut sequence_number);
-                                                                    yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&delta_ev).unwrap())));
+                                                                    yield Ok::<Bytes, String>(codex_sse_frame(&delta_ev));
                                                                 } else {
                                                                     if !message_item_emitted {
                                                                         message_item_emitted = true;
@@ -704,10 +743,10 @@ where
                                                                         next_output_index += 1;
                                                                         let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "phase": "commentary", "status": "in_progress", "content": []}});
                                                                         let output_item_added = inject_seq(output_item_added, &mut sequence_number);
-                                                                        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
-                                                                        let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": ""}});
+                                                                        yield Ok::<Bytes, String>(codex_sse_frame(&output_item_added));
+                                                                        let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": "", "annotations": []}});
                                                                         let content_part_added = inject_seq(content_part_added, &mut sequence_number);
-                                                                        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_added).unwrap())));
+                                                                        yield Ok::<Bytes, String>(codex_sse_frame(&content_part_added));
                                                                     }
 
                                                                     accumulated_text.push_str(&clean_text);
@@ -719,7 +758,7 @@ where
                                                                         "delta": clean_text
                                                                     });
                                                                     let delta_ev = inject_seq(delta_ev, &mut sequence_number);
-                                                                    yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&delta_ev).unwrap())));
+                                                                    yield Ok::<Bytes, String>(codex_sse_frame(&delta_ev));
                                                                 }
                                                             }
                                                         }
@@ -804,7 +843,7 @@ where
                                                                     crate::proxy::adapters::apply_patch_trace::emit(
                                                                         &crate::proxy::adapters::apply_patch_trace::ApplyPatchTrace {
                                                                             source: "gemini_native",
-                                                                            model: &_model,
+                                                                            model: &model,
                                                                             call_id: &call_id,
                                                                             fc_id: &tool_item_id,
                                                                             args_raw: &args_str,
@@ -825,6 +864,8 @@ where
                                                                     continue;
                                                                 }
 
+                                                                has_seen_tool_calls = true;
+
                                                                 let mut added_item = item_obj.clone();
                                                                 added_item["status"] = json!("in_progress");
                                                                 if is_custom_tool {
@@ -838,7 +879,7 @@ where
                                                                     "item": added_item
                                                                 });
                                                                 let added_ev = inject_seq(added_ev, &mut sequence_number);
-                                                                yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&added_ev).unwrap())));
+                                                                yield Ok::<Bytes, String>(codex_sse_frame(&added_ev));
 
                                                                 let mut delta_ev = json!({
                                                                     "type": if is_custom_tool { "response.custom_tool_call_input.delta" } else { "response.function_call_arguments.delta" },
@@ -850,7 +891,7 @@ where
                                                                     delta_ev["call_id"] = json!(&call_id);
                                                                 }
                                                                 let delta_ev = inject_seq(delta_ev, &mut sequence_number);
-                                                                yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&delta_ev).unwrap())));
+                                                                yield Ok::<Bytes, String>(codex_sse_frame(&delta_ev));
 
                                                                 let mut args_done_ev = json!({
                                                                     "type": if is_custom_tool { "response.custom_tool_call_input.done" } else { "response.function_call_arguments.done" },
@@ -864,7 +905,7 @@ where
                                                                     args_done_ev["arguments"] = json!(&final_args_str);
                                                                 }
                                                                 let args_done_ev = inject_seq(args_done_ev, &mut sequence_number);
-                                                                yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&args_done_ev).unwrap())));
+                                                                yield Ok::<Bytes, String>(codex_sse_frame(&args_done_ev));
 
                                                                 let done_ev = json!({
                                                                     "type": "response.output_item.done",
@@ -872,7 +913,7 @@ where
                                                                     "item": item_obj
                                                                 });
                                                                 let done_ev = inject_seq(done_ev, &mut sequence_number);
-                                                                yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&done_ev).unwrap())));
+                                                                yield Ok::<Bytes, String>(codex_sse_frame(&done_ev));
 
                                                                 let tc_val = item_obj.clone();
                                                                 crate::proxy::handlers::openai::insert_cached_tool_call(call_id.clone(), tc_val.clone());
@@ -880,7 +921,7 @@ where
                                                                     crate::proxy::adapters::apply_patch_trace::emit(
                                                                         &crate::proxy::adapters::apply_patch_trace::ApplyPatchTrace {
                                                                             source: "gemini_native",
-                                                                            model: &_model,
+                                                                            model: &model,
                                                                             call_id: &call_id,
                                                                             fc_id: &tool_item_id,
                                                                             args_raw: &args_str,
@@ -931,10 +972,10 @@ where
                                                             next_output_index += 1;
                                                             let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "phase": "commentary", "status": "in_progress", "content": []}});
                                                             let output_item_added = inject_seq(output_item_added, &mut sequence_number);
-                                                            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
-                                                            let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": ""}});
+                                                            yield Ok::<Bytes, String>(codex_sse_frame(&output_item_added));
+                                                            let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": "", "annotations": []}});
                                                             let content_part_added = inject_seq(content_part_added, &mut sequence_number);
-                                                            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_added).unwrap())));
+                                                            yield Ok::<Bytes, String>(codex_sse_frame(&content_part_added));
                                                         }
                                                         accumulated_text.push_str(&grounding_text);
                                                         let delta_ev = json!({
@@ -945,7 +986,7 @@ where
                                                             "delta": grounding_text
                                                         });
                                                         let delta_ev = inject_seq(delta_ev, &mut sequence_number);
-                                                        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&delta_ev).unwrap())));
+                                                        yield Ok::<Bytes, String>(codex_sse_frame(&delta_ev));
                                                     }
                                                 }
                                             }
@@ -970,24 +1011,24 @@ where
                 "type": "response.reasoning_summary_text.done",
                 "item_id": &active_reasoning_item_id,
                 "output_index": reasoning_output_index,
-                "summary_index": current_summary_index,
+                "summary_index": 0,
                 "text": &accumulated_thinking
             });
             let text_done = inject_seq(text_done, &mut sequence_number);
-            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&text_done).unwrap())));
+            yield Ok::<Bytes, String>(codex_sse_frame(&text_done));
 
             let part_done = json!({
                 "type": "response.reasoning_summary_part.done",
                 "item_id": &active_reasoning_item_id,
                 "output_index": reasoning_output_index,
-                "summary_index": current_summary_index,
+                "summary_index": 0,
                 "part": {
                     "type": "summary_text",
                     "text": &accumulated_thinking
                 }
             });
             let part_done = inject_seq(part_done, &mut sequence_number);
-            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&part_done).unwrap())));
+            yield Ok::<Bytes, String>(codex_sse_frame(&part_done));
 
             let reasoning_item = json!({
                 "type": "reasoning",
@@ -1005,25 +1046,27 @@ where
                 "item": &reasoning_item
             });
             let done_ev = inject_seq(done_ev, &mut sequence_number);
-            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&done_ev).unwrap())));
+            yield Ok::<Bytes, String>(codex_sse_frame(&done_ev));
 
             final_outputs_map.insert(reasoning_output_index, reasoning_item);
-            reasoning_open = false;
+            all_reasoning_text.push_str(&accumulated_thinking);
         }
 
-        let mut emit_empty = false;
-        if !message_item_emitted && final_outputs_map.is_empty() {
-            emit_empty = true;
-            message_output_index = message_output_index;
+        // A proxy-generated diagnostic (for example an invalid apply_patch) may
+        // only become available after the upstream stream has ended. Open the
+        // message lazily here so it is not silently dropped behind reasoning.
+        if !message_item_emitted && !accumulated_text.is_empty() {
+            message_item_emitted = true;
+            message_output_index = next_output_index;
             let output_item_added = json!({"type": "response.output_item.added", "output_index": message_output_index, "item": {"id": &message_item_id, "type": "message", "role": "assistant", "phase": "commentary", "status": "in_progress", "content": []}});
             let output_item_added = inject_seq(output_item_added, &mut sequence_number);
-            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_added).unwrap())));
-            let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": ""}});
+            yield Ok::<Bytes, String>(codex_sse_frame(&output_item_added));
+            let content_part_added = json!({"type": "response.content_part.added", "item_id": &message_item_id, "output_index": message_output_index, "content_index": 0, "part": {"type": "output_text", "text": "", "annotations": []}});
             let content_part_added = inject_seq(content_part_added, &mut sequence_number);
-            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_added).unwrap())));
+            yield Ok::<Bytes, String>(codex_sse_frame(&content_part_added));
         }
 
-        if message_item_emitted || emit_empty {
+        if message_item_emitted {
             let text_done = json!({
                 "type": "response.output_text.done",
                 "item_id": &message_item_id,
@@ -1032,7 +1075,7 @@ where
                 "text": &accumulated_text
             });
             let text_done = inject_seq(text_done, &mut sequence_number);
-            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&text_done).unwrap())));
+            yield Ok::<Bytes, String>(codex_sse_frame(&text_done));
 
             let content_part_done = json!({
                 "type": "response.content_part.done",
@@ -1041,21 +1084,26 @@ where
                 "content_index": 0,
                 "part": {
                     "type": "output_text",
-                    "text": &accumulated_text
+                    "text": &accumulated_text,
+                    "annotations": []
                 }
             });
             let content_part_done = inject_seq(content_part_done, &mut sequence_number);
-            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&content_part_done).unwrap())));
+            yield Ok::<Bytes, String>(codex_sse_frame(&content_part_done));
 
+            // Tool rounds are process commentary. Only a response with no tool
+            // call is the authoritative final answer that remains expanded.
+            let message_phase = if has_seen_tool_calls { "commentary" } else { "final_answer" };
             let message_item = json!({
                 "id": &message_item_id,
                 "type": "message",
                 "role": "assistant",
-                "phase": "final_answer",
+                "phase": message_phase,
                 "status": "completed",
                 "content": [{
                     "type": "output_text",
-                    "text": &accumulated_text
+                    "text": &accumulated_text,
+                    "annotations": []
                 }]
             });
 
@@ -1065,29 +1113,86 @@ where
                 "item": message_item.clone()
             });
             let output_item_done = inject_seq(output_item_done, &mut sequence_number);
-            yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&output_item_done).unwrap())));
+            yield Ok::<Bytes, String>(codex_sse_frame(&output_item_done));
 
             final_outputs_map.insert(message_output_index, message_item);
         }
 
         // Cache the reasoning text for next turn
-        if !accumulated_thinking.is_empty() {
+        if !all_reasoning_text.is_empty() {
             crate::proxy::SignatureCache::global().cache_session_reasoning(
                 &session_id,
-                accumulated_thinking,
+                all_reasoning_text,
                 assistant_turn_index,
             );
         }
 
-        let mut final_outputs: Vec<serde_json::Value> = final_outputs_map.into_values().collect();
+        let final_outputs: Vec<serde_json::Value> = final_outputs_map.into_values().collect();
+
+        let missing_actionable_output = !message_item_emitted && !has_seen_tool_calls;
+        let terminal_status = if missing_actionable_output {
+            "incomplete"
+        } else {
+            match final_finish_reason.as_deref() {
+                Some("MAX_TOKENS")
+                | Some("SAFETY")
+                | Some("RECITATION")
+                | Some("BLOCKLIST")
+                | Some("PROHIBITED_CONTENT")
+                | Some("SPII")
+                | Some("IMAGE_SAFETY")
+                | Some("IMAGE_PROHIBITED_CONTENT")
+                | None => "incomplete",
+                _ => "completed",
+            }
+        };
+        let terminal_type = format!("response.{terminal_status}");
+        let incomplete_details = if terminal_status == "incomplete" {
+            let reason = match final_finish_reason.as_deref() {
+                Some("MAX_TOKENS") => "max_output_tokens",
+                Some("SAFETY")
+                | Some("RECITATION")
+                | Some("BLOCKLIST")
+                | Some("PROHIBITED_CONTENT")
+                | Some("SPII")
+                | Some("IMAGE_SAFETY")
+                | Some("IMAGE_PROHIBITED_CONTENT") => "content_filter",
+                _ => "interrupted",
+            };
+            json!({"reason": reason})
+        } else {
+            Value::Null
+        };
+        let terminal_error = if missing_actionable_output {
+            json!({
+                "code": "empty_response",
+                "message": "Gemini stream ended without a final assistant message or tool call."
+            })
+        } else if final_finish_reason.is_none() {
+            json!({
+                "code": "upstream_interrupted",
+                "message": "Gemini stream ended without finishReason."
+            })
+        } else {
+            Value::Null
+        };
+        let completed_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
 
         let mut completed_ev = json!({
-            "type": "response.completed",
+            "type": terminal_type,
             "response": {
                 "id": &response_id,
                 "object": "response",
-                "status": "completed",
-                "output": final_outputs
+                "created_at": created_at,
+                "completed_at": completed_at,
+                "status": terminal_status,
+                "model": &model,
+                "output": final_outputs,
+                "incomplete_details": incomplete_details,
+                "error": terminal_error
             }
         });
 
@@ -1113,7 +1218,7 @@ where
         }
 
         let completed_ev = inject_seq(completed_ev, &mut sequence_number);
-        yield Ok::<Bytes, String>(Bytes::from(format!("data: {}\n\n", serde_json::to_string(&completed_ev).unwrap())));
+        yield Ok::<Bytes, String>(codex_sse_frame(&completed_ev));
     };
     Box::pin(stream)
 }
@@ -1123,6 +1228,208 @@ mod tests {
     use super::*;
     use futures::stream;
     use serde_json::json;
+
+    async fn collect_codex_stream(chunks: Vec<Value>) -> (String, Vec<Value>) {
+        let items: Vec<Result<Bytes, String>> = chunks
+            .into_iter()
+            .map(|chunk| Ok(Bytes::from(format!("data: {chunk}\n\n"))))
+            .collect();
+        let mut stream = create_codex_sse_stream(
+            Box::pin(stream::iter(items)),
+            "gemini-pro-agent".to_string(),
+            "test-codex-session".to_string(),
+            0,
+            0,
+        );
+
+        let mut raw = String::new();
+        while let Some(item) = stream.next().await {
+            raw.push_str(&String::from_utf8_lossy(&item.expect("codex stream item")));
+        }
+        let events = raw
+            .lines()
+            .filter_map(|line| line.strip_prefix("data: "))
+            .filter_map(|data| serde_json::from_str::<Value>(data).ok())
+            .collect();
+        (raw, events)
+    }
+
+    #[tokio::test]
+    async fn test_codex_reasoning_and_tool_are_distinct_named_output_items() {
+        let (raw, events) = collect_codex_stream(vec![
+            json!({
+                "response": {
+                    "candidates": [{
+                        "content": {"parts": [{"text": "Inspecting the workspace.", "thought": true}]}
+                    }]
+                }
+            }),
+            json!({
+                "response": {
+                    "candidates": [{
+                        "content": {"parts": [{
+                            "functionCall": {"name": "shell_command", "args": {"command": "Get-ChildItem"}}
+                        }]}
+                    }]
+                }
+            }),
+            json!({
+                "response": {
+                    "candidates": [{
+                        "finishReason": "STOP",
+                        "content": {"parts": [{"text": ""}]}
+                    }]
+                }
+            }),
+        ])
+        .await;
+
+        assert!(raw.starts_with("event: response.created\ndata: "));
+        let names: Vec<&str> = events
+            .iter()
+            .filter_map(|event| event["type"].as_str())
+            .collect();
+        assert_eq!(names[0], "response.created");
+        assert_eq!(names[1], "response.in_progress");
+        assert!(names.contains(&"response.reasoning_summary_text.delta"));
+        assert!(names.contains(&"response.function_call_arguments.delta"));
+        assert_eq!(names.last().copied(), Some("response.completed"));
+
+        for (expected, event) in events.iter().enumerate() {
+            assert_eq!(event["sequence_number"], expected as u64);
+        }
+        assert!(events
+            .iter()
+            .filter(|event| event["type"] == "response.reasoning_summary_text.delta")
+            .all(|event| event["summary_index"] == 0));
+
+        let added: Vec<&Value> = events
+            .iter()
+            .filter(|event| event["type"] == "response.output_item.added")
+            .collect();
+        assert_eq!(added.len(), 2);
+        assert_eq!(added[0]["item"]["type"], "reasoning");
+        assert!(added[0]["item"]["id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("rs_")));
+        assert_eq!(added[0]["output_index"], 0);
+        assert_eq!(added[1]["item"]["type"], "function_call");
+        assert_eq!(added[1]["output_index"], 1);
+
+        let completed = events.last().expect("terminal event");
+        let output = completed["response"]["output"]
+            .as_array()
+            .expect("completed output");
+        assert_eq!(output.len(), 2);
+        assert_eq!(output[0]["type"], "reasoning");
+        assert_eq!(output[1]["type"], "function_call");
+    }
+
+    #[tokio::test]
+    async fn test_codex_final_message_is_promoted_and_persisted() {
+        let (_, events) = collect_codex_stream(vec![
+            json!({
+                "candidates": [{
+                    "content": {"parts": [{"text": "The task is complete."}]}
+                }]
+            }),
+            json!({
+                "candidates": [{
+                    "finishReason": "STOP",
+                    "content": {"parts": [{"text": ""}]}
+                }]
+            }),
+        ])
+        .await;
+
+        let added = events
+            .iter()
+            .find(|event| {
+                event["type"] == "response.output_item.added" && event["item"]["type"] == "message"
+            })
+            .expect("message added");
+        assert_eq!(added["item"]["phase"], "commentary");
+
+        let done = events
+            .iter()
+            .find(|event| {
+                event["type"] == "response.output_item.done" && event["item"]["type"] == "message"
+            })
+            .expect("message done");
+        assert_eq!(done["item"]["phase"], "final_answer");
+        assert_eq!(done["item"]["content"][0]["text"], "The task is complete.");
+        assert_eq!(done["item"]["content"][0]["annotations"], json!([]));
+
+        let terminal = events.last().expect("terminal event");
+        assert_eq!(terminal["type"], "response.completed");
+        assert_eq!(terminal["response"]["status"], "completed");
+        assert_eq!(terminal["response"]["output"][0]["phase"], "final_answer");
+        assert_eq!(
+            terminal["response"]["output"][0]["content"][0]["text"],
+            "The task is complete."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_codex_tool_round_message_stays_commentary() {
+        let (_, events) = collect_codex_stream(vec![
+            json!({
+                "candidates": [{
+                    "content": {"parts": [{"text": "I will inspect the files first."}]}
+                }]
+            }),
+            json!({
+                "candidates": [{
+                    "content": {"parts": [{
+                        "functionCall": {"name": "shell_command", "args": {"command": "Get-ChildItem"}}
+                    }]}
+                }]
+            }),
+            json!({
+                "candidates": [{
+                    "finishReason": "STOP",
+                    "content": {"parts": [{"text": ""}]}
+                }]
+            }),
+        ])
+        .await;
+
+        let message_done = events
+            .iter()
+            .find(|event| {
+                event["type"] == "response.output_item.done" && event["item"]["type"] == "message"
+            })
+            .expect("message done");
+        assert_eq!(message_done["item"]["phase"], "commentary");
+
+        let terminal = events.last().expect("terminal event");
+        assert_eq!(terminal["type"], "response.completed");
+        let output = terminal["response"]["output"]
+            .as_array()
+            .expect("completed output");
+        assert_eq!(output[0]["type"], "message");
+        assert_eq!(output[0]["phase"], "commentary");
+        assert_eq!(output[1]["type"], "function_call");
+    }
+
+    #[tokio::test]
+    async fn test_codex_empty_stop_is_incomplete_instead_of_blank_final_answer() {
+        let (_, events) = collect_codex_stream(vec![json!({
+            "candidates": [{
+                "finishReason": "STOP",
+                "content": {"parts": [{"text": ""}]}
+            }]
+        })])
+        .await;
+
+        assert!(events.iter().all(|event| {
+            !(event["type"] == "response.output_item.added" && event["item"]["type"] == "message")
+        }));
+        let terminal = events.last().expect("terminal event");
+        assert_eq!(terminal["type"], "response.incomplete");
+        assert_eq!(terminal["response"]["status"], "incomplete");
+        assert_eq!(terminal["response"]["error"]["code"], "empty_response");
+    }
 
     #[tokio::test]
     async fn test_openai_streaming_usage_only_at_end() {
@@ -1227,9 +1534,8 @@ mod tests {
             }]
         });
 
-        let items: Vec<Result<Bytes, reqwest::Error>> = vec![
-            Ok(Bytes::from(format!("data: {}\n\n", chunk_json))),
-        ];
+        let items: Vec<Result<Bytes, reqwest::Error>> =
+            vec![Ok(Bytes::from(format!("data: {}\n\n", chunk_json)))];
 
         let gemini_stream = Box::pin(stream::iter(items));
 

--- a/src-tauri/src/proxy/mappers/openai/streaming.rs
+++ b/src-tauri/src/proxy/mappers/openai/streaming.rs
@@ -643,39 +643,47 @@ where
                                                     for part in parts {
                                                         let is_thought = part.get("thought").and_then(|v| v.as_bool()).unwrap_or(false);
 
-                                                        // 切换到正文或工具时，若思考区开着，则先闭合思考区
+                                                        // Codex Desktop renders `reasoning` as compact/ephemeral status
+                                                        // text. The durable, large transcript block in the "Working"
+                                                        // section is an assistant `message` with phase=commentary.
+                                                        // Close that synthetic thought message before opening normal text
+                                                        // or a tool item so output item lifecycles never overlap.
                                                         let is_text_or_tool = part.get("text").is_some() || part.get("functionCall").is_some() || part.get("inlineData").is_some();
                                                         if is_text_or_tool && !is_thought && reasoning_open {
                                                             let text_done = json!({
-                                                                "type": "response.reasoning_summary_text.done",
+                                                                "type": "response.output_text.done",
                                                                 "item_id": &active_reasoning_item_id,
                                                                 "output_index": reasoning_output_index,
-                                                                "summary_index": 0,
+                                                                "content_index": 0,
                                                                 "text": &accumulated_thinking
                                                             });
                                                             let text_done = inject_seq(text_done, &mut sequence_number);
                                                             yield Ok::<Bytes, String>(codex_sse_frame(&text_done));
 
-                                                            let part_done = json!({
-                                                                "type": "response.reasoning_summary_part.done",
+                                                            let content_part_done = json!({
+                                                                "type": "response.content_part.done",
                                                                 "item_id": &active_reasoning_item_id,
                                                                 "output_index": reasoning_output_index,
-                                                                "summary_index": 0,
+                                                                "content_index": 0,
                                                                 "part": {
-                                                                    "type": "summary_text",
-                                                                    "text": &accumulated_thinking
+                                                                    "type": "output_text",
+                                                                    "text": &accumulated_thinking,
+                                                                    "annotations": []
                                                                 }
                                                             });
-                                                            let part_done = inject_seq(part_done, &mut sequence_number);
-                                                            yield Ok::<Bytes, String>(codex_sse_frame(&part_done));
+                                                            let content_part_done = inject_seq(content_part_done, &mut sequence_number);
+                                                            yield Ok::<Bytes, String>(codex_sse_frame(&content_part_done));
 
                                                             let reasoning_item = json!({
-                                                                "type": "reasoning",
-                                                                "status": "completed",
                                                                 "id": &active_reasoning_item_id,
-                                                                "summary": [{
-                                                                    "type": "summary_text",
-                                                                    "text": &accumulated_thinking
+                                                                "type": "message",
+                                                                "role": "assistant",
+                                                                "phase": "commentary",
+                                                                "status": "completed",
+                                                                "content": [{
+                                                                    "type": "output_text",
+                                                                    "text": &accumulated_thinking,
+                                                                    "annotations": []
                                                                 }]
                                                             });
 
@@ -699,15 +707,15 @@ where
                                                                     if !reasoning_open {
                                                                         reasoning_output_index = next_output_index;
                                                                         next_output_index += 1;
-                                                                        active_reasoning_item_id = format!("rs_{}_{}", &random_str[..16], reasoning_item_seq);
+                                                                        active_reasoning_item_id = format!("msg_thought_{}_{}", &random_str[..16], reasoning_item_seq);
                                                                         reasoning_item_seq += 1;
                                                                         accumulated_thinking.clear();
 
-                                                                        let output_item_added = json!({"type": "response.output_item.added", "output_index": reasoning_output_index, "item": {"id": &active_reasoning_item_id, "type": "reasoning", "status": "in_progress", "summary": []}});
+                                                                        let output_item_added = json!({"type": "response.output_item.added", "output_index": reasoning_output_index, "item": {"id": &active_reasoning_item_id, "type": "message", "role": "assistant", "phase": "commentary", "status": "in_progress", "content": []}});
                                                                         let output_item_added = inject_seq(output_item_added, &mut sequence_number);
                                                                         yield Ok::<Bytes, String>(codex_sse_frame(&output_item_added));
 
-                                                                        let part_added = json!({"type": "response.reasoning_summary_part.added", "item_id": &active_reasoning_item_id, "output_index": reasoning_output_index, "summary_index": 0, "part": {"type": "summary_text", "text": ""}});
+                                                                        let part_added = json!({"type": "response.content_part.added", "item_id": &active_reasoning_item_id, "output_index": reasoning_output_index, "content_index": 0, "part": {"type": "output_text", "text": "", "annotations": []}});
                                                                         let part_added = inject_seq(part_added, &mut sequence_number);
                                                                         yield Ok::<Bytes, String>(codex_sse_frame(&part_added));
 
@@ -716,10 +724,10 @@ where
                                                                         let prefix = "**Thinking**\n\n";
                                                                         accumulated_thinking.push_str(prefix);
                                                                         let prefix_ev = json!({
-                                                                            "type": "response.reasoning_summary_text.delta",
+                                                                            "type": "response.output_text.delta",
                                                                             "item_id": &active_reasoning_item_id,
                                                                             "output_index": reasoning_output_index,
-                                                                            "summary_index": 0,
+                                                                            "content_index": 0,
                                                                             "delta": prefix
                                                                         });
                                                                         let prefix_ev = inject_seq(prefix_ev, &mut sequence_number);
@@ -728,10 +736,10 @@ where
 
                                                                     accumulated_thinking.push_str(&clean_text);
                                                                     let delta_ev = json!({
-                                                                        "type": "response.reasoning_summary_text.delta",
+                                                                        "type": "response.output_text.delta",
                                                                         "item_id": &active_reasoning_item_id,
                                                                         "output_index": reasoning_output_index,
-                                                                        "summary_index": 0,
+                                                                        "content_index": 0,
                                                                         "delta": clean_text
                                                                     });
                                                                     let delta_ev = inject_seq(delta_ev, &mut sequence_number);
@@ -1005,38 +1013,42 @@ where
             }
         }
 
-        // 最终收尾时，若思考区还开着，则先闭合思考区
+        // 最终收尾时，若可见思考 commentary 还开着，则先物化为完整 message。
         if reasoning_open {
             let text_done = json!({
-                "type": "response.reasoning_summary_text.done",
+                "type": "response.output_text.done",
                 "item_id": &active_reasoning_item_id,
                 "output_index": reasoning_output_index,
-                "summary_index": 0,
+                "content_index": 0,
                 "text": &accumulated_thinking
             });
             let text_done = inject_seq(text_done, &mut sequence_number);
             yield Ok::<Bytes, String>(codex_sse_frame(&text_done));
 
-            let part_done = json!({
-                "type": "response.reasoning_summary_part.done",
+            let content_part_done = json!({
+                "type": "response.content_part.done",
                 "item_id": &active_reasoning_item_id,
                 "output_index": reasoning_output_index,
-                "summary_index": 0,
+                "content_index": 0,
                 "part": {
-                    "type": "summary_text",
-                    "text": &accumulated_thinking
+                    "type": "output_text",
+                    "text": &accumulated_thinking,
+                    "annotations": []
                 }
             });
-            let part_done = inject_seq(part_done, &mut sequence_number);
-            yield Ok::<Bytes, String>(codex_sse_frame(&part_done));
+            let content_part_done = inject_seq(content_part_done, &mut sequence_number);
+            yield Ok::<Bytes, String>(codex_sse_frame(&content_part_done));
 
             let reasoning_item = json!({
-                "type": "reasoning",
-                "status": "completed",
                 "id": &active_reasoning_item_id,
-                "summary": [{
-                    "type": "summary_text",
-                    "text": &accumulated_thinking
+                "type": "message",
+                "role": "assistant",
+                "phase": "commentary",
+                "status": "completed",
+                "content": [{
+                    "type": "output_text",
+                    "text": &accumulated_thinking,
+                    "annotations": []
                 }]
             });
 
@@ -1255,7 +1267,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_codex_reasoning_and_tool_are_distinct_named_output_items() {
+    async fn test_codex_visible_thought_commentary_and_tool_are_distinct_output_items() {
         let (raw, events) = collect_codex_stream(vec![
             json!({
                 "response": {
@@ -1291,7 +1303,8 @@ mod tests {
             .collect();
         assert_eq!(names[0], "response.created");
         assert_eq!(names[1], "response.in_progress");
-        assert!(names.contains(&"response.reasoning_summary_text.delta"));
+        assert!(names.contains(&"response.output_text.delta"));
+        assert!(!names.contains(&"response.reasoning_summary_text.delta"));
         assert!(names.contains(&"response.function_call_arguments.delta"));
         assert_eq!(names.last().copied(), Some("response.completed"));
 
@@ -1300,18 +1313,19 @@ mod tests {
         }
         assert!(events
             .iter()
-            .filter(|event| event["type"] == "response.reasoning_summary_text.delta")
-            .all(|event| event["summary_index"] == 0));
+            .filter(|event| event["type"] == "response.output_text.delta")
+            .all(|event| event["content_index"] == 0));
 
         let added: Vec<&Value> = events
             .iter()
             .filter(|event| event["type"] == "response.output_item.added")
             .collect();
         assert_eq!(added.len(), 2);
-        assert_eq!(added[0]["item"]["type"], "reasoning");
+        assert_eq!(added[0]["item"]["type"], "message");
+        assert_eq!(added[0]["item"]["phase"], "commentary");
         assert!(added[0]["item"]["id"]
             .as_str()
-            .is_some_and(|id| id.starts_with("rs_")));
+            .is_some_and(|id| id.starts_with("msg_thought_")));
         assert_eq!(added[0]["output_index"], 0);
         assert_eq!(added[1]["item"]["type"], "function_call");
         assert_eq!(added[1]["output_index"], 1);
@@ -1321,7 +1335,11 @@ mod tests {
             .as_array()
             .expect("completed output");
         assert_eq!(output.len(), 2);
-        assert_eq!(output[0]["type"], "reasoning");
+        assert_eq!(output[0]["type"], "message");
+        assert_eq!(output[0]["phase"], "commentary");
+        assert!(output[0]["content"][0]["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("Inspecting the workspace.")));
         assert_eq!(output[1]["type"], "function_call");
     }
 

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -443,6 +443,8 @@ impl AxumServer {
                 post(handlers::openai::handle_completions)
                     .get(handlers::openai::handle_responses_websocket),
             ) // 兼容 Codex CLI
+            .route("/responses", post(handlers::openai::handle_completions))
+            .route("/responses/compact", post(handlers::openai::handle_completions))
             .route(
                 "/v1/images/generations",
                 post(handlers::openai::handle_images_generations),


### PR DESCRIPTION
规范化流式响应格式，使得思考内容可以显示
修复gemini-pro-agent，实际上是gemini-3.1-pro-high模型无法注入思考程度的bug
但仍存在问题，codex内图片会污染上下文使得token剧增，准备清洗图片格式的上下文，或者恢复gemini原生的图片读取