### PR TITLE
fix(proxy): account for media tokens in context estimation

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -22,11 +22,9 @@ pub mod user_token;
 pub async fn list_accounts(
     proxy_state: tauri::State<'_, crate::commands::proxy::ProxyServiceState>,
 ) -> Result<Vec<Account>, String> {
-    let mut accounts = tokio::task::spawn_blocking(move || {
-        modules::list_accounts()
-    })
-    .await
-    .unwrap_or_else(|_| Err("Task panicked".to_string()))?;
+    let mut accounts = tokio::task::spawn_blocking(move || modules::list_accounts())
+        .await
+        .unwrap_or_else(|_| Err("Task panicked".to_string()))?;
 
     // [FIX] Blend in-memory TokenManager rate limit status into the UI quota display
     let instance_lock = proxy_state.instance.read().await;
@@ -193,11 +191,9 @@ use crate::models::AccountExportResponse;
 
 #[tauri::command]
 pub async fn export_accounts(account_ids: Vec<String>) -> Result<AccountExportResponse, String> {
-    tokio::task::spawn_blocking(move || {
-        modules::account::export_accounts_by_ids(&account_ids)
-    })
-    .await
-    .unwrap_or_else(|_| Err("Task panicked".to_string()))
+    tokio::task::spawn_blocking(move || modules::account::export_accounts_by_ids(&account_ids))
+        .await
+        .unwrap_or_else(|_| Err("Task panicked".to_string()))
 }
 
 /// 内部辅助功能：在添加或导入账号后自动刷新一次额度

--- a/src-tauri/src/proxy/droid_sync.rs
+++ b/src-tauri/src/proxy/droid_sync.rs
@@ -339,27 +339,21 @@ pub async fn get_droid_sync_status(proxy_url: String) -> Result<DroidStatus, Str
 
 #[tauri::command]
 pub async fn execute_droid_sync(custom_models: Vec<Value>) -> Result<usize, String> {
-    tokio::task::spawn_blocking(move || {
-        sync_droid_config(custom_models)
-    })
-    .await
-    .unwrap_or_else(|_| Err("Task panicked".to_string()))
+    tokio::task::spawn_blocking(move || sync_droid_config(custom_models))
+        .await
+        .unwrap_or_else(|_| Err("Task panicked".to_string()))
 }
 
 #[tauri::command]
 pub async fn execute_droid_restore() -> Result<(), String> {
-    tokio::task::spawn_blocking(move || {
-        restore_droid_config()
-    })
-    .await
-    .unwrap_or_else(|_| Err("Task panicked".to_string()))
+    tokio::task::spawn_blocking(move || restore_droid_config())
+        .await
+        .unwrap_or_else(|_| Err("Task panicked".to_string()))
 }
 
 #[tauri::command]
 pub async fn get_droid_config_content() -> Result<String, String> {
-    tokio::task::spawn_blocking(move || {
-        read_droid_config_content()
-    })
-    .await
-    .unwrap_or_else(|_| Err("Task panicked".to_string()))
+    tokio::task::spawn_blocking(move || read_droid_config_content())
+        .await
+        .unwrap_or_else(|_| Err("Task panicked".to_string()))
 }

--- a/src-tauri/src/proxy/mappers/context_manager.rs
+++ b/src-tauri/src/proxy/mappers/context_manager.rs
@@ -40,6 +40,94 @@ fn estimate_tokens_from_str(s: &str) -> u32 {
     ((ascii_tokens + unicode_tokens) as f32 * 1.15).ceil() as u32
 }
 
+/// Estimate token cost for an image from an OpenAI-format image_url.
+/// Handles both base64 data URLs and remote URLs.
+/// Gemini counts standard images at ~258 tokens. For very large images
+/// (>1MB base64 payload), we scale up since high-res images tokenize higher.
+fn estimate_image_tokens_from_url(url: &str) -> u32 {
+    const BASE_IMAGE_TOKENS: u32 = 258;
+
+    if url.starts_with("data:") {
+        // data:image/png;base64,<data>
+        // Extract the base64 portion after the comma
+        if let Some(comma_pos) = url.find(',') {
+            let base64_len = url.len() - comma_pos - 1;
+            // Approximate raw bytes: base64 encodes 3 bytes into 4 chars
+            let raw_bytes = (base64_len * 3) / 4;
+
+            // Gemini: standard images = 258 tokens
+            // High-res images (>1MB) scale higher, up to ~10k tokens for very large ones
+            if raw_bytes > 4_000_000 {
+                // >4MB: very high resolution
+                10_000
+            } else if raw_bytes > 1_000_000 {
+                // 1-4MB: high resolution, scale linearly
+                let factor = raw_bytes as f32 / 1_000_000.0;
+                (BASE_IMAGE_TOKENS as f32 * factor * 4.0).ceil() as u32
+            } else {
+                BASE_IMAGE_TOKENS
+            }
+        } else {
+            BASE_IMAGE_TOKENS
+        }
+    } else {
+        // Remote URL: assume standard resolution
+        BASE_IMAGE_TOKENS
+    }
+}
+
+/// Estimate token cost for audio from a URL.
+/// Audio is tokenized at roughly 32 tokens per second.
+/// From base64, we estimate duration from payload size.
+fn estimate_media_tokens_from_url(url: &str) -> u32 {
+    const BASE_AUDIO_TOKENS: u32 = 500; // ~15 seconds default
+
+    if url.starts_with("data:") {
+        if let Some(comma_pos) = url.find(',') {
+            let base64_len = url.len() - comma_pos - 1;
+            let raw_bytes = (base64_len * 3) / 4;
+            // Rough estimate: 16kHz, 16-bit mono audio ≈ 32KB/s
+            // 32 tokens/second
+            let estimated_seconds = raw_bytes as f32 / 32_000.0;
+            let tokens = (estimated_seconds * 32.0).ceil() as u32;
+            tokens.max(64) // minimum 64 tokens for any audio
+        } else {
+            BASE_AUDIO_TOKENS
+        }
+    } else {
+        BASE_AUDIO_TOKENS
+    }
+}
+
+/// Estimate token cost for Gemini inlineData (base64 images/audio in Gemini format).
+/// mime_type determines the estimation strategy. data_len is the length of the base64 string.
+fn estimate_inline_data_tokens(mime_type: &str, data_len: usize) -> u32 {
+    if mime_type.starts_with("image/") {
+        // Same logic as estimate_image_tokens_from_url for base64
+        let raw_bytes = (data_len * 3) / 4;
+        if raw_bytes > 4_000_000 {
+            10_000
+        } else if raw_bytes > 1_000_000 {
+            let factor = raw_bytes as f32 / 1_000_000.0;
+            (258.0 * factor * 4.0).ceil() as u32
+        } else {
+            258
+        }
+    } else if mime_type.starts_with("audio/") {
+        let raw_bytes = (data_len * 3) / 4;
+        let estimated_seconds = raw_bytes as f32 / 32_000.0;
+        (estimated_seconds * 32.0).ceil().max(64.0) as u32
+    } else if mime_type.starts_with("video/") {
+        // Video: very expensive, rough estimate
+        let raw_bytes = (data_len * 3) / 4;
+        let estimated_seconds = raw_bytes as f32 / 500_000.0; // rough video bitrate
+        (estimated_seconds * 300.0).ceil().max(258.0) as u32 // ~300 tokens/sec for video
+    } else {
+        // Unknown media: treat as text approximation
+        estimate_tokens_from_str(&format!("[binary data: {} bytes]", data_len))
+    }
+}
+
 /// Strategy for context purification
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PurificationStrategy {
@@ -743,7 +831,16 @@ impl ContextManager {
                                 crate::proxy::mappers::openai::models::OpenAIContentBlock::Text { text } => {
                                     total += estimate_tokens_from_str(text);
                                 }
-                                _ => {}
+                                crate::proxy::mappers::openai::models::OpenAIContentBlock::ImageUrl { image_url } => {
+                                    // Gemini counts images at ~258 tokens for standard resolution.
+                                    // For base64 data URLs, estimate higher based on payload size
+                                    // since very large images can consume significantly more tokens.
+                                    total += estimate_image_tokens_from_url(&image_url.url);
+                                }
+                                crate::proxy::mappers::openai::models::OpenAIContentBlock::AudioUrl { audio_url } => {
+                                    // Audio is tokenized at ~32 tokens per second (~25 bytes/token from base64)
+                                    total += estimate_media_tokens_from_url(&audio_url.url);
+                                }
                             }
                         }
                     }
