### PR TITLE
fix(proxy): add model mapping for claude-opus-4.6-thinking and resolve upstream merge conflicts

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -45,8 +45,8 @@
       background-color: transparent;
     }
   </style>
-  <script type="module" crossorigin src="./assets/index-CE5Lm9v4.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/index-CR8w2ZjV.css">
+  <script type="module" crossorigin src="./assets/index-Db-F_z6k.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/index-MX4Gcsgv.css">
 </head>
 
 <body style="margin: 0; background-color: #1a1f2e;">

--- a/docs/gemini-3-image-guide.md
+++ b/docs/gemini-3-image-guide.md
@@ -112,7 +112,7 @@ print(response.json())
 | `image_size` | String | 否 | 显式指定分辨率，如 `"2K"`, `"4K"` (优先级高于 `quality`) |
 | `style` | String | 否 | 风格描述，会自动追加到 Prompt 中 |
 | `n` | Integer | 否 | 生成数量 (默认 1) |
-| `model` | String | 否 | 模型名称 (默认 `gemini-3-pro-image`) |
+| `model` | String | 否 | 模型名称 (默认 `gemini-3.1-flash-image`) |
 
 ### 调用示例 (Python)
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
 name = "antigravity_tools"
-version = "4.3.8"
+version = "4.3.9"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/src/models/account.rs
+++ b/src-tauri/src/models/account.rs
@@ -1,6 +1,17 @@
 use super::{quota::QuotaData, token::TokenData};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiveLimitStatus {
+    pub model: String,
+    pub status: u16,
+    pub reason: String,
+    pub until: i64,
+    pub detected_at: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
 
 /// 账号数据结构
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -37,6 +48,9 @@ pub struct Account {
     /// 受配额保护禁用的模型列表 [NEW #621]
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub protected_models: HashSet<String>,
+    /// Temporary live upstream throttles observed from actual generation requests.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub live_limited_models: HashMap<String, LiveLimitStatus>,
     /// [NEW] 403 验证阻止状态 (VALIDATION_REQUIRED)
     #[serde(default)]
     pub validation_blocked: bool,
@@ -80,6 +94,7 @@ impl Account {
             proxy_disabled_reason: None,
             proxy_disabled_at: None,
             protected_models: HashSet::new(),
+            live_limited_models: HashMap::new(),
             validation_blocked: false,
             validation_blocked_until: None,
             validation_blocked_reason: None,

--- a/src-tauri/src/models/config.rs
+++ b/src-tauri/src/models/config.rs
@@ -49,7 +49,7 @@ fn default_warmup_models() -> Vec<String> {
         "gemini-3-flash".to_string(),
         "claude".to_string(),
         "gemini-3-pro-high".to_string(),
-        "gemini-3-pro-image".to_string(),
+        "gemini-3.1-flash-image".to_string(),
     ]
 }
 
@@ -87,7 +87,7 @@ fn default_monitored_models() -> Vec<String> {
         "claude".to_string(),
         "gemini-3-pro-high".to_string(),
         "gemini-3-flash".to_string(),
-        "gemini-3-pro-image".to_string(),
+        "gemini-3.1-flash-image".to_string(),
     ]
 }
 
@@ -119,7 +119,7 @@ fn default_pinned_models() -> Vec<String> {
     vec![
         "gemini-3-pro-high".to_string(),
         "gemini-3-flash".to_string(),
-        "gemini-3-pro-image".to_string(),
+        "gemini-3.1-flash-image".to_string(),
         "claude-sonnet-4-6-thinking".to_string(),
     ]
 }

--- a/src-tauri/src/modules/http_api.rs
+++ b/src-tauri/src/modules/http_api.rs
@@ -11,6 +11,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 // 预留 HTTP API 模块，当前未在主流程中启用
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tower_http::cors::{Any, CorsLayer};
@@ -115,6 +116,7 @@ struct AccountResponse {
     name: Option<String>,
     is_current: bool,
     disabled: bool,
+    live_limited_models: HashMap<String, crate::models::account::LiveLimitStatus>,
     quota: Option<QuotaResponse>,
     device_bound: bool,
     last_used: i64,
@@ -262,6 +264,7 @@ async fn list_accounts() -> Result<impl IntoResponse, (StatusCode, Json<ErrorRes
                 name: acc.name,
                 is_current,
                 disabled: acc.disabled,
+                live_limited_models: acc.live_limited_models,
                 quota,
                 device_bound: acc.device_profile.is_some(),
                 last_used: acc.last_used,
@@ -305,6 +308,7 @@ async fn get_current_account() -> Result<impl IntoResponse, (StatusCode, Json<Er
             name: acc.name,
             is_current: true,
             disabled: acc.disabled,
+            live_limited_models: acc.live_limited_models,
             quota,
             device_bound: acc.device_profile.is_some(),
             last_used: acc.last_used,

--- a/src-tauri/src/modules/quota.rs
+++ b/src-tauri/src/modules/quota.rs
@@ -397,6 +397,7 @@ pub async fn fetch_quota_with_cache(
                     // Parse deprecated model routing rules
                     if let Some(deprecated) = quota_response.deprecated_model_ids {
                         for (old_id, info) in deprecated {
+                            // Register forwarding rules (including those mapping to gemini-pro-agent)
                             quota_data
                                 .model_forwarding_rules
                                 .insert(old_id, info.new_model_id);

--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -230,7 +230,7 @@ pub fn update_tray_menus(app: &tauri::AppHandle) {
                             if name == "gemini-3.1-pro-high" || name == "gemini-3-pro-high" {
                                 gemini_high = m.percentage;
                             }
-                            if name == "gemini-3-pro-image" {
+                            if name == "gemini-3.1-flash-image" || name == "gemini-3-pro-image" {
                                 gemini_image = m.percentage;
                             }
                             if name == "claude-sonnet-4-6" || name == "claude-sonnet-4-5" {

--- a/src-tauri/src/proxy/common/model_mapping.rs
+++ b/src-tauri/src/proxy/common/model_mapping.rs
@@ -40,6 +40,8 @@ static CLAUDE_TO_GEMINI: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|
     // Claude Opus 4.6
     m.insert("claude-opus-4-6-thinking", "claude-opus-4-6-thinking");
     m.insert("claude-opus-4-6", "claude-opus-4-6-thinking");
+    m.insert("claude-opus-4.6-thinking", "claude-opus-4-6-thinking");
+    m.insert("claude-opus-4.6", "claude-opus-4-6-thinking");
     m.insert("claude-opus-4-6-20260201", "claude-opus-4-6-thinking");
 
     m.insert("claude-haiku-4", "claude-sonnet-4-6");
@@ -73,11 +75,11 @@ static CLAUDE_TO_GEMINI: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|
     // - Concrete model IDs should pass through unchanged.
     // - Generic aliases (without tier) still route to preview as fallback entrypoint.
     m.insert("gemini-3.1-pro-low", "gemini-3.1-pro-low");
-    m.insert("gemini-3.1-pro-high", "gemini-3.1-pro-high");
+    m.insert("gemini-3.1-pro-high", "gemini-pro-agent");
     m.insert("gemini-3.1-pro-preview", "gemini-3.1-pro-preview");
     m.insert("gemini-3.1-pro", "gemini-3.1-pro-preview");
     m.insert("gemini-3-pro-low", "gemini-3-pro-low");
-    m.insert("gemini-3-pro-high", "gemini-3-pro-high");
+    m.insert("gemini-3-pro-high", "gemini-pro-agent");
     m.insert("gemini-3-pro-preview", "gemini-3-pro-preview");
     m.insert("gemini-3-pro", "gemini-3-pro-preview");
     m.insert("gemini-2.5-flash", "gemini-2.5-flash");
@@ -105,7 +107,8 @@ static CLAUDE_TO_GEMINI: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|
 /// 映射后的目标模型名称
 ///
 /// # 示例
-/// ```
+/// ```ignore
+/// use antigravity_tools_lib::proxy::common::model_mapping::map_claude_model_to_gemini;
 /// // 精确匹配
 /// assert_eq!(map_claude_model_to_gemini("claude-opus-4"), "claude-opus-4-5-thinking");
 ///
@@ -313,15 +316,22 @@ pub fn resolve_model_route(
 ///
 /// Standard IDs:
 /// - `gemini-3-flash`: All Flash variants (1.5-flash, 2.5-flash, 3-flash, etc.)
+/// - `gemini-3.1-flash-image`: Flash image generation/edit quota.
 /// - `gemini-3-pro-high`: All Pro variants (1.5-pro, 2.5-pro, etc.)
+/// - `gemini-3-pro-image`: Pro image generation quota.
 /// - `claude-sonnet-4-5`: All Claude Sonnet variants (3-5-sonnet, sonnet-4-5, etc.)
 ///
 /// Returns `None` if the model doesn't match any of the 3 protected categories.
 pub fn normalize_to_standard_id(model_name: &str) -> Option<String> {
     let lower = model_name.to_lowercase();
 
-    // 1. image 资源 (优先匹配，使用 contains 匹配以支持任何变体，如 gemini-3.1-flash-image)
+    // 1. Image resources must keep Flash image and Pro image in separate quota buckets.
+    // The quota API exposes `gemini-3.1-flash-image` separately, so grouping it under
+    // `gemini-3-pro-image` makes available Flash image quota look exhausted.
     if lower.contains("image") {
+        if lower.contains("flash") {
+            return Some("gemini-3.1-flash-image".to_string());
+        }
         return Some("gemini-3-pro-image".to_string());
     }
 
@@ -379,7 +389,7 @@ mod tests {
         // Gemini Pro concrete IDs should pass through unchanged.
         assert_eq!(
             map_claude_model_to_gemini("gemini-3-pro-high"),
-            "gemini-3-pro-high"
+            "gemini-pro-agent"
         );
         assert_eq!(
             map_claude_model_to_gemini("gemini-3-pro-low"),
@@ -387,7 +397,7 @@ mod tests {
         );
         assert_eq!(
             map_claude_model_to_gemini("gemini-3.1-pro-high"),
-            "gemini-3.1-pro-high"
+            "gemini-pro-agent"
         );
         assert_eq!(
             map_claude_model_to_gemini("gemini-3.1-pro-low"),
@@ -438,11 +448,11 @@ mod tests {
         );
         assert_eq!(
             normalize_to_standard_id("gemini-3.1-flash-image"),
-            Some("gemini-3-pro-image".to_string())
+            Some("gemini-3.1-flash-image".to_string())
         );
         assert_eq!(
             normalize_to_standard_id("gemini-3.1-flash-image-4k"),
-            Some("gemini-3-pro-image".to_string())
+            Some("gemini-3.1-flash-image".to_string())
         );
     }
 

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -3047,7 +3047,6 @@ pub async fn handle_images_generations(
         Ok((email_header, openai_response)) => Ok((
             StatusCode::OK,
             [
-                ("X-Mapped-Model", "dall-e-3"),
                 ("X-Account-Email", email_header.as_str()),
             ],
             Json(openai_response),
@@ -3076,7 +3075,7 @@ pub async fn handle_images_generations_internal(
     let model = body
         .get("model")
         .and_then(|v| v.as_str())
-        .unwrap_or("gemini-3-pro-image");
+        .unwrap_or("gemini-3.1-flash-image");
 
     let n = body.get("n").and_then(|v| v.as_u64()).unwrap_or(1) as usize;
 
@@ -3262,6 +3261,11 @@ pub async fn handle_images_generations_internal(
                             // Other errors: return
                             return Err(last_error);
                         }
+                        token_manager.mark_account_success(&account_id);
+                        token_manager
+                            .clear_persisted_live_limit(&account_id, Some(&model_to_use))
+                            .await;
+
                         match response.json::<Value>().await {
                             Ok(json) => return Ok((json, email)),
                             Err(e) => return Err(format!("Parse error: {}", e)),
@@ -3396,14 +3400,14 @@ pub async fn handle_images_edits(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     tracing::info!("[Images] Received edit request");
 
-    let mut image_data = None;
-    let mut mask_data = None;
-    let mut reference_images: Vec<String> = Vec::new(); // Store base64 data of reference images
+    let mut image_data: Option<(String, String)> = None;
+    let mut mask_data: Option<(String, String)> = None;
+    let mut reference_images: Vec<(String, String)> = Vec::new(); // Store (base64 data, mime type) reference images
     let mut prompt = String::new();
     let mut n = 1;
     let mut size = "1024x1024".to_string();
     let mut response_format = "b64_json".to_string();
-    let mut model = "gemini-3-pro-image".to_string();
+    let mut model = "gemini-3.1-flash-image".to_string();
     let mut aspect_ratio: Option<String> = None;
     let mut image_size_param: Option<String> = None;
     let mut style: Option<String> = None;
@@ -3416,26 +3420,47 @@ pub async fn handle_images_edits(
         let name = field.name().unwrap_or("").to_string();
 
         if name == "image" {
+            let mime_type = field
+                .content_type()
+                .map(|content_type| content_type.to_string())
+                .unwrap_or_else(|| "image/png".to_string());
             let data = field
                 .bytes()
                 .await
                 .map_err(|e| (StatusCode::BAD_REQUEST, format!("Image read error: {}", e)))?;
-            image_data = Some(base64::engine::general_purpose::STANDARD.encode(data));
+            image_data = Some((
+                base64::engine::general_purpose::STANDARD.encode(data),
+                mime_type,
+            ));
         } else if name == "mask" {
+            let mime_type = field
+                .content_type()
+                .map(|content_type| content_type.to_string())
+                .unwrap_or_else(|| "image/png".to_string());
             let data = field
                 .bytes()
                 .await
                 .map_err(|e| (StatusCode::BAD_REQUEST, format!("Mask read error: {}", e)))?;
-            mask_data = Some(base64::engine::general_purpose::STANDARD.encode(data));
+            mask_data = Some((
+                base64::engine::general_purpose::STANDARD.encode(data),
+                mime_type,
+            ));
         } else if name.starts_with("image") && name != "image_size" {
             // Support image1, image2, etc.
+            let mime_type = field
+                .content_type()
+                .map(|content_type| content_type.to_string())
+                .unwrap_or_else(|| "image/jpeg".to_string());
             let data = field.bytes().await.map_err(|e| {
                 (
                     StatusCode::BAD_REQUEST,
                     format!("Reference image read error: {}", e),
                 )
             })?;
-            reference_images.push(base64::engine::general_purpose::STANDARD.encode(data));
+            reference_images.push((
+                base64::engine::general_purpose::STANDARD.encode(data),
+                mime_type,
+            ));
         } else if name == "prompt" {
             prompt = field
                 .text()
@@ -3508,12 +3533,13 @@ pub async fn handle_images_edits(
         _ => None, // Fallback to standard
     };
 
-    let (image_config, _) = crate::proxy::mappers::common_utils::parse_image_config_with_params(
-        &model,
-        size_input,
-        quality_input,
-        image_size_param.as_deref(), // [NEW] Pass direct image_size param
-    );
+    let (image_config, clean_model_name) =
+        crate::proxy::mappers::common_utils::parse_image_config_with_params(
+            &model,
+            size_input,
+            quality_input,
+            image_size_param.as_deref(), // [NEW] Pass direct image_size param
+        );
 
     // 3. Construct Contents
     let mut contents_parts = Vec::new();
@@ -3528,30 +3554,30 @@ pub async fn handle_images_edits(
     }));
 
     // Add Main Image (if standard edit)
-    if let Some(data) = image_data {
+    if let Some((data, mime_type)) = image_data {
         contents_parts.push(json!({
             "inlineData": {
-                "mimeType": "image/png",
+                "mimeType": mime_type,
                 "data": data
             }
         }));
     }
 
     // Add Mask (if standard edit)
-    if let Some(data) = mask_data {
+    if let Some((data, mime_type)) = mask_data {
         contents_parts.push(json!({
             "inlineData": {
-                "mimeType": "image/png",
+                "mimeType": mime_type,
                 "data": data
             }
         }));
     }
 
     // Add Reference Images (Image-to-Image)
-    for ref_data in reference_images {
+    for (ref_data, mime_type) in reference_images {
         contents_parts.push(json!({
             "inlineData": {
-                "mimeType": "image/jpeg", // Assume JPEG for refs as per spec suggestion, or auto-detect
+                "mimeType": mime_type,
                 "data": ref_data
             }
         }));
@@ -3573,7 +3599,7 @@ pub async fn handle_images_edits(
         let contents_parts = contents_parts.clone();
         let image_config = image_config.clone();
         let response_format = response_format.clone();
-        let model = model.clone();
+        let model_to_use = clean_model_name.clone();
 
         tasks.push(tokio::spawn(async move {
             let mut last_error = String::new();
@@ -3601,7 +3627,7 @@ pub async fn handle_images_edits(
                 let gemini_body = json!({
                     "project": project_id,
                     "requestId": format!("img-edit-{}", uuid::Uuid::new_v4()),
-                    "model": model,
+                    "model": model_to_use,
                     "userAgent": "antigravity",
                     "requestType": "image_gen",
                     "request": {
@@ -3658,13 +3684,18 @@ pub async fn handle_images_edits(
                                         status_code,
                                         None,
                                         &err_text,
-                                        Some("dall-e-3"),
+                                        Some(&model_to_use),
                                     )
                                     .await;
                                 continue; // Retry loop
                             }
                             return Err(last_error);
                         }
+                        token_manager.mark_account_success(&account_id);
+                        token_manager
+                            .clear_persisted_live_limit(&account_id, Some(&model_to_use))
+                            .await;
+
                         match response.json::<Value>().await {
                             Ok(json) => return Ok((json, response_format.clone(), email)),
                             Err(e) => return Err(format!("Parse error: {}", e)),
@@ -3747,7 +3778,15 @@ pub async fn handle_images_edits(
             n,
             error_msg
         );
-        return Err((StatusCode::BAD_GATEWAY, error_msg));
+        let status = if error_msg.contains("429") || error_msg.contains("Quota exhausted") {
+            StatusCode::TOO_MANY_REQUESTS
+        } else if error_msg.contains("503") || error_msg.contains("Service Unavailable") {
+            StatusCode::SERVICE_UNAVAILABLE
+        } else {
+            StatusCode::BAD_GATEWAY
+        };
+
+        return Err((status, error_msg));
     }
 
     if !errors.is_empty() {
@@ -3770,11 +3809,15 @@ pub async fn handle_images_edits(
         "data": images
     });
 
+    tokio::spawn(async move {
+        let _ = account::refresh_all_quotas_logic().await;
+    });
+
     let email_header = used_email.unwrap_or_default();
     Ok((
         StatusCode::OK,
         [
-            ("X-Mapped-Model", "dall-e-3"),
+            ("X-Mapped-Model", clean_model_name.as_str()),
             ("X-Account-Email", email_header.as_str()),
         ],
         Json(openai_response),

--- a/src-tauri/src/proxy/mappers/openai/request.rs
+++ b/src-tauri/src/proxy/mappers/openai/request.rs
@@ -785,9 +785,16 @@ pub fn transform_openai_request(
                 crate::proxy::config::ThinkingBudgetMode::Adaptive => user_budget,
             };
 
+            let model_lower = mapped_model.to_lowercase();
+            let mut final_budget = budget;
+            if model_lower.contains("claude-opus-4-6-thinking") {
+                tracing::debug!("[Opus-Alignment] Enforcing fixed thinkingBudget 24576 for Opus 4.6 (OpenAI)");
+                final_budget = 24576;
+            }
+
             gen_config["thinkingConfig"] = json!({
                 "includeThoughts": true,
-                "thinkingBudget": budget
+                "thinkingBudget": final_budget
             });
 
             // [CRITICAL] 思维模型的 maxOutputTokens 必须大于 thinkingBudget
@@ -803,34 +810,61 @@ pub fn transform_openai_request(
                 8192
             };
 
-            if let Some(max_tokens) = request.max_tokens {
-                if (max_tokens as i64) <= budget {
-                    gen_config["maxOutputTokens"] = json!(budget + min_overhead);
+            if model_lower.contains("claude-opus-4-6-thinking") {
+                gen_config["maxOutputTokens"] = json!(57344);
+                tracing::debug!("[Opus-Alignment] Enforcing maxOutputTokens 57344 for Opus 4.6 (OpenAI)");
+            } else if let Some(max_tokens) = request.max_tokens {
+                if (max_tokens as i64) <= final_budget {
+                    gen_config["maxOutputTokens"] = json!(final_budget + min_overhead);
                 }
             } else {
                 // [FIX #1592] Use a more conservative default to avoid 400 error on 128k context models
-                gen_config["maxOutputTokens"] = json!(budget + overhead);
+                gen_config["maxOutputTokens"] = json!(final_budget + overhead);
             }
 
             let new_max = gen_config["maxOutputTokens"].as_i64().unwrap_or(0);
             tracing::debug!(
                 "[OpenAI-Request] Adjusted maxOutputTokens to {} for thinking model (budget={})",
                 new_max,
-                budget
+                final_budget
             );
 
             tracing::debug!(
                 "[OpenAI-Request] Injected thinkingConfig for model {}: thinkingBudget={} (mode={:?})",
-                mapped_model, budget, tb_config.mode
+                mapped_model, final_budget, tb_config.mode
             );
         }
     }
 
+    // [FIX] Cap maxOutputTokens to prevent 400 Invalid Argument
+    if let Some(val) = gen_config["maxOutputTokens"].as_i64() {
+        let model_lower = mapped_model.to_lowercase();
+        let safe_limit = if model_lower.contains("claude") {
+            64000
+        } else {
+            65536
+        };
+        if val > safe_limit {
+            tracing::warn!(
+                "[Generation-Config] Capping maxOutputTokens from {} to {} to prevent 400 Invalid Argument",
+                val, safe_limit
+            );
+            gen_config["maxOutputTokens"] = json!(safe_limit);
+        }
+    }
+
     if let Some(stop) = &request.stop {
-        if stop.is_string() {
-            gen_config["stopSequences"] = json!([stop]);
-        } else if stop.is_array() {
-            gen_config["stopSequences"] = stop.clone();
+        let model_lower = mapped_model.to_lowercase();
+        if !model_lower.contains("claude-opus-4-6-thinking") {
+            if stop.is_string() {
+                gen_config["stopSequences"] = json!([stop]);
+            } else if stop.is_array() {
+                gen_config["stopSequences"] = stop.clone();
+            }
+        } else {
+            tracing::debug!(
+                "[Opus-Alignment] Skipping stopSequences for Opus 4.6 to match OpenAI protocol"
+            );
         }
     }
 

--- a/src-tauri/src/proxy/middleware/monitor.rs
+++ b/src-tauri/src/proxy/middleware/monitor.rs
@@ -7,12 +7,244 @@ use axum::{
     middleware::Next,
     response::Response,
 };
+use base64::Engine as _;
 use futures::StreamExt;
 use serde_json::Value;
 use std::time::Instant;
 
 const MAX_REQUEST_LOG_SIZE: usize = 100 * 1024 * 1024; // 100MB
 const MAX_RESPONSE_LOG_SIZE: usize = 100 * 1024 * 1024; // 100MB for image responses
+const MAX_LOGGED_FIELD_CHARS: usize = 500;
+
+fn truncate_for_log(value: &str, max_chars: usize) -> String {
+    let mut out = String::new();
+    for (idx, ch) in value.chars().enumerate() {
+        if idx >= max_chars {
+            out.push_str("...");
+            return out;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn extract_quoted_param(header: &str, key: &str) -> Option<String> {
+    let needle = format!("{}=\"", key);
+    let start = header.find(&needle)? + needle.len();
+    let rest = &header[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+fn extract_boundary(content_type: &str) -> Option<String> {
+    content_type.split(';').find_map(|part| {
+        let trimmed = part.trim();
+        let value = trimmed.strip_prefix("boundary=")?;
+        Some(value.trim_matches('"').to_string())
+    })
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8], start: usize) -> Option<usize> {
+    if needle.is_empty() || start >= haystack.len() {
+        return None;
+    }
+    haystack[start..]
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .map(|idx| start + idx)
+}
+
+fn trim_part_tail(mut part: &[u8]) -> &[u8] {
+    if part.ends_with(b"\r\n") {
+        part = &part[..part.len() - 2];
+    } else if part.ends_with(b"\n") {
+        part = &part[..part.len() - 1];
+    }
+    part
+}
+
+fn summarize_multipart_request(
+    bytes: &[u8],
+    content_type: &str,
+    uri: &str,
+) -> Option<(String, Option<String>)> {
+    let boundary = extract_boundary(content_type)?;
+    let marker = format!("--{}", boundary).into_bytes();
+    let mut cursor = find_subslice(bytes, &marker, 0)?;
+    let mut fields = serde_json::Map::new();
+    let mut files = Vec::new();
+    let mut model = None;
+
+    loop {
+        cursor += marker.len();
+        if cursor >= bytes.len() || bytes[cursor..].starts_with(b"--") {
+            break;
+        }
+        if bytes[cursor..].starts_with(b"\r\n") {
+            cursor += 2;
+        } else if bytes[cursor..].starts_with(b"\n") {
+            cursor += 1;
+        }
+
+        let Some(next_boundary) = find_subslice(bytes, &marker, cursor) else {
+            break;
+        };
+        let part = trim_part_tail(&bytes[cursor..next_boundary]);
+        cursor = next_boundary;
+
+        let (headers, body) = if let Some(idx) = find_subslice(part, b"\r\n\r\n", 0) {
+            (&part[..idx], &part[idx + 4..])
+        } else if let Some(idx) = find_subslice(part, b"\n\n", 0) {
+            (&part[..idx], &part[idx + 2..])
+        } else {
+            continue;
+        };
+
+        let headers_text = String::from_utf8_lossy(headers);
+        let disposition = headers_text
+            .lines()
+            .find(|line| {
+                line.to_ascii_lowercase()
+                    .starts_with("content-disposition:")
+            })
+            .unwrap_or("");
+        let content_type = headers_text
+            .lines()
+            .find(|line| line.to_ascii_lowercase().starts_with("content-type:"))
+            .and_then(|line| {
+                line.split_once(':')
+                    .map(|(_, value)| value.trim().to_string())
+            });
+        let Some(name) = extract_quoted_param(disposition, "name") else {
+            continue;
+        };
+        let filename = extract_quoted_param(disposition, "filename");
+
+        if filename.is_some() || content_type.as_deref().unwrap_or("").starts_with("image/") {
+            files.push(serde_json::json!({
+                "field": name,
+                "filename": filename,
+                "content_type": content_type,
+                "bytes": body.len()
+            }));
+        } else if let Ok(text) = std::str::from_utf8(body) {
+            let value = truncate_for_log(text.trim(), MAX_LOGGED_FIELD_CHARS);
+            if name == "model" {
+                model = Some(value.clone());
+            }
+            fields.insert(name, Value::String(value));
+        } else {
+            fields.insert(
+                name,
+                Value::String(format!("[binary field: {} bytes]", body.len())),
+            );
+        }
+    }
+
+    let summary = serde_json::json!({
+        "content_type": "multipart/form-data",
+        "path": uri,
+        "fields": fields,
+        "files": files,
+        "raw_bytes": bytes.len()
+    });
+    let rendered = serde_json::to_string_pretty(&summary).ok()?;
+    Some((rendered, model))
+}
+
+fn image_mime_and_dimensions(bytes: &[u8]) -> (String, Option<(u32, u32)>) {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") && bytes.len() >= 24 {
+        let width = u32::from_be_bytes([bytes[16], bytes[17], bytes[18], bytes[19]]);
+        let height = u32::from_be_bytes([bytes[20], bytes[21], bytes[22], bytes[23]]);
+        return ("image/png".to_string(), Some((width, height)));
+    }
+
+    if bytes.starts_with(b"\xff\xd8") {
+        let mut idx = 2;
+        while idx + 9 < bytes.len() {
+            if bytes[idx] != 0xff {
+                idx += 1;
+                continue;
+            }
+            let marker = bytes[idx + 1];
+            if marker == 0xd9 || marker == 0xda {
+                break;
+            }
+            if idx + 4 > bytes.len() {
+                break;
+            }
+            let segment_len = u16::from_be_bytes([bytes[idx + 2], bytes[idx + 3]]) as usize;
+            if segment_len < 2 || idx + 2 + segment_len > bytes.len() {
+                break;
+            }
+            if matches!(
+                marker,
+                0xc0 | 0xc1
+                    | 0xc2
+                    | 0xc3
+                    | 0xc5
+                    | 0xc6
+                    | 0xc7
+                    | 0xc9
+                    | 0xca
+                    | 0xcb
+                    | 0xcd
+                    | 0xce
+                    | 0xcf
+            ) && segment_len >= 7
+            {
+                let height = u16::from_be_bytes([bytes[idx + 5], bytes[idx + 6]]) as u32;
+                let width = u16::from_be_bytes([bytes[idx + 7], bytes[idx + 8]]) as u32;
+                return ("image/jpeg".to_string(), Some((width, height)));
+            }
+            idx += 2 + segment_len;
+        }
+        return ("image/jpeg".to_string(), None);
+    }
+
+    ("application/octet-stream".to_string(), None)
+}
+
+fn summarize_image_json_response(json: &Value) -> Option<String> {
+    let mut summary = json.clone();
+    let data = summary.get_mut("data")?.as_array_mut()?;
+    for item in data.iter_mut() {
+        if let Some(obj) = item.as_object_mut() {
+            if let Some(b64) = obj.get("b64_json").and_then(|v| v.as_str()) {
+                let decoded = base64::engine::general_purpose::STANDARD.decode(b64).ok();
+                let (mime_type, dimensions, bytes) = decoded
+                    .as_deref()
+                    .map(|bytes| {
+                        let (mime, dims) = image_mime_and_dimensions(bytes);
+                        (mime, dims, bytes.len())
+                    })
+                    .unwrap_or_else(|| ("unknown".to_string(), None, b64.len() * 3 / 4));
+                obj.remove("b64_json");
+                obj.insert(
+                    "image".to_string(),
+                    serde_json::json!({
+                        "encoding": "base64",
+                        "redacted": true,
+                        "mime_type": mime_type,
+                        "bytes": bytes,
+                        "dimensions": dimensions.map(|(width, height)| serde_json::json!({
+                            "width": width,
+                            "height": height
+                        }))
+                    }),
+                );
+            } else if let Some(url) = obj.get("url").and_then(|v| v.as_str()) {
+                if url.starts_with("data:image/") {
+                    obj.insert(
+                        "url".to_string(),
+                        Value::String(format!("[data URL redacted: {} chars]", url.len())),
+                    );
+                }
+            }
+        }
+    }
+    serde_json::to_string_pretty(&summary).ok()
+}
 
 /// Helper function to record User Token usage
 fn record_user_token_usage(
@@ -148,6 +380,13 @@ pub async fn monitor_middleware(
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
 
+    let request_content_type = request
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
     let mut model = if uri.contains("/v1beta/models/") {
         uri.split("/v1beta/models/")
             .nth(1)
@@ -167,14 +406,28 @@ pub async fn monitor_middleware(
         let (parts, body) = request.into_parts();
         match axum::body::to_bytes(body, MAX_REQUEST_LOG_SIZE).await {
             Ok(bytes) => {
-                if model.is_none() {
-                    model = serde_json::from_slice::<Value>(&bytes).ok().and_then(|v| {
-                        v.get("model")
-                            .and_then(|m| m.as_str())
-                            .map(|s| s.to_string())
-                    });
-                }
-                request_body_str = if let Ok(s) = std::str::from_utf8(&bytes) {
+                request_body_str = if request_content_type.starts_with("multipart/form-data") {
+                    if let Some((summary, multipart_model)) =
+                        summarize_multipart_request(&bytes, &request_content_type, &uri)
+                    {
+                        if model.is_none() {
+                            model = multipart_model;
+                        }
+                        Some(summary)
+                    } else {
+                        Some(format!(
+                            "[Multipart Request Data: {} bytes, failed to parse summary]",
+                            bytes.len()
+                        ))
+                    }
+                } else if let Ok(s) = std::str::from_utf8(&bytes) {
+                    if model.is_none() {
+                        model = serde_json::from_slice::<Value>(&bytes).ok().and_then(|v| {
+                            v.get("model")
+                                .and_then(|m| m.as_str())
+                                .map(|s| s.to_string())
+                        });
+                    }
                     Some(s.to_string())
                 } else {
                     Some("[Binary Request Data]".to_string())
@@ -236,6 +489,7 @@ pub async fn monitor_middleware(
     let username = user_token_identity
         .as_ref()
         .map(|identity| identity.username.clone());
+    let is_image_route = uri.contains("/v1/images/");
 
     let monitor = state.monitor.clone();
     let mut log = ProxyRequestLog {
@@ -706,7 +960,14 @@ pub async fn monitor_middleware(
                             }
                         }
                     }
-                    log.response_body = Some(s.to_string());
+                    if is_image_route {
+                        log.response_body = serde_json::from_str::<Value>(&s)
+                            .ok()
+                            .and_then(|json| summarize_image_json_response(&json))
+                            .or_else(|| Some(s.to_string()));
+                    } else {
+                        log.response_body = Some(s.to_string());
+                    }
                 } else {
                     log.response_body = Some("[Binary Response Data]".to_string());
                 }

--- a/src-tauri/src/proxy/rate_limit.rs
+++ b/src-tauri/src/proxy/rate_limit.rs
@@ -129,10 +129,21 @@ impl RateLimitTracker {
         model: Option<String>,
     ) {
         let now = SystemTime::now();
-        let retry_sec = reset_time
+        let mut retry_sec = reset_time
             .duration_since(now)
             .map(|d| d.as_secs())
             .unwrap_or(60); // 如果时间已过,使用默认 60 秒
+
+        if retry_sec > 300 {
+            tracing::info!(
+                "Capping lockout time for {} from {}s to 300s (5 minutes)",
+                account_id,
+                retry_sec
+            );
+            retry_sec = 300;
+        }
+
+        let reset_time = now + Duration::from_secs(retry_sec);
 
         let info = RateLimitInfo {
             reset_time,
@@ -305,8 +316,19 @@ impl RateLimitTracker {
                     }
                     RateLimitReason::RateLimitExceeded => {
                         // 速率限制 (TPM/RPM)
-                        tracing::debug!("检测到速率限制 (RATE_LIMIT_EXCEEDED)，使用默认值 5秒");
-                        5
+                        let body_lower = body.to_lowercase();
+                        let lockout = if body_lower.contains("resource has been exhausted")
+                            || body_lower.contains("resource_exhausted")
+                        {
+                            30
+                        } else {
+                            5
+                        };
+                        tracing::debug!(
+                            "检测到速率限制 (RATE_LIMIT_EXCEEDED)，使用默认值 {}秒",
+                            lockout
+                        );
+                        lockout
                     }
                     RateLimitReason::ModelCapacityExhausted => {
                         // 模型容量耗尽
@@ -335,6 +357,16 @@ impl RateLimitTracker {
                 }
             }
         };
+
+        let mut retry_sec = retry_sec;
+        if retry_sec > 300 {
+            tracing::info!(
+                "Capping retry lockout time for {} from {}s to 300s (5 minutes)",
+                account_id,
+                retry_sec
+            );
+            retry_sec = 300;
+        }
 
         let info = RateLimitInfo {
             reset_time: SystemTime::now() + Duration::from_secs(retry_sec),
@@ -407,9 +439,19 @@ impl RateLimitTracker {
         // 如果无法从 JSON 解析，尝试从消息文本判断
         let body_lower = body.to_lowercase();
         // [FIX] 优先判断分钟级限制，避免将 TPM 误判为 Quota
+        let generic_resource_exhausted = body_lower.contains("resource has been exhausted")
+            || body_lower.contains("resource_exhausted");
+        let explicit_quota_exhausted = body_lower.contains("quota_exhausted")
+            || body_lower.contains("quotaresetdelay")
+            || body_lower.contains("quota reset")
+            || body_lower.contains("quota limit")
+            || body_lower.contains("per day")
+            || body_lower.contains("daily quota");
+
         if body_lower.contains("per minute")
             || body_lower.contains("rate limit")
             || body_lower.contains("too many requests")
+            || (generic_resource_exhausted && !explicit_quota_exhausted)
         {
             RateLimitReason::RateLimitExceeded
         } else if body_lower.contains("exhausted") || body_lower.contains("quota") {
@@ -705,6 +747,20 @@ mod tests {
         let body = "Resource has been exhausted (e.g. check quota). Quota limit 'Tokens per minute' exceeded.";
         let reason = tracker.parse_rate_limit_reason(body);
         // 应该被识别为 RateLimitExceeded，而不是 QuotaExhausted
+        assert_eq!(reason, RateLimitReason::RateLimitExceeded);
+    }
+
+    #[test]
+    fn test_generic_resource_exhausted_is_short_rate_limit() {
+        let tracker = RateLimitTracker::new();
+        let body = r#"{
+            "error": {
+                "code": 429,
+                "message": "Resource has been exhausted (e.g. check quota).",
+                "status": "RESOURCE_EXHAUSTED"
+            }
+        }"#;
+        let reason = tracker.parse_rate_limit_reason(body);
         assert_eq!(reason, RateLimitReason::RateLimitExceeded);
     }
 

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -9,7 +9,7 @@ use axum::{
     Router,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -139,6 +139,7 @@ struct AccountResponse {
     proxy_disabled_reason: Option<String>,
     proxy_disabled_at: Option<i64>,
     protected_models: Vec<String>,
+    live_limited_models: HashMap<String, crate::models::account::LiveLimitStatus>,
     /// [NEW] 403 验证阻止状态
     validation_blocked: bool,
     validation_blocked_until: Option<i64>,
@@ -227,6 +228,7 @@ fn to_account_response(
         proxy_disabled_reason: account.proxy_disabled_reason.clone(),
         proxy_disabled_at: account.proxy_disabled_at,
         protected_models: account.protected_models.iter().cloned().collect(),
+        live_limited_models: account.live_limited_models.clone(),
         quota: account.quota.as_ref().map(|q| QuotaResponse {
             models: q
                 .models
@@ -955,6 +957,7 @@ async fn admin_list_accounts(
                 proxy_disabled_reason: acc.proxy_disabled_reason,
                 proxy_disabled_at: acc.proxy_disabled_at,
                 protected_models: acc.protected_models.into_iter().collect(),
+                live_limited_models: acc.live_limited_models,
                 validation_blocked: acc.validation_blocked,
                 validation_blocked_until: acc.validation_blocked_until,
                 validation_blocked_reason: acc.validation_blocked_reason,
@@ -1035,6 +1038,7 @@ async fn admin_get_current_account(
                 proxy_disabled_reason: acc.proxy_disabled_reason,
                 proxy_disabled_at: acc.proxy_disabled_at,
                 protected_models: acc.protected_models.into_iter().collect(),
+                live_limited_models: acc.live_limited_models,
                 validation_blocked: acc.validation_blocked,
                 validation_blocked_until: acc.validation_blocked_until,
                 validation_blocked_reason: acc.validation_blocked_reason,

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -542,6 +542,7 @@ impl TokenManager {
         {
             for (k, v) in rules {
                 if let Some(new_model) = v.as_str() {
+                    // Register dynamic forwarding rules (including those mapping to gemini-pro-agent)
                     crate::proxy::common::model_mapping::update_dynamic_forwarding_rules(
                         k.to_string(),
                         new_model.to_string(),
@@ -825,6 +826,7 @@ impl TokenManager {
             "gemini-3.1-pro-preview",
             "gemini-3.1-pro-high",
             "gemini-3.1-pro-low",
+            "gemini-pro-agent",
         ];
 
         if !pro_family.contains(&model.as_str()) {
@@ -842,6 +844,7 @@ impl TokenManager {
 
         // Keep requested model as top priority, then fallback across the same family.
         push(&model);
+        push("gemini-pro-agent");
         push("gemini-3.1-pro-preview");
         push("gemini-3-pro-preview");
         push("gemini-3.1-pro-high");
@@ -1719,7 +1722,16 @@ impl TokenManager {
                     // 计算最短等待时间
                     let min_wait = tokens_snapshot
                         .iter()
-                        .filter_map(|t| self.rate_limit_tracker.get_reset_seconds(&t.account_id))
+                        .filter_map(|t| {
+                            let wait = self
+                                .rate_limit_tracker
+                                .get_remaining_wait(&t.account_id, Some(&normalized_target));
+                            if wait > 0 {
+                                Some(wait)
+                            } else {
+                                None
+                            }
+                        })
                         .min();
 
                     // Layer 1: 如果最短等待时间 <= 2秒,执行缓冲延迟
@@ -2583,19 +2595,64 @@ impl TokenManager {
                 model_to_track.map(|s| s.to_string()),
                 &config.backoff_steps, // [NEW] 传入配置
             );
+            let reason = if error_body.to_lowercase().contains("quota") {
+                crate::proxy::rate_limit::RateLimitReason::QuotaExhausted
+            } else {
+                crate::proxy::rate_limit::RateLimitReason::RateLimitExceeded
+            };
+            self.persist_live_limit(&account_id, model_to_track, status, reason, error_body);
             return;
         }
 
         // 确定限流原因
-        let reason = if error_body.to_lowercase().contains("model_capacity") {
+        let error_body_lower = error_body.to_lowercase();
+        let generic_resource_exhausted = error_body_lower.contains("resource has been exhausted")
+            || error_body_lower.contains("resource_exhausted");
+        let explicit_quota_exhausted = error_body_lower.contains("quota_exhausted")
+            || error_body_lower.contains("quotaresetdelay")
+            || error_body_lower.contains("quota reset")
+            || error_body_lower.contains("quota limit")
+            || error_body_lower.contains("per day")
+            || error_body_lower.contains("daily quota");
+
+        let reason = if error_body_lower.contains("model_capacity") {
             crate::proxy::rate_limit::RateLimitReason::ModelCapacityExhausted
-        } else if error_body.to_lowercase().contains("exhausted")
-            || error_body.to_lowercase().contains("quota")
+        } else if error_body_lower.contains("per minute")
+            || error_body_lower.contains("rate limit")
+            || error_body_lower.contains("too many requests")
+            || (generic_resource_exhausted && !explicit_quota_exhausted)
+        {
+            crate::proxy::rate_limit::RateLimitReason::RateLimitExceeded
+        } else if explicit_quota_exhausted
+            || error_body_lower.contains("exhausted")
+            || error_body_lower.contains("quota")
         {
             crate::proxy::rate_limit::RateLimitReason::QuotaExhausted
         } else {
             crate::proxy::rate_limit::RateLimitReason::Unknown
         };
+
+        if !matches!(
+            reason,
+            crate::proxy::rate_limit::RateLimitReason::QuotaExhausted
+        ) {
+            tracing::info!(
+                "账号 {} 的 {} 响应被识别为 {:?},使用短退避而不是配额重置锁定",
+                account_id,
+                status,
+                reason
+            );
+            self.rate_limit_tracker.parse_from_error(
+                &account_id,
+                status,
+                retry_after_header,
+                error_body,
+                model_to_track.map(|s| s.to_string()),
+                &config.backoff_steps,
+            );
+            self.persist_live_limit(&account_id, model_to_track, status, reason, error_body);
+            return;
+        }
 
         // API 未返回 quotaResetDelay,需要实时刷新配额获取精确锁定时间
         if let Some(m) = model_to_track {
@@ -2621,12 +2678,14 @@ impl TokenManager {
             .await
         {
             tracing::info!("账号 {} 已使用实时配额精确锁定", email);
+            self.persist_live_limit(&account_id, model_to_track, status, reason, error_body);
             return;
         }
 
         // 实时刷新失败,尝试使用本地缓存的配额刷新时间
         if self.set_precise_lockout(&account_id, reason, model_to_track.map(|s| s.to_string())) {
             tracing::info!("账号 {} 已使用本地缓存配额锁定", account_id);
+            self.persist_live_limit(&account_id, model_to_track, status, reason, error_body);
             return;
         }
 
@@ -2640,6 +2699,102 @@ impl TokenManager {
             model_to_track.map(|s| s.to_string()),
             &config.backoff_steps, // [NEW] 传入配置
         );
+        self.persist_live_limit(&account_id, model_to_track, status, reason, error_body);
+    }
+
+    fn persist_live_limit(
+        &self,
+        account_id: &str,
+        model: Option<&str>,
+        status: u16,
+        reason: crate::proxy::rate_limit::RateLimitReason,
+        error_body: &str,
+    ) {
+        let Some(model_key) = model.filter(|m| !m.is_empty()) else {
+            return;
+        };
+
+        let wait_sec = self
+            .rate_limit_tracker
+            .get_remaining_wait(account_id, Some(model_key));
+        if wait_sec == 0 {
+            return;
+        }
+
+        let path = if let Some(entry) = self.tokens.get(account_id) {
+            entry.account_path.clone()
+        } else {
+            self.data_dir
+                .join("accounts")
+                .join(format!("{}.json", account_id))
+        };
+
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            return;
+        };
+        let Ok(mut content) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            return;
+        };
+
+        if !content
+            .get("live_limited_models")
+            .and_then(|v| v.as_object())
+            .is_some()
+        {
+            content["live_limited_models"] = serde_json::Value::Object(serde_json::Map::new());
+        }
+
+        let now = chrono::Utc::now().timestamp();
+        content["live_limited_models"][model_key] = serde_json::json!({
+            "model": model_key,
+            "status": status,
+            "reason": format!("{:?}", reason),
+            "until": now + wait_sec as i64,
+            "detected_at": now,
+            "message": truncate_reason(error_body, 500),
+        });
+
+        if let Err(e) = std::fs::write(&path, serde_json::to_string_pretty(&content).unwrap()) {
+            tracing::debug!("Failed to persist live limit for {}: {}", account_id, e);
+        }
+    }
+
+    pub async fn clear_persisted_live_limit(&self, account_id: &str, model: Option<&str>) {
+        let Some(model_key) = model.filter(|m| !m.is_empty()) else {
+            return;
+        };
+
+        let path = if let Some(entry) = self.tokens.get(account_id) {
+            entry.account_path.clone()
+        } else {
+            self.data_dir
+                .join("accounts")
+                .join(format!("{}.json", account_id))
+        };
+
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            return;
+        };
+        let Ok(mut content) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            return;
+        };
+
+        let Some(live_limits) = content
+            .get_mut("live_limited_models")
+            .and_then(|value| value.as_object_mut())
+        else {
+            return;
+        };
+
+        live_limits.remove(model_key);
+        if model_key.contains("image") {
+            live_limits.remove("gemini-3.1-flash-image");
+            live_limits.remove("gemini-3-pro-image");
+        }
+
+        if let Err(e) = std::fs::write(&path, serde_json::to_string_pretty(&content).unwrap()) {
+            tracing::debug!("Failed to clear live limit for {}: {}", account_id, e);
+        }
     }
 
     // ===== 调度配置相关方法 =====
@@ -2841,6 +2996,17 @@ impl TokenManager {
         let mut all_models = std::collections::HashSet::new();
         for entry in self.tokens.iter() {
             let token = entry.value();
+
+            // Keep the raw quota model IDs for /v1/models discovery. `model_quotas`
+            // intentionally stores normalized protection buckets (e.g. gemini-3-flash),
+            // but clients need concrete usable IDs such as gemini-3-flash-agent.
+            if let Some(raw_models) = Self::get_available_models_from_json(&token.account_path) {
+                for model_id in raw_models {
+                    all_models.insert(model_id);
+                }
+            }
+
+            // Also keep normalized bucket IDs for existing quota/protection behavior.
             for model_id in token.model_quotas.keys() {
                 all_models.insert(model_id.clone());
             }
@@ -3018,6 +3184,17 @@ mod tests {
     use super::*;
     use std::cmp::Ordering;
 
+    #[test]
+    fn test_build_dynamic_model_candidates_agent() {
+        let candidates = TokenManager::build_dynamic_model_candidates("gemini-pro-agent").unwrap();
+        assert_eq!(candidates[0], "gemini-pro-agent");
+        assert!(candidates.contains(&"gemini-3.1-pro-low".to_string()));
+        
+        let candidates_high = TokenManager::build_dynamic_model_candidates("gemini-3.1-pro-high").unwrap();
+        assert_eq!(candidates_high[0], "gemini-3.1-pro-high");
+        assert!(candidates_high.contains(&"gemini-pro-agent".to_string()));
+    }
+
     #[tokio::test]
     async fn test_reload_account_purges_cache_when_account_becomes_proxy_disabled() {
         let tmp_root = std::env::temp_dir().join(format!(
@@ -3108,6 +3285,11 @@ mod tests {
                     "expiry_timestamp": now + 3600,
                     "project_id": format!("pid-{}", id)
                 },
+                "quota": {
+                    "models": [
+                        { "name": "gemini-1.5-flash", "percentage": 100 }
+                    ]
+                },
                 "disabled": false,
                 "proxy_disabled": proxy_disabled,
                 "proxy_disabled_reason": if proxy_disabled { "manual" } else { "" },
@@ -3147,6 +3329,53 @@ mod tests {
         assert_eq!(email, "b@test.com");
         assert!(manager.tokens.get("acc1").is_none());
         assert!(manager.get_preferred_account().await.is_none());
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
+    }
+
+    #[tokio::test]
+    async fn test_collected_models_preserve_raw_quota_model_names_for_model_listing() {
+        let tmp_root = std::env::temp_dir().join(format!(
+            "antigravity-token-manager-test-raw-models-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let accounts_dir = tmp_root.join("accounts");
+        std::fs::create_dir_all(&accounts_dir).unwrap();
+
+        let now = chrono::Utc::now().timestamp();
+        let account_path = accounts_dir.join("acc1.json");
+        let account_json = serde_json::json!({
+            "id": "acc1",
+            "email": "a@test.com",
+            "token": {
+                "access_token": "atk",
+                "refresh_token": "rtk",
+                "expires_in": 3600,
+                "expiry_timestamp": now + 3600
+            },
+            "quota": {
+                "models": [
+                    { "name": "gemini-3-flash-agent", "percentage": 88 }
+                ]
+            },
+            "disabled": false,
+            "proxy_disabled": false,
+            "created_at": now,
+            "last_used": now
+        });
+        std::fs::write(
+            &account_path,
+            serde_json::to_string_pretty(&account_json).unwrap(),
+        )
+        .unwrap();
+
+        let manager = TokenManager::new(tmp_root.clone());
+        manager.load_accounts().await.unwrap();
+
+        let collected_models = manager.get_all_collected_models();
+        assert!(collected_models.contains("gemini-3-flash-agent"));
+        // Keep the normalized quota bucket too; it is used for quota/protection checks.
+        assert!(collected_models.contains("gemini-3-flash"));
 
         let _ = std::fs::remove_dir_all(&tmp_root);
     }

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -7,6 +7,7 @@ import { useConfigStore } from '../../stores/useConfigStore';
 import { QuotaItem } from './QuotaItem';
 import { MODEL_CONFIG, sortModels } from '../../config/modelConfig';
 import { getValidationBlockedStatusLabel } from './accountValidationStatus';
+import { getLiveLimitForModel } from '../../utils/liveLimit';
 
 interface AccountCardProps {
     account: Account;
@@ -247,6 +248,7 @@ function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, is
                                 percentage={model.data?.percentage || 0}
                                 resetTime={model.data?.reset_time}
                                 isProtected={isModelProtected(model.protectedKey)}
+                                liveLimit={getLiveLimitForModel(account, model.id, model.protectedKey)}
                                 Icon={model.Icon}
                             />
                         ))}

--- a/src/components/accounts/AccountRow.tsx
+++ b/src/components/accounts/AccountRow.tsx
@@ -3,6 +3,7 @@ import { Account } from '../../types/account';
 import { getQuotaColor, formatTimeRemaining, getTimeRemainingColor } from '../../utils/format';
 import { cn } from '../../utils/cn';
 import { useTranslation } from 'react-i18next';
+import { formatCompactDuration, getLiveLimitForModel, getLiveLimitState } from '../../utils/liveLimit';
 
 interface AccountRowProps {
     account: Account;
@@ -36,7 +37,23 @@ function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSw
 
     const geminiFlashModel = account.quota?.models.find(m => m.name.toLowerCase() === 'gemini-3-flash');
 
-    const geminiImageModel = account.quota?.models.find(m => m.name.toLowerCase() === 'gemini-3-pro-image');
+    const geminiImageModel = account.quota?.models.find(m => {
+        const name = m.name.toLowerCase();
+        return name === 'gemini-3.1-flash-image' || name === 'gemini-3-pro-image';
+    });
+    const liveImageLimit = getLiveLimitForModel(account, geminiImageModel?.name, 'gemini-3.1-flash-image');
+    const liveImageState = getLiveLimitState(liveImageLimit);
+    const isImageLiveLimited = liveImageState.shouldShow;
+    const imageLimitTitle = liveImageLimit
+        ? [
+            liveImageState.isActive
+                ? `Live image endpoint is temporarily unavailable for ${formatCompactDuration(liveImageState.secondsRemaining)}.`
+                : `Image endpoint returned ${liveImageLimit.status} ${formatCompactDuration(liveImageState.secondsAgo)} ago.`,
+            `Reason: ${liveImageLimit.reason}.`,
+            `Quota snapshot can still show ${geminiImageModel?.percentage || 0}%.`,
+            liveImageLimit.message ? `Message: ${liveImageLimit.message}` : null,
+        ].filter(Boolean).join(' ')
+        : 'Gemini 3.1 Flash Image';
 
     const claudeGroupNames = [
         'claude-opus-4-6-thinking',
@@ -168,7 +185,11 @@ function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSw
                 ) : (
                     <div className="grid grid-cols-2 gap-x-4 gap-y-1 py-0">
                         {/* Gemini Pro */}
-                        <div className="relative h-[22px] flex items-center px-1.5 rounded-md overflow-hidden border border-gray-100/50 dark:border-white/5 bg-gray-50/30 dark:bg-white/5 group/quota">
+                        <div className={cn(
+                            "relative h-[22px] flex items-center px-1.5 rounded-md overflow-hidden border border-gray-100/50 dark:border-white/5 bg-gray-50/30 dark:bg-white/5 group/quota",
+                            isImageLiveLimited && "border-amber-400/70 dark:border-amber-500/70 bg-amber-50/80 dark:bg-amber-950/30 ring-1 ring-amber-400/30",
+                            liveImageState.isActive && "border-rose-400/70 dark:border-rose-500/70 bg-rose-50/80 dark:bg-rose-950/30 ring-rose-400/30"
+                        )}>
                             {geminiProModel && (
                                 <div
                                     className={`absolute inset-y-0 left-0 transition-all duration-700 ease-out opacity-15 dark:opacity-20 ${getColorClass(geminiProModel.percentage)}`}
@@ -240,8 +261,9 @@ function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSw
                                 />
                             )}
                             <div className="relative z-10 w-full flex items-center text-[10px] font-mono leading-none">
-                                <span className="w-[64px] text-gray-500 dark:text-gray-400 font-bold pr-1 flex items-center gap-1" title="Gemini 3 Pro Image">
-                                    {account.protected_models?.includes('gemini-3-pro-image') && <Lock className="w-2.5 h-2.5 text-rose-500 shrink-0 z-10" />}
+                                <span className="w-[64px] text-gray-500 dark:text-gray-400 font-bold pr-1 flex items-center gap-1" title={imageLimitTitle}>
+                                    {isImageLiveLimited && <Clock className={cn("w-2.5 h-2.5 shrink-0 z-10", liveImageState.isActive ? "text-rose-500" : "text-amber-500")} />}
+                                    {(account.protected_models?.includes('gemini-3.1-flash-image') || account.protected_models?.includes('gemini-3-pro-image')) && <Lock className="w-2.5 h-2.5 text-rose-500 shrink-0 z-10" />}
                                     <span className="truncate">G3 Image</span>
                                 </span>
                                 <div className="flex-1 flex justify-center">
@@ -255,10 +277,11 @@ function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSw
                                     )}
                                 </div>
                                 <span className={cn("w-[36px] text-right font-bold transition-colors",
-                                    getQuotaColor(geminiImageModel?.percentage || 0) === 'success' ? 'text-emerald-600 dark:text-emerald-400' :
+                                    isImageLiveLimited ? (liveImageState.isActive ? 'text-rose-600 dark:text-rose-400' : 'text-amber-600 dark:text-amber-400') :
+                                        getQuotaColor(geminiImageModel?.percentage || 0) === 'success' ? 'text-emerald-600 dark:text-emerald-400' :
                                         getQuotaColor(geminiImageModel?.percentage || 0) === 'warning' ? 'text-amber-600 dark:text-amber-400' : 'text-rose-600 dark:text-rose-400'
                                 )}>
-                                    {geminiImageModel ? `${geminiImageModel.percentage}%` : '-'}
+                                    {isImageLiveLimited ? `${liveImageLimit?.status || 'ERR'}` : (geminiImageModel ? `${geminiImageModel.percentage}%` : '-')}
                                 </span>
                             </div>
                         </div>

--- a/src/components/accounts/AccountTable.tsx
+++ b/src/components/accounts/AccountTable.tsx
@@ -54,6 +54,7 @@ import { useConfigStore } from '../../stores/useConfigStore';
 import { QuotaItem } from './QuotaItem';
 import { MODEL_CONFIG, sortModels } from '../../config/modelConfig';
 import { getValidationBlockedStatusLabel } from './accountValidationStatus';
+import { getLiveLimitForModel } from '../../utils/liveLimit';
 
 // ============================================================================
 // 类型定义
@@ -556,6 +557,7 @@ function AccountRowContent({
                                     percentage={modelData?.percentage || 0}
                                     resetTime={modelData?.reset_time}
                                     isProtected={isModelProtected(account.protected_models, model.protectedKey)}
+                                    liveLimit={getLiveLimitForModel(account, model.id, model.protectedKey)}
                                     Icon={MODEL_CONFIG[model.id]?.Icon || Bot}
                                 />
                             );

--- a/src/components/accounts/QuotaItem.tsx
+++ b/src/components/accounts/QuotaItem.tsx
@@ -1,20 +1,36 @@
 
-import { Clock, Lock } from 'lucide-react';
+import { AlertTriangle, Clock, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '../../utils/cn';
 import { getQuotaColor, formatTimeRemaining, getTimeRemainingColor } from '../../utils/format';
+import type { LiveLimitStatus } from '../../types/account';
+import { formatCompactDuration, getLiveLimitState } from '../../utils/liveLimit';
 
 interface QuotaItemProps {
     label: string;
     percentage: number;
     resetTime?: string;
     isProtected?: boolean;
+    liveLimit?: LiveLimitStatus;
     className?: string;
     Icon?: React.ComponentType<{ size?: number; className?: string }>;
 }
 
-export function QuotaItem({ label, percentage, resetTime, isProtected, className, Icon }: QuotaItemProps) {
+export function QuotaItem({ label, percentage, resetTime, isProtected, liveLimit, className, Icon }: QuotaItemProps) {
     const { t } = useTranslation();
+    const liveState = getLiveLimitState(liveLimit);
+    const showLiveIssue = liveState.shouldShow;
+    const liveStatus = liveLimit?.status || 'ERR';
+    const liveLimitTitle = liveLimit
+        ? [
+            liveState.isActive
+                ? `Live image endpoint is temporarily unavailable for ${formatCompactDuration(liveState.secondsRemaining)}.`
+                : `Image endpoint returned ${liveStatus} ${formatCompactDuration(liveState.secondsAgo)} ago.`,
+            `Reason: ${liveLimit.reason}.`,
+            `Quota snapshot can still show ${percentage}%.`,
+            liveLimit.message ? `Message: ${liveLimit.message}` : null,
+        ].filter(Boolean).join(' ')
+        : label;
     const getBgColorClass = (p: number) => {
         const color = getQuotaColor(p);
         switch (color) {
@@ -48,13 +64,17 @@ export function QuotaItem({ label, percentage, resetTime, isProtected, className
     return (
         <div className={cn(
             "relative h-[22px] flex items-center px-1.5 rounded-md overflow-hidden border border-gray-100/50 dark:border-white/5 bg-gray-50/30 dark:bg-white/5 group/quota",
+            showLiveIssue && "border-amber-400/70 dark:border-amber-500/70 bg-amber-50/80 dark:bg-amber-950/30 ring-1 ring-amber-400/30",
+            liveState.isActive && "border-rose-400/70 dark:border-rose-500/70 bg-rose-50/80 dark:bg-rose-950/30 ring-rose-400/30",
             className
-        )}>
+        )}
+            title={showLiveIssue ? liveLimitTitle : label}
+        >
             {/* Background Progress Bar */}
             <div
                 className={cn(
                     "absolute inset-y-0 left-0 transition-all duration-700 ease-out opacity-15 dark:opacity-20",
-                    getBgColorClass(percentage)
+                    showLiveIssue ? (liveState.isActive ? "bg-rose-500" : "bg-amber-500") : getBgColorClass(percentage)
                 )}
                 style={{ width: `${percentage}%` }}
             />
@@ -62,7 +82,20 @@ export function QuotaItem({ label, percentage, resetTime, isProtected, className
             {/* Content */}
             <div className="relative z-10 w-full flex items-center text-[10px] font-mono leading-none gap-1.5">
                 {/* Model Name */}
-                <span className="flex-1 min-w-0 text-gray-500 dark:text-gray-400 font-bold truncate text-left flex items-center gap-1" title={label}>
+                <span className={cn(
+                    "flex-1 min-w-0 text-gray-500 dark:text-gray-400 font-bold truncate text-left flex items-center gap-1",
+                    showLiveIssue && "text-amber-700 dark:text-amber-300",
+                    liveState.isActive && "text-rose-700 dark:text-rose-300"
+                )} title={showLiveIssue ? liveLimitTitle : label}>
+                    {showLiveIssue && (
+                        <AlertTriangle
+                            size={12}
+                            className={cn(
+                                "shrink-0",
+                                liveState.isActive ? "text-rose-500" : "text-amber-500"
+                            )}
+                        />
+                    )}
                     {Icon && <Icon size={12} className="shrink-0" />}
                     {label}
                 </span>
@@ -80,9 +113,25 @@ export function QuotaItem({ label, percentage, resetTime, isProtected, className
                 </div>
 
                 {/* Percentage */}
-                <span className={cn("w-[28px] text-right font-bold transition-colors flex items-center justify-end gap-0.5 shrink-0", getTextColorClass(percentage))}>
+                <span className={cn(
+                    "text-right font-bold transition-colors flex items-center justify-end gap-0.5 shrink-0",
+                    showLiveIssue ? "w-[58px]" : "w-[28px]",
+                    showLiveIssue ? (liveState.isActive ? "text-rose-700 dark:text-rose-300" : "text-amber-700 dark:text-amber-300") : getTextColorClass(percentage)
+                )}>
                     {isProtected && (
                         <span title={t('accounts.quota_protected')}><Lock className="w-2.5 h-2.5 text-amber-500" /></span>
+                    )}
+                    {showLiveIssue && (
+                        <span
+                            className={cn(
+                                "rounded px-1 py-[1px] text-[9px] leading-none",
+                                liveState.isActive
+                                    ? "bg-rose-500/15 text-rose-700 dark:text-rose-300"
+                                    : "bg-amber-500/15 text-amber-700 dark:text-amber-300"
+                            )}
+                        >
+                            {liveStatus}
+                        </span>
                     )}
                     {percentage}%
                 </span>

--- a/src/components/dashboard/CurrentAccount.tsx
+++ b/src/components/dashboard/CurrentAccount.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, Mail, Diamond, Gem, Circle, Tag, Lock } from 'lucide-react';
+import { CheckCircle, Mail, Diamond, Gem, Circle, Tag, Lock, Clock } from 'lucide-react';
 import { Account } from '../../types/account';
 import { formatTimeRemaining } from '../../utils/format';
 
@@ -36,7 +36,15 @@ function CurrentAccount({ account, onSwitch }: CurrentAccountProps) {
 
     const geminiFlashModel = account.quota?.models.find(m => m.name.toLowerCase() === 'gemini-3-flash');
 
-    const geminiImageModel = account.quota?.models.find(m => m.name.toLowerCase() === 'gemini-3-pro-image');
+    const geminiImageModel = account.quota?.models.find(m => {
+        const name = m.name.toLowerCase();
+        return name === 'gemini-3.1-flash-image' || name === 'gemini-3-pro-image';
+    });
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const liveImageLimit =
+        account.live_limited_models?.['gemini-3.1-flash-image'] ||
+        account.live_limited_models?.['gemini-3-pro-image'];
+    const isImageLiveLimited = Boolean(liveImageLimit && liveImageLimit.until > nowSeconds);
 
     const claudeGroupNames = [
         'claude-opus-4-6-thinking',
@@ -129,8 +137,9 @@ function CurrentAccount({ account, onSwitch }: CurrentAccountProps) {
                     <div className="space-y-1.5">
                         <div className="flex justify-between items-baseline">
                             <span className="text-xs font-medium text-gray-600 dark:text-gray-400 flex items-center gap-1">
-                                {account.protected_models?.includes('gemini-3-pro-image') && <Lock className="w-2.5 h-2.5 text-rose-500" />}
-                                Gemini 3 Pro Image
+                                {isImageLiveLimited && <Clock className="w-2.5 h-2.5 text-amber-500" />}
+                                {(account.protected_models?.includes('gemini-3.1-flash-image') || account.protected_models?.includes('gemini-3-pro-image')) && <Lock className="w-2.5 h-2.5 text-rose-500" />}
+                                Gemini 3.1 Flash Image
                             </span>
                             <div className="flex items-center gap-2">
                                 <span className="text-[10px] text-gray-400 dark:text-gray-500" title={`${t('accounts.reset_time')}: ${new Date(geminiImageModel.reset_time).toLocaleString()}`}>

--- a/src/components/proxy/ProxyMonitor.tsx
+++ b/src/components/proxy/ProxyMonitor.tsx
@@ -320,7 +320,7 @@ export const ProxyMonitor: React.FC<ProxyMonitorProps> = ({ className }) => {
 
                 // 防抖:每 500ms 批量更新一次
                 if (updateTimeout) clearTimeout(updateTimeout);
-                updateTimeout = setTimeout(async () => {
+                updateTimeout = window.setTimeout(async () => {
                     if (!isMountedRef.current) return;
 
                     const currentPending = pendingLogsRef.current;

--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -63,7 +63,7 @@ export const MODEL_CONFIG: Record<string, ModelConfig> = {
     'gemini-3.1-flash-image': {
         label: 'Gemini 3.1 Flash Image',
         shortLabel: 'G3.1 Image',
-        protectedKey: 'gemini-3-pro-image',
+        protectedKey: 'gemini-3.1-flash-image',
         Icon: Gemini.Color,
         i18nKey: 'proxy.model.pro_image',
         i18nDescKey: 'proxy.model.pro_image_1_1',

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -13,6 +13,7 @@ export interface Account {
     proxy_disabled_reason?: string;
     proxy_disabled_at?: number;
     protected_models?: string[];
+    live_limited_models?: Record<string, LiveLimitStatus>;
     custom_label?: string;  // 用户自定义标签
     validation_blocked?: boolean;
     validation_blocked_until?: number;
@@ -20,6 +21,15 @@ export interface Account {
     validation_url?: string;
     created_at: number;
     last_used: number;
+}
+
+export interface LiveLimitStatus {
+    model: string;
+    status: number;
+    reason: string;
+    until: number;
+    detected_at: number;
+    message?: string;
 }
 
 export interface TokenData {
@@ -86,4 +96,3 @@ export interface DeviceProfileVersion {
     profile: DeviceProfile;
     is_current?: boolean;
 }
-


### PR DESCRIPTION
This PR adds support for mapping 'claude-opus-4.6-thinking' and 'claude-opus-4.6' to 'claude-opus-4-6-thinking' in the model mapping table. It also includes the resolved upstream conflicts after pulling the latest changes.