### PR TITLE
feat: add Windows and Linux x86_64 PE binary pattern patching support

### DIFF
--- a/src-tauri/src/commands/patch.rs
+++ b/src-tauri/src/commands/patch.rs
@@ -13,66 +13,113 @@ pub async fn patch_agy_binary(file_path: String) -> Result<String, String> {
     let n = data.len();
     let mut patch_offset = None;
     let mut new_inst_bytes = None;
+    let mut is_pe_x64 = false;
 
-    // Scan for eligibility gate pattern (ARM64)
-    for i in (0..n - 20).step_by(4) {
-        let inst1 = u32::from_le_bytes(data[i..i+4].try_into().unwrap());
-        let inst2 = u32::from_le_bytes(data[i+4..i+8].try_into().unwrap());
-        let inst4 = u32::from_le_bytes(data[i+12..i+16].try_into().unwrap());
-        let inst5 = u32::from_le_bytes(data[i+16..i+20].try_into().unwrap());
-
-        // 1. ldrb wA, [xB, #0x58]
-        if (inst1 & 0xfffffc00) != 0x39416000 {
-            continue;
+    // 1. Scan for x86_64 PE (Windows/Linux) pattern
+    // Pattern: cmpb $0x0, (%r12) -> 41 80 3c 24 00
+    //          jne offset32      -> 0f 85 XX XX XX XX
+    //          leaq rip_off, rax -> 48 8d 05 XX XX XX XX
+    //          mov $0x18, %ebx   -> bb 18 00 00 00
+    let pe_pattern = [0x41, 0x80, 0x3c, 0x24, 0x00, 0x0f, 0x85];
+    let mut i = 0;
+    while i < n - 25 {
+        if data[i..i+7] == pe_pattern {
+            // Validate the rest of the pattern
+            // leaq opcode starts after jne (which is 6 bytes: 0f 85 XX XX XX XX)
+            let leaq_idx = i + 5 + 6;
+            if data[leaq_idx..leaq_idx+3] == [0x48, 0x8d, 0x05] {
+                // mov $0x18, %ebx starts after leaq (which is 7 bytes: 48 8d 05 XX XX XX XX)
+                let mov_idx = leaq_idx + 7;
+                if data[mov_idx..mov_idx+2] == [0xbb, 0x18] {
+                    // Found the gate!
+                    patch_offset = Some(i + 5); // Points to the jne instruction: 0f 85 ...
+                    // Rewrite jne to 6 NOP bytes (0x90) so it falls through unconditionally
+                    new_inst_bytes = Some(vec![0x90; 6]);
+                    is_pe_x64 = true;
+                    break;
+                }
+            }
         }
-        let b_reg = (inst1 >> 5) & 0x1f;
-        let a_reg = inst1 & 0x1f;
+        i += 1;
+    }
 
-        // 2. tbnz wA, #0, label1
-        if (inst2 & 0xffe0001f) != (0x37000000 | a_reg) {
-            continue;
+    // 2. Scan for ARM64 eligibility gate pattern if not PE x86_64
+    if patch_offset.is_none() {
+        for j in (0..n - 20).step_by(4) {
+            let inst1 = u32::from_le_bytes(data[j..j+4].try_into().unwrap());
+            let inst2 = u32::from_le_bytes(data[j+4..j+8].try_into().unwrap());
+            let inst4 = u32::from_le_bytes(data[j+12..j+16].try_into().unwrap());
+            let inst5 = u32::from_le_bytes(data[j+16..j+20].try_into().unwrap());
+
+            // 1. ldrb wA, [xB, #0x58]
+            if (inst1 & 0xfffffc00) != 0x39416000 {
+                continue;
+            }
+            let b_reg = (inst1 >> 5) & 0x1f;
+            let a_reg = inst1 & 0x1f;
+
+            // 2. tbnz wA, #0, label1
+            if (inst2 & 0xffe0001f) != (0x37000000 | a_reg) {
+                continue;
+            }
+
+            // 3. ldr xC, [xB, #0x38]
+            if (inst4 & 0xfffffc00) != 0xf9401c00 || ((inst4 >> 5) & 0x1f) != b_reg {
+                continue;
+            }
+            let c_reg = inst4 & 0x1f;
+
+            // 4. cbz xC, label_send
+            if (inst5 & 0xffe0001f) != (0xb4000000 | c_reg) {
+                continue;
+            }
+
+            // Extract imm19 from cbz
+            let imm19_raw = (inst5 >> 5) & 0x7ffff;
+            let imm19 = if (imm19_raw & 0x40000) != 0 {
+                (imm19_raw as i32) - 0x80000
+            } else {
+                imm19_raw as i32
+            };
+
+            patch_offset = Some(j + 16);
+            // Encode unconditional branch: b label_send (0x14000000 | (imm19 & 0x3ffffff))
+            let b_inst = 0x14000000 | ((imm19 as u32) & 0x3ffffff);
+            new_inst_bytes = Some(b_inst.to_le_bytes().to_vec());
+            break;
         }
-
-        // 3. ldr xC, [xB, #0x38]
-        if (inst4 & 0xfffffc00) != 0xf9401c00 || ((inst4 >> 5) & 0x1f) != b_reg {
-            continue;
-        }
-        let c_reg = inst4 & 0x1f;
-
-        // 4. cbz xC, label_send
-        if (inst5 & 0xffe0001f) != (0xb4000000 | c_reg) {
-            continue;
-        }
-
-        // Extract imm19 from cbz
-        let imm19_raw = (inst5 >> 5) & 0x7ffff;
-        let imm19 = if (imm19_raw & 0x40000) != 0 {
-            (imm19_raw as i32) - 0x80000
-        } else {
-            imm19_raw as i32
-        };
-
-        patch_offset = Some(i + 16);
-        // Encode unconditional branch: b label_send (0x14000000 | (imm19 & 0x3ffffff))
-        let b_inst = 0x14000000 | ((imm19 as u32) & 0x3ffffff);
-        new_inst_bytes = Some(b_inst.to_le_bytes());
-        break;
     }
 
     if patch_offset.is_none() {
-        // Check if already patched
-        for i in (0..n - 20).step_by(4) {
-            let inst1 = u32::from_le_bytes(data[i..i+4].try_into().unwrap());
-            let inst2 = u32::from_le_bytes(data[i+4..i+8].try_into().unwrap());
-            let inst4 = u32::from_le_bytes(data[i+12..i+16].try_into().unwrap());
-            let inst5 = u32::from_le_bytes(data[i+16..i+20].try_into().unwrap());
+        // Check if already patched for x86_64 PE
+        let mut check_idx = 0;
+        while check_idx < n - 25 {
+            if data[check_idx..check_idx+7] == pe_pattern {
+                let leaq_idx = check_idx + 5 + 6;
+                if data[leaq_idx..leaq_idx+3] == [0x48, 0x8d, 0x05] {
+                    let mov_idx = leaq_idx + 7;
+                    if data[mov_idx..mov_idx+2] == [0xbb, 0x18] {
+                        if data[check_idx+5..check_idx+11] == [0x90; 6] {
+                            return Ok("Binary is already patched.".into());
+                        }
+                    }
+                }
+            }
+            check_idx += 1;
+        }
+
+        // Check if already patched for ARM64
+        for j in (0..n - 20).step_by(4) {
+            let inst1 = u32::from_le_bytes(data[j..j+4].try_into().unwrap());
+            let inst2 = u32::from_le_bytes(data[j+4..j+8].try_into().unwrap());
+            let inst4 = u32::from_le_bytes(data[j+12..j+16].try_into().unwrap());
+            let inst5 = u32::from_le_bytes(data[j+16..j+20].try_into().unwrap());
 
             if (inst1 & 0xfffffc00) == 0x39416000 {
                 let b_reg = (inst1 >> 5) & 0x1f;
                 let a_reg = inst1 & 0x1f;
                 if (inst2 & 0xffe0001f) == (0x37000000 | a_reg) {
                     if (inst4 & 0xfffffc00) == 0xf9401c00 && ((inst4 >> 5) & 0x1f) == b_reg {
-                        // If inst5 is already `b label_send` (0x14000000)
                         if (inst5 & 0xfc000000) == 0x14000000 {
                             return Ok("Binary is already patched.".into());
                         }
@@ -80,6 +127,7 @@ pub async fn patch_agy_binary(file_path: String) -> Result<String, String> {
                 }
             }
         }
+
         return Err("Pattern not found. This version of the CLI might not have the eligibility gate, or the structure has changed.".into());
     }
 
@@ -103,18 +151,20 @@ pub async fn patch_agy_binary(file_path: String) -> Result<String, String> {
     file.write_all(&patch_bytes)
         .map_err(|e| format!("Write failed: {}", e))?;
 
-    // Re-sign on macOS
+    // Re-sign on macOS (only if we patched an ARM64 macOS executable)
     #[cfg(target_os = "macos")]
     {
-        let _ = Command::new("codesign")
-            .args(&["--remove-signature", &file_path])
-            .output();
-        let status = Command::new("codesign")
-            .args(&["--sign", "-", &file_path])
-            .status();
-        match status {
-            Ok(s) if s.success() => {},
-            _ => return Err("Patch applied, but codesigning failed on macOS.".into()),
+        if !is_pe_x64 {
+            let _ = Command::new("codesign")
+                .args(&["--remove-signature", &file_path])
+                .output();
+            let status = Command::new("codesign")
+                .args(&["--sign", "-", &file_path])
+                .status();
+            match status {
+                Ok(s) if s.success() => {},
+                _ => return Err("Patch applied, but codesigning failed on macOS.".into()),
+            }
         }
     }
 


### PR DESCRIPTION
### 💡 Background
In newer versions of the Google Antigravity CLI binary client (`agy` / `antigravity.exe` 1.1.2 and above), a local **Eligibility Check** is enforced. If the user's Google account is not configured as eligible on the server, the client intercepts inputs in the interactive terminal (TUI) and prompts:
`Your current account is not eligible for Antigravity...`

This prevents unauthorized accounts from starting local conversations. This Pull Request implements an **instruction-level pattern matching patcher** that dynamically bypasses this local gate without modifying network configurations.

---

### 🛠️ Key Changes

1. **Rust Backend (`src-tauri`)**:
   * Added the Tauri command `patch_agy_binary` ([patch.rs](src-tauri/src/commands/patch.rs)).
   * **Multi-Architecture Support**:
     * **macOS (ARM64)**: Scans machine code by 4-byte (32-bit aligned) strides to dynamically locate the `userInputLoop` instruction pattern (`ldrb`, `tbnz`, `ldr`, and `cbz`) and overwrites the conditional branch `cbz` to `b` (unconditional jump to the send path) to bypass the gate. Also handles macOS ad-hoc code re-signing.
     * **Windows/Linux (x86_64 PE/ELF)**: Scans for the x86_64 verification gate pattern: `cmpb $0x0, (%r12)`, `jne label`, `leaq rip_off, %rax`, `mov $0x18, %ebx`. Dynamically replaces the conditional jump instruction `jne` with NOP (6 bytes of `0x90`) to bypass the gate.
   * Handles backing up the binary to `.bak`.

2. **React Frontend UI (`src`)**:
   * Updated the Advanced Settings tab in [Settings.tsx](src/pages/Settings.tsx). If an executable path for Antigravity is specified, it will automatically show a patch panel allowing the user to bypass the check with one click.
   * Invokes the Tauri backend command and handles user toast feedback.
   * Added i18n keys for Chinese and English in [zh.json](src/locales/zh.json) and [en.json](src/locales/en.json).

---

### 🧪 Tested & Verified
* **Platform**: macOS (ARM64) & Windows (x64)
* **Target Binary**: Antigravity CLI 1.1.2
* **Result**: Successfully bypassed the `Eligibility Check failed` window and restored fully working AI interactions in the terminal for standard Google accounts.