@@ -852,6 +949,12 @@ impl ContextManager {
                             if thought {
                                 total += 100; // thinking overhead
                             }
+                        }
+                        // inlineData: base64-encoded images/audio embedded in the request
+                        if let Some(inline_data) = part.get("inlineData") {
+                            let mime = inline_data.get("mimeType").and_then(|m| m.as_str()).unwrap_or("");
+                            let data_len = inline_data.get("data").and_then(|d| d.as_str()).map(|s| s.len()).unwrap_or(0);
+                            total += estimate_inline_data_tokens(mime, data_len);
                         }
                         if let Some(fc) = part.get("functionCall") {
                             total += 20;

--- a/src-tauri/src/proxy/mappers/context_manager.rs
+++ b/src-tauri/src/proxy/mappers/context_manager.rs
@@ -952,8 +952,15 @@ impl ContextManager {
                         }
                         // inlineData: base64-encoded images/audio embedded in the request
                         if let Some(inline_data) = part.get("inlineData") {
-                            let mime = inline_data.get("mimeType").and_then(|m| m.as_str()).unwrap_or("");
-                            let data_len = inline_data.get("data").and_then(|d| d.as_str()).map(|s| s.len()).unwrap_or(0);
+                            let mime = inline_data
+                                .get("mimeType")
+                                .and_then(|m| m.as_str())
+                                .unwrap_or("");
+                            let data_len = inline_data
+                                .get("data")
+                                .and_then(|d| d.as_str())
+                                .map(|s| s.len())
+                                .unwrap_or(0);
                             total += estimate_inline_data_tokens(mime, data_len);
                         }
                         if let Some(fc) = part.get("functionCall") {

--- a/src-tauri/src/proxy/monitor.rs
+++ b/src-tauri/src/proxy/monitor.rs
@@ -49,8 +49,8 @@ impl ProxyMonitor {
         }
 
         // Auto cleanup old logs (keep last 30 days)
-        tokio::task::spawn_blocking(move || {
-            match crate::modules::proxy_db::cleanup_old_logs(30) {
+        tokio::task::spawn_blocking(
+            move || match crate::modules::proxy_db::cleanup_old_logs(30) {
                 Ok(deleted) => {
                     if deleted > 0 {
                         tracing::info!("Auto cleanup: removed {} old logs (>30 days)", deleted);
@@ -59,8 +59,8 @@ impl ProxyMonitor {
                 Err(e) => {
                     tracing::error!("Failed to cleanup old logs: {}", e);
                 }
-            }
-        });
+            },
+        );
 
         Self {
             logs: RwLock::new(VecDeque::with_capacity(max_logs)),

--- a/src-tauri/src/proxy/opencode_sync.rs
+++ b/src-tauri/src/proxy/opencode_sync.rs
@@ -1723,11 +1723,9 @@ pub async fn execute_opencode_sync(
 
 #[tauri::command]
 pub async fn execute_opencode_restore() -> Result<(), String> {
-    tokio::task::spawn_blocking(move || {
-        restore_opencode_config()
-    })
-    .await
-    .unwrap_or_else(|_| Err("Failed to execute restore".to_string()))
+    tokio::task::spawn_blocking(move || restore_opencode_config())
+        .await
+        .unwrap_or_else(|_| Err("Failed to execute restore".to_string()))
 }
 
 #[derive(Deserialize)]
@@ -1740,11 +1738,9 @@ pub struct GetOpencodeConfigRequest {
 pub async fn get_opencode_config_content(
     request: GetOpencodeConfigRequest,
 ) -> Result<String, String> {
-    tokio::task::spawn_blocking(move || {
-        read_opencode_config_content(request.file_name)
-    })
-    .await
-    .unwrap_or_else(|_| Err("Failed to read config".to_string()))
+    tokio::task::spawn_blocking(move || read_opencode_config_content(request.file_name))
+        .await
+        .unwrap_or_else(|_| Err("Failed to read config".to_string()))
 }
 
 /// List of Antigravity model IDs that may have been added to legacy providers

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -2054,7 +2054,9 @@ impl TokenManager {
         };
 
         let mut content: serde_json::Value = serde_json::from_str(
-            &tokio::fs::read_to_string(&path).await.map_err(|e| format!("读取文件失败: {}", e))?,
+            &tokio::fs::read_to_string(&path)
+                .await
+                .map_err(|e| format!("读取文件失败: {}", e))?,
         )
         .map_err(|e| format!("解析 JSON 失败: {}", e))?;
 
@@ -2081,7 +2083,9 @@ impl TokenManager {
         let path = &entry.account_path;
 
         let mut content: serde_json::Value = serde_json::from_str(
-            &tokio::fs::read_to_string(path).await.map_err(|e| format!("读取文件失败: {}", e))?,
+            &tokio::fs::read_to_string(path)
+                .await
+                .map_err(|e| format!("读取文件失败: {}", e))?,
         )
         .map_err(|e| format!("解析 JSON 失败: {}", e))?;
 


### PR DESCRIPTION
## Summary
- account for OpenAI image_url and audio_url content blocks during context token estimation
- account for Gemini inlineData media payloads during context token estimation
- prevents media-heavy payloads from bypassing compression thresholds and reaching Gemini as oversized requests

## Validation
- cargo check