### PR TITLE
feat(quota): 配额查找统一与模型显示名回退

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -624,6 +624,7 @@ pub fn run() {
             proxy::cli_sync::execute_cli_restore,
             proxy::cli_sync::get_cli_config_content,
             proxy::opencode_sync::get_opencode_sync_status,
+            proxy::opencode_sync::get_canonical_families,
             proxy::opencode_sync::execute_opencode_sync,
             proxy::opencode_sync::execute_opencode_restore,
             proxy::opencode_sync::get_opencode_config_content,

--- a/src-tauri/src/proxy/common/mod.rs
+++ b/src-tauri/src/proxy/common/mod.rs
@@ -11,3 +11,4 @@ pub mod session;
 pub mod tool_adapter;
 pub mod tool_adapters;
 pub mod utils; // [ADDED v4.1.24] Tools for deriving stable session identifiers
+pub mod variant_mapping; // Canonical model + variant → real model ID + params

--- a/src-tauri/src/proxy/common/variant_mapping.rs
+++ b/src-tauri/src/proxy/common/variant_mapping.rs
@@ -78,6 +78,16 @@ pub fn infer_tier(budget_tokens: Option<u32>) -> VariantTier {
     }
 }
 
+/// Parse a supported Anthropic SDK output effort into a Gemini variant tier.
+pub fn tier_from_effort(effort: Option<&str>) -> Option<VariantTier> {
+    match effort {
+        Some("low") => Some(VariantTier::Low),
+        Some("medium") => Some(VariantTier::Medium),
+        Some("high") => Some(VariantTier::High),
+        _ => None,
+    }
+}
+
 /// Resolve a canonical model + tier to the real model + params.
 ///
 /// Returns None for models that have no variant split (use
@@ -136,12 +146,21 @@ pub fn resolve_non_variant_model(model: &str) -> Option<RealModelSpec> {
     None
 }
 
-/// Top-level resolver: tries variant split first, then non-variant, for any model.
+/// Resolve a model with an optional explicit variant tier.
 ///
-/// `budget_tokens` is the client-sent thinking budget used to infer the tier.
-pub fn resolve(canonical: &str, budget_tokens: Option<u32>) -> Option<RealModelSpec> {
-    let tier = infer_tier(budget_tokens);
+/// An explicit tier takes precedence over the client thinking budget.
+pub fn resolve_with_tier(
+    canonical: &str,
+    explicit_tier: Option<VariantTier>,
+    budget_tokens: Option<u32>,
+) -> Option<RealModelSpec> {
+    let tier = explicit_tier.unwrap_or_else(|| infer_tier(budget_tokens));
     resolve_real_model(canonical, tier).or_else(|| resolve_non_variant_model(canonical))
+}
+
+/// Top-level compatibility resolver using the client thinking budget.
+pub fn resolve(canonical: &str, budget_tokens: Option<u32>) -> Option<RealModelSpec> {
+    resolve_with_tier(canonical, None, budget_tokens)
 }
 
 // ── verified real model specs (from upstream spec) ──
@@ -323,6 +342,61 @@ mod tests {
         let s = resolve("gemini-3.5-flash", Some(1000)).unwrap();
         assert_eq!(s.id, "gemini-3.5-flash-extra-low");
         assert_eq!(s.thinking_budget, 1000);
+    }
+
+    #[test]
+    fn tier_from_effort_accepts_only_anthropic_sdk_values() {
+        assert_eq!(tier_from_effort(Some("low")), Some(VariantTier::Low));
+        assert_eq!(tier_from_effort(Some("medium")), Some(VariantTier::Medium));
+        assert_eq!(tier_from_effort(Some("high")), Some(VariantTier::High));
+        assert_eq!(tier_from_effort(Some("max")), None);
+        assert_eq!(tier_from_effort(None), None);
+    }
+
+    #[test]
+    fn resolve_with_tier_prefers_explicit_effort_over_budget() {
+        for (canonical, tier, budget, expected_id) in [
+            (
+                "gemini-3.5-flash",
+                VariantTier::Low,
+                10_000,
+                "gemini-3.5-flash-extra-low",
+            ),
+            (
+                "gemini-3.5-flash",
+                VariantTier::Medium,
+                1_000,
+                "gemini-3.5-flash-low",
+            ),
+            (
+                "gemini-3.5-flash",
+                VariantTier::High,
+                1_000,
+                "gemini-3-flash-agent",
+            ),
+            (
+                "gemini-3.1-pro",
+                VariantTier::Low,
+                10_000,
+                "gemini-3.1-pro-low",
+            ),
+            (
+                "gemini-3.1-pro",
+                VariantTier::Medium,
+                1_000,
+                "gemini-pro-agent",
+            ),
+            (
+                "gemini-3.1-pro",
+                VariantTier::High,
+                1_000,
+                "gemini-pro-agent",
+            ),
+        ] {
+            let spec = resolve_with_tier(canonical, Some(tier), Some(budget))
+                .expect("canonical Gemini tier must resolve");
+            assert_eq!(spec.id, expected_id);
+        }
     }
 
     #[test]

--- a/src-tauri/src/proxy/common/variant_mapping.rs
+++ b/src-tauri/src/proxy/common/variant_mapping.rs
@@ -1,0 +1,526 @@
+//! Canonical model + variant → real model ID + real params.
+//!
+//! OpenCode 配置 canonical 模型（如 `gemini-3.5-flash`）带 variants（low/medium/high）。
+//! 收到请求后，AM 根据 canonical + 档位映射到目标模型 ID
+//! （如 `gemini-3-flash-agent`），并用已校准的 thinkingBudget / maxOutputTokens
+//! 替换客户端传来的值，保证中转请求参数与上游服务一致。
+//!
+//! 所有数值为已校准的目标模型参数。
+
+/// Variant tier inferred from the client's `thinking.budget_tokens`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariantTier {
+    Low,
+    Medium,
+    High,
+}
+
+/// How an alias selects a variant tier within its canonical Gemini family.
+#[derive(Debug, Clone, Copy)]
+pub enum AliasPolicy {
+    HonorTier,
+    Fixed(VariantTier),
+}
+
+/// Static metadata and tier routing for one canonical Gemini model family.
+pub struct CanonicalFamily {
+    pub canonical_id: &'static str,
+    pub display_name: &'static str,
+    pub context_limit: u32,
+    pub output_limit: u32,
+    pub input_modalities: &'static [&'static str],
+    pub output_modalities: &'static [&'static str],
+    pub reasoning: bool,
+    pub tiers: &'static [(VariantTier, RealModelSpec)],
+    pub aliases: &'static [(&'static str, AliasPolicy)],
+}
+
+/// A resolved real model with its verified request params.
+#[derive(Debug, Clone, Copy)]
+pub struct RealModelSpec {
+    /// The real model ID to put in the upstream `model` field.
+    pub id: &'static str,
+    /// verified thinkingBudget (0 means no thinking).
+    pub thinking_budget: u32,
+    /// verified maxOutputTokens.
+    pub max_output_tokens: u32,
+    /// Whether to include thoughts in the response.
+    pub include_thoughts: bool,
+    /// Whether a Claude client-selected thinking budget may pass through.
+    pub preserve_client_budget: bool,
+}
+
+impl RealModelSpec {
+    /// Select the upstream thinking budget for this resolved model.
+    pub const fn effective_thinking_budget(&self, client_budget: Option<u32>) -> u32 {
+        if self.preserve_client_budget {
+            match client_budget {
+                Some(budget) => budget,
+                None => self.thinking_budget,
+            }
+        } else {
+            self.thinking_budget
+        }
+    }
+}
+
+/// Infer the variant tier from the client-sent `thinking.budget_tokens`.
+///
+/// OpenCode derives budgetTokens from its model capabilities (max = budget-1,
+/// high = floor(budget/2)), so the exact value is not the real budget —
+/// we only use its magnitude to guess which tier the user selected. When no budget
+/// is present we default to High (the most capable tier).
+pub fn infer_tier(budget_tokens: Option<u32>) -> VariantTier {
+    match budget_tokens {
+        Some(b) if b < 2000 => VariantTier::Low,
+        Some(b) if b < 7000 => VariantTier::Medium,
+        _ => VariantTier::High,
+    }
+}
+
+/// Resolve a canonical model + tier to the real model + params.
+///
+/// Returns None for models that have no variant split (use
+/// [`resolve_non_variant_model`] for those).
+pub fn resolve_real_model(canonical: &str, tier: VariantTier) -> Option<RealModelSpec> {
+    // Normalize: lowercase, trim a trailing variant-like suffix the client may have appended.
+    let key = canonical.to_lowercase();
+    for family in GEMINI_FAMILIES {
+        let resolved_tier = if family.canonical_id == key.as_str() {
+            tier
+        } else if let Some((_, policy)) = family
+            .aliases
+            .iter()
+            .find(|(alias, _)| *alias == key.as_str())
+        {
+            match *policy {
+                AliasPolicy::HonorTier => tier,
+                AliasPolicy::Fixed(fixed_tier) => fixed_tier,
+            }
+        } else {
+            continue;
+        };
+
+        return family
+            .tiers
+            .iter()
+            .find(|(candidate_tier, _)| *candidate_tier == resolved_tier)
+            .map(|(_, spec)| *spec);
+    }
+
+    None
+}
+
+/// Resolve a canonical model that has NO variant split — use real ID + params directly.
+///
+/// Covers models the user may configure without variants (flash-lite, claude, etc.).
+/// Also accepts the real IDs themselves (idempotent passthrough).
+pub fn resolve_non_variant_model(model: &str) -> Option<RealModelSpec> {
+    let key = model.to_lowercase();
+    // gemini-3.1-flash-lite: checkpoint-only model, no thinking.
+    if matches!(
+        key.as_str(),
+        "gemini-3.1-flash-lite" | "gemini-2.5-flash-lite" | "gemini-2.5-flash" | "gemini-2.5-flash-thinking"
+    ) {
+        return Some(SPEC_31_FLASH_LITE);
+    }
+    if key == "claude-sonnet-4-6" {
+        return Some(SPEC_CLAUDE_SONNET_46);
+    }
+    if matches!(key.as_str(), "claude-opus-4-6-thinking" | "claude-opus-4-6") {
+        return Some(SPEC_CLAUDE_OPUS_46);
+    }
+    if key == "gpt-oss-120b-medium" {
+        return Some(SPEC_GPT_OSS_120B);
+    }
+    None
+}
+
+/// Top-level resolver: tries variant split first, then non-variant, for any model.
+///
+/// `budget_tokens` is the client-sent thinking budget used to infer the tier.
+pub fn resolve(canonical: &str, budget_tokens: Option<u32>) -> Option<RealModelSpec> {
+    let tier = infer_tier(budget_tokens);
+    resolve_real_model(canonical, tier).or_else(|| resolve_non_variant_model(canonical))
+}
+
+// ── verified real model specs (from upstream spec) ──
+// gemini-3.5-flash family (maxOutputTokens = 65536)
+const SPEC_35_FLASH_EXTRA_LOW: RealModelSpec = RealModelSpec {
+    id: "gemini-3.5-flash-extra-low",
+    thinking_budget: 1000,
+    max_output_tokens: 65536,
+    include_thoughts: true,
+    preserve_client_budget: false,
+};
+const SPEC_35_FLASH_LOW: RealModelSpec = RealModelSpec {
+    id: "gemini-3.5-flash-low",
+    thinking_budget: 4000,
+    max_output_tokens: 65536,
+    include_thoughts: true,
+    preserve_client_budget: false,
+};
+const SPEC_3_FLASH_AGENT: RealModelSpec = RealModelSpec {
+    id: "gemini-3-flash-agent",
+    thinking_budget: 10000,
+    max_output_tokens: 65536,
+    include_thoughts: true,
+    preserve_client_budget: false,
+};
+
+// gemini-3.1-pro family (maxOutputTokens = 65535 — note the off-by-one vs Flash)
+const SPEC_31_PRO_LOW: RealModelSpec = RealModelSpec {
+    id: "gemini-3.1-pro-low",
+    thinking_budget: 1001,
+    max_output_tokens: 65535,
+    include_thoughts: true,
+    preserve_client_budget: false,
+};
+const SPEC_PRO_AGENT: RealModelSpec = RealModelSpec {
+    id: "gemini-pro-agent",
+    thinking_budget: 10001,
+    max_output_tokens: 65535,
+    include_thoughts: true,
+    preserve_client_budget: false,
+};
+
+// Non-variant models
+const SPEC_31_FLASH_LITE: RealModelSpec = RealModelSpec {
+    id: "gemini-3.1-flash-lite",
+    thinking_budget: 0,
+    max_output_tokens: 16384,
+    include_thoughts: false,
+    preserve_client_budget: false,
+};
+const SPEC_CLAUDE_SONNET_46: RealModelSpec = RealModelSpec {
+    id: "claude-sonnet-4-6",
+    thinking_budget: 1024,
+    max_output_tokens: 64000,
+    include_thoughts: true,
+    preserve_client_budget: true,
+};
+const SPEC_CLAUDE_OPUS_46: RealModelSpec = RealModelSpec {
+    id: "claude-opus-4-6-thinking",
+    thinking_budget: 1024,
+    max_output_tokens: 64000,
+    include_thoughts: true,
+    preserve_client_budget: true,
+};
+const SPEC_GPT_OSS_120B: RealModelSpec = RealModelSpec {
+    id: "gpt-oss-120b-medium",
+    thinking_budget: 8192,
+    max_output_tokens: 32768,
+    include_thoughts: true,
+    preserve_client_budget: false,
+};
+
+pub static GEMINI_FAMILIES: &[CanonicalFamily] = &[
+    CanonicalFamily {
+        canonical_id: "gemini-3.5-flash",
+        display_name: "Gemini 3.5 Flash",
+        context_limit: 1_000_000,
+        output_limit: 65_536,
+        input_modalities: &["text", "image", "audio", "video", "pdf"],
+        output_modalities: &["text"],
+        reasoning: true,
+        tiers: &[
+            (VariantTier::Low, SPEC_35_FLASH_EXTRA_LOW),
+            (VariantTier::Medium, SPEC_35_FLASH_LOW),
+            (VariantTier::High, SPEC_3_FLASH_AGENT),
+        ],
+        aliases: &[
+            ("gemini-3.5-flash-high", AliasPolicy::HonorTier),
+            (
+                "gemini-3.5-flash-medium",
+                AliasPolicy::Fixed(VariantTier::Medium),
+            ),
+            (
+                "gemini-3.5-flash-low",
+                AliasPolicy::Fixed(VariantTier::Low),
+            ),
+            ("gemini-3-flash", AliasPolicy::HonorTier),
+        ],
+    },
+    CanonicalFamily {
+        canonical_id: "gemini-3.1-pro",
+        display_name: "Gemini 3.1 Pro",
+        context_limit: 1_048_576,
+        output_limit: 65_535,
+        input_modalities: &["text", "image", "audio", "video", "pdf"],
+        output_modalities: &["text"],
+        reasoning: true,
+        tiers: &[
+            (VariantTier::Low, SPEC_31_PRO_LOW),
+            (VariantTier::Medium, SPEC_PRO_AGENT),
+            (VariantTier::High, SPEC_PRO_AGENT),
+        ],
+        aliases: &[
+            ("gemini-3.1-pro-high", AliasPolicy::HonorTier),
+            ("gemini-pro", AliasPolicy::HonorTier),
+            (
+                "gemini-3.1-pro-low",
+                AliasPolicy::Fixed(VariantTier::Low),
+            ),
+        ],
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_specs_preserve_the_client_budget() {
+        assert!(SPEC_CLAUDE_SONNET_46.preserve_client_budget);
+        assert!(SPEC_CLAUDE_OPUS_46.preserve_client_budget);
+        assert_eq!(
+            SPEC_CLAUDE_OPUS_46.effective_thinking_budget(Some(32_768)),
+            32_768
+        );
+        assert_eq!(SPEC_CLAUDE_OPUS_46.effective_thinking_budget(None), 1_024);
+    }
+
+    #[test]
+    fn non_claude_specs_keep_the_server_budget() {
+        assert!(!SPEC_35_FLASH_EXTRA_LOW.preserve_client_budget);
+        assert!(!SPEC_35_FLASH_LOW.preserve_client_budget);
+        assert!(!SPEC_3_FLASH_AGENT.preserve_client_budget);
+        assert!(!SPEC_31_PRO_LOW.preserve_client_budget);
+        assert!(!SPEC_PRO_AGENT.preserve_client_budget);
+        assert!(!SPEC_31_FLASH_LITE.preserve_client_budget);
+        assert!(!SPEC_GPT_OSS_120B.preserve_client_budget);
+        assert_eq!(
+            SPEC_3_FLASH_AGENT.effective_thinking_budget(Some(32_768)),
+            10_000
+        );
+    }
+
+    #[test]
+    fn test_infer_tier_ranges() {
+        assert_eq!(infer_tier(None), VariantTier::High);
+        assert_eq!(infer_tier(Some(0)), VariantTier::Low);
+        assert_eq!(infer_tier(Some(1999)), VariantTier::Low);
+        assert_eq!(infer_tier(Some(2000)), VariantTier::Medium);
+        assert_eq!(infer_tier(Some(6999)), VariantTier::Medium);
+        assert_eq!(infer_tier(Some(7000)), VariantTier::High);
+        assert_eq!(infer_tier(Some(50000)), VariantTier::High);
+    }
+
+    #[test]
+    fn test_resolve_35_flash_variants() {
+        // High (default)
+        let s = resolve("gemini-3.5-flash", None).unwrap();
+        assert_eq!(s.id, "gemini-3-flash-agent");
+        assert_eq!(s.thinking_budget, 10000);
+        assert_eq!(s.max_output_tokens, 65536);
+
+        // Medium
+        let s = resolve("gemini-3.5-flash", Some(4000)).unwrap();
+        assert_eq!(s.id, "gemini-3.5-flash-low");
+        assert_eq!(s.thinking_budget, 4000);
+
+        // Low
+        let s = resolve("gemini-3.5-flash", Some(1000)).unwrap();
+        assert_eq!(s.id, "gemini-3.5-flash-extra-low");
+        assert_eq!(s.thinking_budget, 1000);
+    }
+
+    #[test]
+    fn gemini_3_flash_alias_follows_tier() {
+        check("gemini-3-flash", Some(0), "gemini-3.5-flash-extra-low", 1000, 65536);
+        check("gemini-3-flash", Some(4000), "gemini-3.5-flash-low", 4000, 65536);
+        check("gemini-3-flash", None, "gemini-3-flash-agent", 10000, 65536);
+    }
+
+    #[test]
+    fn test_resolve_31_pro_variants() {
+        let s = resolve("gemini-3.1-pro", None).unwrap();
+        assert_eq!(s.id, "gemini-pro-agent");
+        assert_eq!(s.thinking_budget, 10001);
+        assert_eq!(s.max_output_tokens, 65535); // Pro uses 65535, not 65536
+
+        let s = resolve("gemini-3.1-pro", Some(1001)).unwrap();
+        assert_eq!(s.id, "gemini-3.1-pro-low");
+        assert_eq!(s.thinking_budget, 1001);
+    }
+
+    #[test]
+    fn test_resolve_non_variant_models() {
+        let s = resolve("gemini-3.1-flash-lite", None).unwrap();
+        assert_eq!(s.id, "gemini-3.1-flash-lite");
+        assert_eq!(s.thinking_budget, 0);
+        assert!(!s.include_thoughts);
+
+        let s = resolve("claude-sonnet-4-6", None).unwrap();
+        assert_eq!(s.id, "claude-sonnet-4-6");
+        assert_eq!(s.thinking_budget, 1024);
+        assert_eq!(s.max_output_tokens, 64000);
+    }
+
+    #[test]
+    fn test_unknown_model_returns_none() {
+        assert!(resolve("some-unknown-model", None).is_none());
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let s = resolve("GEMINI-3.5-FLASH", None).unwrap();
+        assert_eq!(s.id, "gemini-3-flash-agent");
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    // baseline tests — capture current resolve() output as equivalence
+    // anchors for future refactoring.  Do NOT change these assertions;
+    // if a refactor breaks them, the refactor is wrong.
+    // ═════════════════════════════════════════════════════════════════════
+
+    /// Helper: call `resolve(canonical, budget)` and assert id / tb / mot.
+    fn check(canonical: &str, budget: Option<u32>, id: &str, tb: u32, mot: u32) {
+        let s = resolve(canonical, budget)
+            .unwrap_or_else(|| panic!("resolve({canonical:?}, {budget:?}) unexpectedly returned None"));
+        assert_eq!(s.id, id, "resolve({canonical:?}, {budget:?}).id");
+        assert_eq!(s.thinking_budget, tb, "resolve({canonical:?}, {budget:?}).thinking_budget");
+        assert_eq!(s.max_output_tokens, mot, "resolve({canonical:?}, {budget:?}).max_output_tokens");
+    }
+
+    #[test]
+    fn baseline_resolve_35_flash_variants() {
+        // ── gemini-3.5-flash (canonical) ───────────────────────────────
+        // None → High → gemini-3-flash-agent
+        check("gemini-3.5-flash", None, "gemini-3-flash-agent", 10000, 65536);
+        // Some(0) → Low → gemini-3.5-flash-extra-low
+        check("gemini-3.5-flash", Some(0), "gemini-3.5-flash-extra-low", 1000, 65536);
+        // Some(4000) → Medium → gemini-3.5-flash-low
+        check("gemini-3.5-flash", Some(4000), "gemini-3.5-flash-low", 4000, 65536);
+        // Some(7000) → High → gemini-3-flash-agent
+        check("gemini-3.5-flash", Some(7000), "gemini-3-flash-agent", 10000, 65536);
+
+        // ── gemini-3.5-flash-high ──────────────────────────────────────
+        // Same canonical arm as gemini-3.5-flash (both match the first arm)
+        check("gemini-3.5-flash-high", None, "gemini-3-flash-agent", 10000, 65536);
+        check("gemini-3.5-flash-high", Some(0), "gemini-3.5-flash-extra-low", 1000, 65536);
+        check("gemini-3.5-flash-high", Some(4000), "gemini-3.5-flash-low", 4000, 65536);
+        check("gemini-3.5-flash-high", Some(7000), "gemini-3-flash-agent", 10000, 65536);
+
+        // ── gemini-3.5-flash-medium (fixed → SPEC_35_FLASH_LOW) ────────
+        check("gemini-3.5-flash-medium", None, "gemini-3.5-flash-low", 4000, 65536);
+        check("gemini-3.5-flash-medium", Some(0), "gemini-3.5-flash-low", 4000, 65536);
+        check("gemini-3.5-flash-medium", Some(4000), "gemini-3.5-flash-low", 4000, 65536);
+        check("gemini-3.5-flash-medium", Some(7000), "gemini-3.5-flash-low", 4000, 65536);
+
+        // ── gemini-3.5-flash-low (fixed → SPEC_35_FLASH_EXTRA_LOW) ─────
+        check("gemini-3.5-flash-low", None, "gemini-3.5-flash-extra-low", 1000, 65536);
+        check("gemini-3.5-flash-low", Some(0), "gemini-3.5-flash-extra-low", 1000, 65536);
+        check("gemini-3.5-flash-low", Some(4000), "gemini-3.5-flash-extra-low", 1000, 65536);
+        check("gemini-3.5-flash-low", Some(7000), "gemini-3.5-flash-extra-low", 1000, 65536);
+    }
+
+    #[test]
+    fn baseline_resolve_31_pro_variants() {
+        // ── gemini-3.1-pro (canonical) ─────────────────────────────────
+        // None → High → gemini-pro-agent
+        check("gemini-3.1-pro", None, "gemini-pro-agent", 10001, 65535);
+        // Some(0) → Low → gemini-3.1-pro-low
+        check("gemini-3.1-pro", Some(0), "gemini-3.1-pro-low", 1001, 65535);
+        // Some(4000) → Medium → High fallback → gemini-pro-agent
+        check("gemini-3.1-pro", Some(4000), "gemini-pro-agent", 10001, 65535);
+        // Some(7000) → High → gemini-pro-agent
+        check("gemini-3.1-pro", Some(7000), "gemini-pro-agent", 10001, 65535);
+
+        // ── gemini-3.1-pro-high (same canonical arm) ───────────────────
+        check("gemini-3.1-pro-high", None, "gemini-pro-agent", 10001, 65535);
+        check("gemini-3.1-pro-high", Some(0), "gemini-3.1-pro-low", 1001, 65535);
+        check("gemini-3.1-pro-high", Some(4000), "gemini-pro-agent", 10001, 65535);
+        check("gemini-3.1-pro-high", Some(7000), "gemini-pro-agent", 10001, 65535);
+
+        // ── gemini-pro (same canonical arm) ────────────────────────────
+        check("gemini-pro", None, "gemini-pro-agent", 10001, 65535);
+        check("gemini-pro", Some(0), "gemini-3.1-pro-low", 1001, 65535);
+        check("gemini-pro", Some(4000), "gemini-pro-agent", 10001, 65535);
+        check("gemini-pro", Some(7000), "gemini-pro-agent", 10001, 65535);
+
+        // ── gemini-3.1-pro-low (fixed → SPEC_31_PRO_LOW) ──────────────
+        check("gemini-3.1-pro-low", None, "gemini-3.1-pro-low", 1001, 65535);
+        check("gemini-3.1-pro-low", Some(0), "gemini-3.1-pro-low", 1001, 65535);
+        check("gemini-3.1-pro-low", Some(4000), "gemini-3.1-pro-low", 1001, 65535);
+        check("gemini-3.1-pro-low", Some(7000), "gemini-3.1-pro-low", 1001, 65535);
+    }
+
+    #[test]
+    fn baseline_resolve_non_variant_models() {
+        // Gemini flash-lite family – all map to SPEC_31_FLASH_LITE
+        let check_lite = |c: &str| {
+            check(c, None, "gemini-3.1-flash-lite", 0, 16384);
+            // budget should not affect non-variant resolution
+            check(c, Some(0), "gemini-3.1-flash-lite", 0, 16384);
+            check(c, Some(7000), "gemini-3.1-flash-lite", 0, 16384);
+        };
+        check_lite("gemini-3.1-flash-lite");
+        check_lite("gemini-2.5-flash-lite");
+        check_lite("gemini-2.5-flash");
+        check_lite("gemini-2.5-flash-thinking");
+
+        // ── Claude family ──────────────────────────────────────────────
+        check("claude-sonnet-4-6", None, "claude-sonnet-4-6", 1024, 64000);
+        // claude-opus-4-6-thinking and claude-opus-4-6 → same spec
+        check("claude-opus-4-6-thinking", None, "claude-opus-4-6-thinking", 1024, 64000);
+        check("claude-opus-4-6", None, "claude-opus-4-6-thinking", 1024, 64000);
+
+        // ── GPT OSS ────────────────────────────────────────────────────
+        check("gpt-oss-120b-medium", None, "gpt-oss-120b-medium", 8192, 32768);
+    }
+
+    #[test]
+    fn baseline_unknown_model() {
+        assert!(resolve("some-unknown-model", None).is_none());
+        assert!(resolve("gemini-4.0-super", Some(4000)).is_none());
+        assert!(resolve("", None).is_none());
+    }
+
+    #[test]
+    fn baseline_case_insensitive() {
+        // Canonical variant split model
+        check("GEMINI-3.5-FLASH", None, "gemini-3-flash-agent", 10000, 65536);
+        check("Gemini-3.5-Flash", None, "gemini-3-flash-agent", 10000, 65536);
+        check("GEMINI-3.1-PRO", None, "gemini-pro-agent", 10001, 65535);
+        // Non-variant model
+        check("CLAUDE-SONNET-4-6", None, "claude-sonnet-4-6", 1024, 64000);
+        check("GPT-OSS-120B-MEDIUM", None, "gpt-oss-120b-medium", 8192, 32768);
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    // old catalog id fallback — these legacy top-level ids must keep
+    // resolving through their family aliases.  See task-5-brief.md.
+    // ═════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn old_catalog_alias_fallback() {
+        // ── gemini-3.1-pro-high (HonorTier → same as gemini-3.1-pro) ────
+        // None → High → gemini-pro-agent
+        check("gemini-3.1-pro-high", None, "gemini-pro-agent", 10001, 65535);
+        // Some(0) → Low → gemini-3.1-pro-low
+        check("gemini-3.1-pro-high", Some(0), "gemini-3.1-pro-low", 1001, 65535);
+        // Some(4000) → Medium → High fallback → gemini-pro-agent
+        check("gemini-3.1-pro-high", Some(4000), "gemini-pro-agent", 10001, 65535);
+        // Some(7000) → High → gemini-pro-agent
+        check("gemini-3.1-pro-high", Some(7000), "gemini-pro-agent", 10001, 65535);
+
+        // ── gemini-3.1-pro-low (Fixed(Low) → always gemini-3.1-pro-low)
+        check("gemini-3.1-pro-low", None, "gemini-3.1-pro-low", 1001, 65535);
+        check("gemini-3.1-pro-low", Some(0), "gemini-3.1-pro-low", 1001, 65535);
+        check("gemini-3.1-pro-low", Some(4000), "gemini-3.1-pro-low", 1001, 65535);
+        check("gemini-3.1-pro-low", Some(7000), "gemini-3.1-pro-low", 1001, 65535);
+
+        // ── gemini-pro (HonorTier → same as gemini-3.1-pro) ────────────
+        check("gemini-pro", None, "gemini-pro-agent", 10001, 65535);
+        check("gemini-pro", Some(0), "gemini-3.1-pro-low", 1001, 65535);
+        check("gemini-pro", Some(4000), "gemini-pro-agent", 10001, 65535);
+        check("gemini-pro", Some(7000), "gemini-pro-agent", 10001, 65535);
+
+        // ── gemini-3-flash (HonorTier → same as gemini-3.5-flash) ──────
+        check("gemini-3-flash", None, "gemini-3-flash-agent", 10000, 65536);
+        check("gemini-3-flash", Some(0), "gemini-3.5-flash-extra-low", 1000, 65536);
+        check("gemini-3-flash", Some(4000), "gemini-3.5-flash-low", 4000, 65536);
+        check("gemini-3-flash", Some(7000), "gemini-3-flash-agent", 10000, 65536);
+    }
+}

--- a/src-tauri/src/proxy/handlers/claude.rs
+++ b/src-tauri/src/proxy/handlers/claude.rs
@@ -313,6 +313,43 @@ pub async fn handle_messages(
     let thinking_hint = extract_thinking_hint(&original_body);
     apply_thinking_hints(&mut request, &thinking_hint, &trace_id, temp_cap);
 
+    // [Variant] Resolve canonical model + variant → real model + real params.
+    // OpenCode sends canonical model names (e.g. gemini-3.5-flash) with the variant
+    // encoded as thinking.budget_tokens. We map to the real model ID and REPLACE the
+    // client's thinking/max_tokens with verified real values, so the forwarded
+    // request matches the expected upstream format.
+    let client_budget = original_body
+        .get("thinking")
+        .and_then(|t| t.get("budget_tokens"))
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32);
+    if let Some(spec) =
+        crate::proxy::common::variant_mapping::resolve(&request.model, client_budget)
+    {
+        tracing::info!(
+            "[{}] [Variant] canonical='{}' budget_hint={:?} -> real_model='{}' budget={} maxOut={}",
+            trace_id, request.model, client_budget, spec.id, spec.thinking_budget, spec.max_output_tokens
+        );
+        request.model = spec.id.to_string();
+        if spec.thinking_budget == 0 {
+            // Non-thinking checkpoint model (e.g. gemini-3.1-flash-lite): disable thinking
+            // entirely AND strip tools/toolConfig — per upstream spec §3 the upstream service's
+            // checkpoint requests carry no tools.
+            request.thinking = None;
+            request.tools = None;
+        } else {
+            request.thinking = Some(crate::proxy::mappers::claude::models::ThinkingConfig {
+                type_: "enabled".to_string(),
+                budget_tokens: Some(spec.effective_thinking_budget(client_budget)),
+                effort: None,
+            });
+        }
+        // Clear any client-sent output_config so a stale effort level cannot leak into
+        // the adaptive thinkingLevel resolution downstream.
+        request.output_config = None;
+        request.max_tokens = Some(spec.max_output_tokens);
+    }
+
     if debug_logger::is_enabled(&debug_cfg) {
         // [FIX] 使用原始 body 副本记录日志，确保不丢失任何字段
         let original_payload = json!({
@@ -1801,6 +1838,40 @@ pub async fn handle_count_tokens(
         "output_tokens": 0
     }))
     .into_response()
+}
+
+#[cfg(test)]
+mod variant_tests {
+    use crate::proxy::common::variant_mapping;
+    use crate::proxy::mappers::claude::models::ThinkingConfig;
+
+    #[test]
+    fn claude_opus_preserves_client_budget_when_present() {
+        let client_budget = Some(32_768);
+        let spec = variant_mapping::resolve("claude-opus-4-6-thinking", client_budget)
+            .expect("Claude Opus 4.6 thinking must resolve");
+        let request_thinking = ThinkingConfig {
+            type_: "enabled".to_string(),
+            budget_tokens: Some(spec.effective_thinking_budget(client_budget)),
+            effort: None,
+        };
+
+        assert_eq!(request_thinking.budget_tokens, client_budget);
+    }
+
+    #[test]
+    fn claude_opus_falls_back_to_spec_budget_when_client_budget_is_absent() {
+        let client_budget = None;
+        let spec = variant_mapping::resolve("claude-opus-4-6-thinking", client_budget)
+            .expect("Claude Opus 4.6 thinking must resolve");
+        let request_thinking = ThinkingConfig {
+            type_: "enabled".to_string(),
+            budget_tokens: Some(spec.effective_thinking_budget(client_budget)),
+            effort: None,
+        };
+
+        assert_eq!(request_thinking.budget_tokens, Some(1_024));
+    }
 }
 
 // 移除已失效的简单单元测试，后续将补全完整的集成测试

--- a/src-tauri/src/proxy/handlers/claude.rs
+++ b/src-tauri/src/proxy/handlers/claude.rs
@@ -243,6 +243,144 @@ use super::common::{
 
 // ===== 退避策略模块结束 =====
 
+#[cfg(test)]
+mod variant_tests {
+    use super::*;
+
+    fn request_with_effort(model: &str, effort: &str, budget_tokens: u32) -> ClaudeRequest {
+        serde_json::from_value(json!({
+            "model": model,
+            "messages": [{"role": "user", "content": "test"}],
+            "thinking": {"type": "enabled", "budget_tokens": budget_tokens},
+            "output_config": {"effort": effort}
+        }))
+        .expect("test request must deserialize")
+    }
+
+    #[test]
+    fn applies_flash_low_effort_and_removes_output_config_before_serialization() {
+        let mut request = request_with_effort("gemini-3.5-flash", "low", 10_000);
+        let effort = crate::proxy::common::variant_mapping::tier_from_effort(
+            request
+                .output_config
+                .as_ref()
+                .and_then(|config| config.effort.as_deref()),
+        );
+
+        apply_variant(&mut request, effort, Some(10_000))
+            .expect("Gemini 3.5 Flash must resolve");
+
+        assert_eq!(request.model, "gemini-3.5-flash-extra-low");
+        assert!(request.output_config.is_none());
+        assert!(serde_json::to_value(request)
+            .expect("resolved request must serialize")
+            .get("output_config")
+            .is_none());
+    }
+
+    #[test]
+    fn applies_pro_high_effort_over_low_budget() {
+        let mut request = request_with_effort("gemini-3.1-pro", "high", 1_000);
+        let effort = crate::proxy::common::variant_mapping::tier_from_effort(
+            request
+                .output_config
+                .as_ref()
+                .and_then(|config| config.effort.as_deref()),
+        );
+
+        apply_variant(&mut request, effort, Some(1_000))
+            .expect("Gemini 3.1 Pro must resolve");
+
+        assert_eq!(request.model, "gemini-pro-agent");
+    }
+
+    #[test]
+    fn invalid_effort_falls_back_to_budget_tokens_for_gemini_3_model() {
+        // Given a Gemini 3 model ("gemini-3-flash") with an unrecognized
+        // effort value ("max"), tier_from_effort returns None, so
+        // apply_variant falls back to budget-based tier inference.
+        let mut request = request_with_effort("gemini-3-flash", "max", 4_000);
+        let effort = crate::proxy::common::variant_mapping::tier_from_effort(
+            request
+                .output_config
+                .as_ref()
+                .and_then(|config| config.effort.as_deref()),
+        );
+
+        // tier_from_effort(Some("max")) → None (invalid value)
+        assert_eq!(effort, None);
+
+        // With effort=None and budget=4_000, infer_tier → Medium →
+        // resolve_with_tier("gemini-3-flash", None, Some(4_000)) →
+        // SPEC_35_FLASH_LOW → physical id "gemini-3.5-flash-low"
+        apply_variant(&mut request, effort, Some(4_000))
+            .expect("gemini-3-flash must resolve even without valid effort");
+
+        assert_eq!(request.model, "gemini-3.5-flash-low");
+        assert!(request.output_config.is_none());
+        // SPEC_35_FLASH_LOW has thinking_budget=4_000, preserve_client_budget=false
+        assert_eq!(
+            request.thinking.as_ref().and_then(|t| t.budget_tokens),
+            Some(4_000)
+        );
+    }
+
+    #[test]
+    fn claude_model_without_variant_mapping_preserves_output_config_on_none() {
+        // claude-sonnet-4-5 is NOT in GEMINI_FAMILIES and NOT in
+        // resolve_non_variant_model, so resolve_with_tier returns None,
+        // and apply_variant returns None without mutating the request.
+        let mut request = request_with_effort("claude-sonnet-4-5", "high", 10_000);
+        let effort = crate::proxy::common::variant_mapping::tier_from_effort(
+            request
+                .output_config
+                .as_ref()
+                .and_then(|config| config.effort.as_deref()),
+        );
+
+        let result = apply_variant(&mut request, effort, Some(10_000));
+        assert!(result.is_none(), "unregistered Claude model must return None");
+
+        // Model and output_config must remain untouched.
+        assert_eq!(request.model, "claude-sonnet-4-5");
+        assert_eq!(
+            request
+                .output_config
+                .as_ref()
+                .and_then(|c| c.effort.as_deref()),
+            Some("high")
+        );
+    }
+}
+
+fn apply_variant(
+    request: &mut ClaudeRequest,
+    effort_tier: Option<crate::proxy::common::variant_mapping::VariantTier>,
+    client_budget: Option<u32>,
+) -> Option<crate::proxy::common::variant_mapping::RealModelSpec> {
+    let spec = crate::proxy::common::variant_mapping::resolve_with_tier(
+        &request.model,
+        effort_tier,
+        client_budget,
+    )?;
+
+    request.model = spec.id.to_string();
+    if spec.thinking_budget == 0 {
+        request.thinking = None;
+        request.tools = None;
+    } else {
+        request.thinking = Some(crate::proxy::mappers::claude::models::ThinkingConfig {
+            type_: "enabled".to_string(),
+            budget_tokens: Some(spec.effective_thinking_budget(client_budget)),
+            effort: None,
+        });
+    }
+    request.output_config = None;
+    request.max_tokens = Some(spec.max_output_tokens);
+
+    Some(spec)
+}
+
 /// 处理 Claude messages 请求
 ///
 /// 处理 Chat 消息请求流程
@@ -314,40 +452,23 @@ pub async fn handle_messages(
     apply_thinking_hints(&mut request, &thinking_hint, &trace_id, temp_cap);
 
     // [Variant] Resolve canonical model + variant → real model + real params.
-    // OpenCode sends canonical model names (e.g. gemini-3.5-flash) with the variant
-    // encoded as thinking.budget_tokens. We map to the real model ID and REPLACE the
-    // client's thinking/max_tokens with verified real values, so the forwarded
-    // request matches the expected upstream format.
     let client_budget = original_body
         .get("thinking")
         .and_then(|t| t.get("budget_tokens"))
         .and_then(|v| v.as_u64())
         .map(|v| v as u32);
-    if let Some(spec) =
-        crate::proxy::common::variant_mapping::resolve(&request.model, client_budget)
-    {
+    let effort_hint = request
+        .output_config
+        .as_ref()
+        .and_then(|config| config.effort.clone());
+    let effort_tier =
+        crate::proxy::common::variant_mapping::tier_from_effort(effort_hint.as_deref());
+    let canonical_model = request.model.clone();
+    if let Some(spec) = apply_variant(&mut request, effort_tier, client_budget) {
         tracing::info!(
-            "[{}] [Variant] canonical='{}' budget_hint={:?} -> real_model='{}' budget={} maxOut={}",
-            trace_id, request.model, client_budget, spec.id, spec.thinking_budget, spec.max_output_tokens
+            "[{}] [Variant] canonical='{}' effort_hint={:?} budget_hint={:?} -> real_model='{}' budget={} maxOut={}",
+            trace_id, canonical_model, effort_hint, client_budget, spec.id, spec.thinking_budget, spec.max_output_tokens
         );
-        request.model = spec.id.to_string();
-        if spec.thinking_budget == 0 {
-            // Non-thinking checkpoint model (e.g. gemini-3.1-flash-lite): disable thinking
-            // entirely AND strip tools/toolConfig — per upstream spec §3 the upstream service's
-            // checkpoint requests carry no tools.
-            request.thinking = None;
-            request.tools = None;
-        } else {
-            request.thinking = Some(crate::proxy::mappers::claude::models::ThinkingConfig {
-                type_: "enabled".to_string(),
-                budget_tokens: Some(spec.effective_thinking_budget(client_budget)),
-                effort: None,
-            });
-        }
-        // Clear any client-sent output_config so a stale effort level cannot leak into
-        // the adaptive thinkingLevel resolution downstream.
-        request.output_config = None;
-        request.max_tokens = Some(spec.max_output_tokens);
     }
 
     if debug_logger::is_enabled(&debug_cfg) {

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -154,6 +154,40 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
     }
 }
 
+#[cfg(test)]
+mod variant_tests {
+    use crate::proxy::common::variant_mapping;
+    use crate::proxy::mappers::openai::models::ThinkingConfig;
+
+    #[test]
+    fn openai_opus_preserves_client_budget_when_present() {
+        let client_budget = Some(32_768);
+        let spec = variant_mapping::resolve("claude-opus-4-6-thinking", client_budget)
+            .expect("Claude Opus 4.6 thinking must resolve");
+        let request_thinking = ThinkingConfig {
+            thinking_type: Some("enabled".to_string()),
+            budget_tokens: Some(spec.effective_thinking_budget(client_budget)),
+            effort: None,
+        };
+
+        assert_eq!(request_thinking.budget_tokens, client_budget);
+    }
+
+    #[test]
+    fn openai_opus_falls_back_to_spec_budget_when_client_budget_is_absent() {
+        let client_budget = None;
+        let spec = variant_mapping::resolve("claude-opus-4-6-thinking", client_budget)
+            .expect("Claude Opus 4.6 thinking must resolve");
+        let request_thinking = ThinkingConfig {
+            thinking_type: Some("enabled".to_string()),
+            budget_tokens: Some(spec.effective_thinking_budget(client_budget)),
+            effort: None,
+        };
+
+        assert_eq!(request_thinking.budget_tokens, Some(1_024));
+    }
+}
+
 fn compact_apply_patch_failure_output(
     output: String,
     seen: &mut std::collections::HashSet<String>,
@@ -396,6 +430,39 @@ pub async fn handle_chat_completions(
         .cloned();
     if client_adapter.is_some() {
         debug!("[{}] Client Adapter detected", trace_id);
+    }
+
+    // [Variant] Resolve canonical model + variant → real model + real params.
+    // Replace the client's model/thinking/max_tokens with verified real values so the
+    // forwarded request matches the expected upstream format. OpenCode encodes the variant as
+    // thinking.budget_tokens; we infer the tier from its magnitude.
+    let client_budget = openai_req
+        .thinking
+        .as_ref()
+        .and_then(|t| t.budget_tokens);
+    if let Some(spec) =
+        crate::proxy::common::variant_mapping::resolve(&openai_req.model, client_budget)
+    {
+        tracing::info!(
+            "[{}] [Variant] canonical='{}' budget_hint={:?} -> real_model='{}' budget={} maxOut={}",
+            trace_id, openai_req.model, client_budget, spec.id, spec.thinking_budget, spec.max_output_tokens
+        );
+        openai_req.model = spec.id.to_string();
+        if spec.thinking_budget == 0 {
+            // Non-thinking checkpoint model (e.g. gemini-3.1-flash-lite): disable thinking
+            // AND strip tools/tool_choice — per upstream spec §3 checkpoint requests carry
+            // no tools.
+            openai_req.thinking = None;
+            openai_req.tools = None;
+            openai_req.tool_choice = None;
+        } else {
+            openai_req.thinking = Some(crate::proxy::mappers::openai::models::ThinkingConfig {
+                thinking_type: Some("enabled".to_string()),
+                budget_tokens: Some(spec.effective_thinking_budget(client_budget)),
+                effort: None,
+            });
+        }
+        openai_req.max_tokens = Some(spec.max_output_tokens);
     }
 
     let client_tool_names =

--- a/src-tauri/src/proxy/opencode_sync.rs
+++ b/src-tauri/src/proxy/opencode_sync.rs
@@ -1,10 +1,12 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+
+use crate::proxy::common::variant_mapping::{VariantTier, GEMINI_FAMILIES};
 
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
@@ -14,6 +16,7 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 const OPENCODE_DIR: &str = ".config/opencode";
 const OPENCODE_CONFIG_FILE: &str = "opencode.json";
+const OPENCODE_CONFIG_FILE_JSONC: &str = "opencode.jsonc";
 const ANTIGRAVITY_CONFIG_FILE: &str = "antigravity.json";
 const ANTIGRAVITY_ACCOUNTS_FILE: &str = "antigravity-accounts.json";
 const BACKUP_SUFFIX: &str = ".antigravity-manager.bak";
@@ -26,9 +29,9 @@ const ANTIGRAVITY_PROVIDER_ID: &str = "antigravity-manager";
 enum VariantType {
     /// Claude-style thinking with budget_tokens
     ClaudeThinking,
-    /// Gemini 3 Pro style with thinkingLevel
+    /// Gemini 3 Pro style with thinking budgets
     Gemini3Pro,
-    /// Gemini 3 Flash style with thinkingLevel
+    /// Gemini 3 Flash style with thinking budgets
     Gemini3Flash,
     /// Gemini 2.5 thinking style
     Gemini25Thinking,
@@ -49,7 +52,7 @@ struct ModelDef {
 
 /// Build the complete model catalog for antigravity-manager provider
 fn build_model_catalog() -> Vec<ModelDef> {
-    vec![
+    let mut catalog = vec![
         // Claude models
         ModelDef {
             id: "claude-sonnet-4-6",
@@ -91,36 +94,33 @@ fn build_model_catalog() -> Vec<ModelDef> {
             reasoning: true,
             variant_type: Some(VariantType::ClaudeThinking),
         },
-        // Gemini 3.1 Pro models
-        ModelDef {
-            id: "gemini-3.1-pro-high",
-            name: "Gemini 3.1 Pro High",
-            context_limit: 1_048_576,
-            output_limit: 65_535,
-            input_modalities: &["text", "image", "pdf"],
-            output_modalities: &["text", "image"],
-            reasoning: true,
-            variant_type: Some(VariantType::Gemini3Pro),
+    ];
+
+    catalog.extend(GEMINI_FAMILIES.iter().map(|family| ModelDef {
+        id: family.canonical_id,
+        name: family.display_name,
+        context_limit: family.context_limit,
+        output_limit: family.output_limit,
+        input_modalities: family.input_modalities,
+        output_modalities: family.output_modalities,
+        reasoning: family.reasoning,
+        variant_type: match family.canonical_id {
+            "gemini-3.1-pro" => Some(VariantType::Gemini3Pro),
+            "gemini-3.5-flash" => Some(VariantType::Gemini3Flash),
+            _ => None,
         },
+    }));
+
+    catalog.extend([
         ModelDef {
-            id: "gemini-3.1-pro-low",
-            name: "Gemini 3.1 Pro Low",
-            context_limit: 1_048_576,
-            output_limit: 65_535,
-            input_modalities: &["text", "image", "pdf"],
-            output_modalities: &["text", "image"],
-            reasoning: true,
-            variant_type: Some(VariantType::Gemini3Pro),
-        },
-        ModelDef {
-            id: "gemini-3-flash",
-            name: "Gemini 3 Flash",
+            id: "gemini-3.1-flash-lite",
+            name: "Gemini 3.1 Flash Lite",
             context_limit: 1_048_576,
             output_limit: 65_536,
             input_modalities: &["text", "image", "pdf"],
             output_modalities: &["text"],
             reasoning: true,
-            variant_type: Some(VariantType::Gemini3Flash),
+            variant_type: None,
         },
         ModelDef {
             id: "gemini-3-pro-image",
@@ -173,7 +173,9 @@ fn build_model_catalog() -> Vec<ModelDef> {
             reasoning: true,
             variant_type: None,
         },
-    ]
+    ]);
+
+    catalog
 }
 
 /// Normalize OpenCode base URL to ensure it ends with `/v1` (Anthropic protocol requirement)
@@ -197,6 +199,13 @@ pub struct OpencodeStatus {
     pub has_backup: bool,
     pub current_base_url: Option<String>,
     pub files: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct CanonicalFamilyDto {
+    pub canonical_id: String,
+    pub display_name: String,
+    pub match_ids: Vec<String>,
 }
 
 /// Plugin schema v3 account structure
@@ -256,14 +265,181 @@ fn get_opencode_dir() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(OPENCODE_DIR))
 }
 
+/// Resolve the active OpenCode config file name for the given directory.
+///
+/// OpenCode accepts both `opencode.json` and `opencode.jsonc`. To avoid creating a
+/// parallel `opencode.json` next to a user's existing `opencode.jsonc`, we probe the
+/// directory: if a `.jsonc` file already exists we keep using it, otherwise we fall
+/// back to the default `opencode.json`. This keeps each user on the file they
+/// already use.
+///
+/// Pass `Some(dir)` to probe a real directory, or `None` to get the default file
+/// name without filesystem access (used by pure-function helpers).
+fn resolve_active_config_file_name(dir: Option<&PathBuf>) -> &'static str {
+    if let Some(dir) = dir {
+        let jsonc = dir.join(OPENCODE_CONFIG_FILE_JSONC);
+        if jsonc.exists() {
+            return OPENCODE_CONFIG_FILE_JSONC;
+        }
+    }
+    OPENCODE_CONFIG_FILE
+}
+
 fn get_config_paths() -> Option<(PathBuf, PathBuf, PathBuf)> {
     get_opencode_dir().map(|dir| {
+        let config_file = resolve_active_config_file_name(Some(&dir));
         (
-            dir.join(OPENCODE_CONFIG_FILE),
+            dir.join(config_file),
             dir.join(ANTIGRAVITY_CONFIG_FILE),
             dir.join(ANTIGRAVITY_ACCOUNTS_FILE),
         )
     })
+}
+
+/// Strip JSONC comments (both `// line` and `/* block */`) so the remainder can be
+/// parsed by `serde_json`, which only understands strict JSON.
+///
+/// This is intentionally a small, conservative scanner: it tracks whether the current
+/// position is inside a string literal (respecting `\"` escapes) so that `//` or `/*`
+/// appearing inside a string value is never mistaken for a comment. Trailing commas are
+/// handled separately by [`strip_jsonc_trailing_commas`].
+fn strip_jsonc_comments(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    let mut in_string = false;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+
+        if in_string {
+            out.push(c as char);
+            if c == b'\\' && i + 1 < bytes.len() {
+                // Keep the escaped char verbatim (e.g. \", \\, \/).
+                out.push(bytes[i + 1] as char);
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        match c {
+            b'"' => {
+                in_string = true;
+                out.push('"');
+                i += 1;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                // Line comment: skip until newline.
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                // Block comment: skip until closing */.
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(bytes.len());
+            }
+            _ => {
+                out.push(c as char);
+                i += 1;
+            }
+        }
+    }
+
+    out
+}
+
+/// Remove trailing commas (a `,` followed, after optional whitespace, by a closing
+/// `}` or `]`) so `serde_json` can parse JSONC that permits them. Like the comment
+/// stripper, this respects string literals so a comma at the end of a string value is
+/// never touched.
+fn strip_jsonc_trailing_commas(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    let mut in_string = false;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+
+        if in_string {
+            out.push(c as char);
+            if c == b'\\' && i + 1 < bytes.len() {
+                out.push(bytes[i + 1] as char);
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if c == b'"' {
+            in_string = true;
+            out.push('"');
+            i += 1;
+            continue;
+        }
+
+        // When we hit a comma outside a string, look ahead past whitespace. If the next
+        // significant character closes an object/array, this is a trailing comma — drop
+        // it. Otherwise keep the comma (it separates real elements).
+        if c == b',' {
+            let mut j = i + 1;
+            let mut is_trailing = false;
+            while j < bytes.len() {
+                match bytes[j] {
+                    b' ' | b'\t' | b'\n' | b'\r' => j += 1,
+                    b'}' | b']' => {
+                        is_trailing = true;
+                        break;
+                    }
+                    _ => break,
+                }
+            }
+            if is_trailing {
+                // Skip the comma (don't push it); leave the whitespace to be pushed normally.
+                i += 1;
+            } else {
+                out.push(',');
+                i += 1;
+            }
+            continue;
+        }
+
+        out.push(c as char);
+        i += 1;
+    }
+
+    out
+}
+
+/// Read and parse an OpenCode config file, tolerating JSONC comments and trailing commas.
+fn parse_config_file(path: &PathBuf) -> Option<Value> {
+    let content = fs::read_to_string(path).ok()?;
+    parse_jsonc(&content)
+}
+
+/// Parse a JSON/JSONC string: try strict JSON first, then normalize comments and
+/// trailing commas and retry. Used everywhere a user opencode config is read.
+fn parse_jsonc(content: &str) -> Option<Value> {
+    serde_json::from_str(content)
+        .or_else(|_| {
+            let normalized = strip_jsonc_trailing_commas(&strip_jsonc_comments(content));
+            serde_json::from_str(&normalized)
+        })
+        .ok()
 }
 
 fn extract_version(raw: &str) -> String {
@@ -677,12 +853,24 @@ pub fn get_sync_status(proxy_url: &str) -> (bool, bool, Option<String>) {
     let mut has_backup = false;
     let mut current_base_url = None;
 
-    let backup_path =
-        config_path.with_file_name(format!("{}{}", OPENCODE_CONFIG_FILE, BACKUP_SUFFIX));
-    let old_backup_path =
-        config_path.with_file_name(format!("{}{}", OPENCODE_CONFIG_FILE, OLD_BACKUP_SUFFIX));
-    if backup_path.exists() || old_backup_path.exists() {
-        has_backup = true;
+    // Backups may have been created against either opencode.json or opencode.jsonc.
+    // Check both the active file name's backup and the canonical json backup so a
+    // previously-synced state is still detected after switching file types.
+    let active_file_name = config_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(OPENCODE_CONFIG_FILE);
+    let backup_candidates = [
+        format!("{}{}", active_file_name, BACKUP_SUFFIX),
+        format!("{}{}", active_file_name, OLD_BACKUP_SUFFIX),
+        format!("{}{}", OPENCODE_CONFIG_FILE, BACKUP_SUFFIX),
+        format!("{}{}", OPENCODE_CONFIG_FILE, OLD_BACKUP_SUFFIX),
+    ];
+    for name in &backup_candidates {
+        if config_path.with_file_name(name).exists() {
+            has_backup = true;
+            break;
+        }
     }
 
     if !config_path.exists() {
@@ -694,7 +882,7 @@ pub fn get_sync_status(proxy_url: &str) -> (bool, bool, Option<String>) {
         Err(_) => return (false, has_backup, None),
     };
 
-    let json: Value = serde_json::from_str(&content).unwrap_or_default();
+    let json: Value = parse_jsonc(&content).unwrap_or_default();
 
     // Normalize proxy URL for comparison
     let normalized_proxy = normalize_opencode_base_url(proxy_url);
@@ -808,11 +996,25 @@ fn build_claude_thinking_variant(budget: u32) -> Value {
     })
 }
 
-/// Build Gemini 3 style variant with thinkingLevel
-fn build_gemini3_variant(level: &str) -> Value {
-    serde_json::json!({
-        "thinkingLevel": level
-    })
+/// Look up a Gemini variant's registered thinking budget.
+fn gemini_variant_budget(canonical_id: &str, tier: VariantTier) -> Option<u32> {
+    GEMINI_FAMILIES
+        .iter()
+        .find(|family| family.canonical_id == canonical_id)
+        .and_then(|family| {
+            family
+                .tiers
+                .iter()
+                .find(|(candidate_tier, _)| *candidate_tier == tier)
+        })
+        .map(|(_, spec)| spec.thinking_budget)
+}
+
+/// Build Gemini 3 style variant with the OpenCode thinking budget fields.
+fn build_gemini3_variant(budget: u32) -> Value {
+    let mut variant = build_claude_thinking_variant(budget);
+    variant["budgetTokens"] = Value::from(budget);
+    variant
 }
 
 /// Build Gemini 2.5 thinking variant with thinkingConfig and thinking
@@ -842,16 +1044,45 @@ fn build_variants_object(variant_type: Option<VariantType>) -> Option<Value> {
         }
         Some(VariantType::Gemini3Pro) => {
             let mut variants = serde_json::Map::new();
-            variants.insert("low".to_string(), build_gemini3_variant("low"));
-            variants.insert("high".to_string(), build_gemini3_variant("high"));
+            variants.insert(
+                "low".to_string(),
+                build_gemini3_variant(gemini_variant_budget(
+                    "gemini-3.1-pro",
+                    VariantTier::Low,
+                )?),
+            );
+            variants.insert(
+                "high".to_string(),
+                build_gemini3_variant(gemini_variant_budget(
+                    "gemini-3.1-pro",
+                    VariantTier::High,
+                )?),
+            );
             Some(Value::Object(variants))
         }
         Some(VariantType::Gemini3Flash) => {
             let mut variants = serde_json::Map::new();
-            variants.insert("minimal".to_string(), build_gemini3_variant("minimal"));
-            variants.insert("low".to_string(), build_gemini3_variant("low"));
-            variants.insert("medium".to_string(), build_gemini3_variant("medium"));
-            variants.insert("high".to_string(), build_gemini3_variant("high"));
+            variants.insert(
+                "low".to_string(),
+                build_gemini3_variant(gemini_variant_budget(
+                    "gemini-3.5-flash",
+                    VariantTier::Low,
+                )?),
+            );
+            variants.insert(
+                "medium".to_string(),
+                build_gemini3_variant(gemini_variant_budget(
+                    "gemini-3.5-flash",
+                    VariantTier::Medium,
+                )?),
+            );
+            variants.insert(
+                "high".to_string(),
+                build_gemini3_variant(gemini_variant_budget(
+                    "gemini-3.5-flash",
+                    VariantTier::High,
+                )?),
+            );
             Some(Value::Object(variants))
         }
         Some(VariantType::Gemini25Thinking) => {
@@ -899,8 +1130,179 @@ fn build_model_json(model_def: &ModelDef) -> Value {
     Value::Object(model_obj)
 }
 
-/// Merge catalog models into provider.models without deleting user models
-fn merge_catalog_models(provider: &mut Value, model_ids: Option<&[&str]>) {
+/// A model to sync, optionally carrying the display name from the frontend.
+/// When `name` is provided (the common case from the OpenCode sync modal), it is used
+/// verbatim so the config shows the same recognizable name the user saw in the UI.
+/// When absent (e.g. a plain id list), a name is derived from the id.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelInput {
+    pub id: String,
+    pub name: Option<String>,
+}
+
+/// Sensible per-series defaults derived from the model id prefix. Real model metadata
+/// lives in the catalog; this is only used for ids the catalog doesn't know (e.g. a
+/// newly released model or an account-specific variant), so the entry still gets useful
+/// limit/modalities instead of a bare `{ "name": ... }`. Returns None for unknown
+/// families, in which case only the name is written.
+fn series_defaults_for(model_id: &str) -> Option<Value> {
+    let id = model_id.to_lowercase();
+    // Gemini 3.x / 3.5 / 3.1 family: 1M context, 64k output, multimodal in, text out.
+    if id.starts_with("gemini-3") || id.starts_with("gemini-3.1") || id.starts_with("gemini-3.5")
+    {
+        return Some(serde_json::json!({
+            "limit": { "context": 1_048_576, "output": 65_536 },
+            "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        }));
+    }
+    // Gemini 2.5 family: same shape.
+    if id.starts_with("gemini-2.5") || id.starts_with("gemini-2.0") {
+        return Some(serde_json::json!({
+            "limit": { "context": 1_048_576, "output": 65_536 },
+            "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        }));
+    }
+    // Claude family: 200k context, 64k output.
+    if id.starts_with("claude") {
+        return Some(serde_json::json!({
+            "limit": { "context": 200_000, "output": 64_000 },
+            "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        }));
+    }
+    None
+}
+
+/// Build a minimal but valid model entry for a model id that is not in the catalog.
+///
+/// OpenCode's schema only requires a `name` for a model entry, so a model the user
+/// explicitly selected — even one we have no metadata for — should still be written
+/// rather than silently dropped. If a display name was passed from the frontend we use
+/// it verbatim (so the config matches what the user saw); otherwise we derive one.
+/// When we can infer the model family from the id we also fill in limit/modalities.
+fn build_fallback_model_json(model_id: &str, display_name: Option<&str>) -> Value {
+    // Prefer the caller-provided display name; fall back to a cleaned-up id.
+    let name = display_name
+        .filter(|n| !n.trim().is_empty())
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| humanize_model_id(model_id));
+
+    let mut entry = serde_json::Map::new();
+    entry.insert("name".to_string(), Value::String(name));
+    if let Some(defaults) = series_defaults_for(model_id) {
+        if let Some(obj) = defaults.as_object() {
+            for (k, v) in obj.iter() {
+                entry.insert(k.clone(), v.clone());
+            }
+        }
+    }
+    Value::Object(entry)
+}
+
+/// Derive a readable name from a model id, preserving version dots
+/// (e.g. "gemini-3.5-flash-low" -> "Gemini 3.5 Flash Low").
+fn humanize_model_id(model_id: &str) -> String {
+    model_id
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            let mut chars = s.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Return a Gemini canonical catalog id for a canonical id or one of its aliases.
+fn canonical_gemini_model_id(model_id: &str) -> Option<&'static str> {
+    GEMINI_FAMILIES.iter().find_map(|family| {
+        (family.canonical_id == model_id
+            || family
+                .aliases
+                .iter()
+                .any(|(alias_id, _)| *alias_id == model_id))
+        .then_some(family.canonical_id)
+    })
+}
+
+/// Normalize Gemini aliases and preserve the first frontend entry for each model id.
+fn normalize_model_inputs(model_inputs: &[ModelInput]) -> Vec<ModelInput> {
+    let mut seen_model_ids = HashSet::new();
+
+    model_inputs
+        .iter()
+        .filter_map(|input| {
+            let model_id = canonical_gemini_model_id(&input.id).unwrap_or(&input.id);
+            if !seen_model_ids.insert(model_id.to_string()) {
+                return None;
+            }
+
+            let mut normalized = input.clone();
+            normalized.id = model_id.to_string();
+            Some(normalized)
+        })
+        .collect()
+}
+
+/// Migrate known Gemini alias keys without touching non-Gemini user models.
+fn migrate_gemini_alias_models(provider: &mut Value) {
+    let Some(models) = provider.get_mut("models").and_then(Value::as_object_mut) else {
+        return;
+    };
+
+    for family in GEMINI_FAMILIES {
+        for (alias_id, _) in family.aliases {
+            let Some(alias_value) = models.remove(*alias_id) else {
+                continue;
+            };
+
+            let merged = match models.remove(family.canonical_id) {
+                Some(canonical_value) => {
+                    match (canonical_value.as_object(), alias_value.as_object()) {
+                        (Some(canonical), Some(alias)) => {
+                            let mut merged = canonical.clone();
+                            for (field, value) in alias {
+                                match merged.get(field) {
+                                    Some(canonical_value) if canonical_value != value => {
+                                        tracing::warn!(
+                                            canonical_model = family.canonical_id,
+                                            alias_model = alias_id,
+                                            field = field.as_str(),
+                                            "OpenCode sync model field conflict; canonical value retained"
+                                        );
+                                    }
+                                    Some(_) => {}
+                                    None => {
+                                        merged.insert(field.clone(), value.clone());
+                                    }
+                                }
+                            }
+                            Value::Object(merged)
+                        }
+                        _ => {
+                            tracing::warn!(
+                                canonical_model = family.canonical_id,
+                                alias_model = alias_id,
+                                "OpenCode sync could not merge a non-object alias model; canonical value retained"
+                            );
+                            canonical_value
+                        }
+                    }
+                }
+                None => alias_value,
+            };
+            models.insert(family.canonical_id.to_string(), merged);
+        }
+    }
+}
+
+/// Merge catalog models into provider.models without deleting user models.
+/// Each entry carries an optional display name from the frontend so fallback entries
+/// for non-catalog models get a recognizable name.
+fn merge_catalog_models(provider: &mut Value, model_inputs: Option<&[ModelInput]>) {
     if provider.get("models").is_none() {
         provider["models"] = serde_json::json!({});
     }
@@ -909,12 +1311,12 @@ fn merge_catalog_models(provider: &mut Value, model_ids: Option<&[&str]>) {
     let catalog_map: HashMap<&str, &ModelDef> = catalog.iter().map(|m| (m.id, m)).collect();
 
     if let Some(models) = provider.get_mut("models").and_then(|m| m.as_object_mut()) {
-        let ids_to_sync: Vec<&str> = match model_ids {
-            Some(ids) => ids.to_vec(),
-            None => catalog_map.keys().copied().collect(),
-        };
+        // When no specific models are requested, sync the whole catalog.
+        let catalog_ids: Vec<&str> = catalog_map.keys().copied().collect();
 
-        for model_id in ids_to_sync {
+        let normalized_inputs = normalize_model_inputs(model_inputs.unwrap_or(&[]));
+        for input in &normalized_inputs {
+            let model_id = input.id.as_str();
             if let Some(model_def) = catalog_map.get(model_id) {
                 let catalog_model = build_model_json(model_def);
 
@@ -939,6 +1341,30 @@ fn merge_catalog_models(provider: &mut Value, model_ids: Option<&[&str]>) {
                     // Model doesn't exist, insert full catalog entry
                     models.insert(model_id.to_string(), catalog_model);
                 }
+            } else {
+                // Fallback: the id isn't in our catalog (e.g. a dynamically discovered
+                // model from the user's account quota, or a new model not yet listed).
+                // Previously these were silently dropped, which caused selected models to
+                // never appear in the config. OpenCode only requires a `name`, so write a
+                // minimal entry using the frontend-provided display name when available.
+                // Preserve any user-defined object the user may already have.
+                if !models.contains_key(model_id) {
+                    models.insert(
+                        model_id.to_string(),
+                        build_fallback_model_json(model_id, input.name.as_deref()),
+                    );
+                }
+            }
+        }
+
+        // No inputs at all => sync the entire catalog (None means "all").
+        if model_inputs.is_none() {
+            for model_id in &catalog_ids {
+                if let Some(model_def) = catalog_map.get(model_id) {
+                    if !models.contains_key(*model_id) {
+                        models.insert((*model_id).to_string(), build_model_json(model_def));
+                    }
+                }
             }
         }
     }
@@ -948,7 +1374,7 @@ pub fn sync_opencode_config(
     proxy_url: &str,
     api_key: &str,
     sync_accounts: bool,
-    models_to_sync: Option<Vec<String>>,
+    models_to_sync: Option<Vec<ModelInput>>,
 ) -> Result<(), String> {
     let Some((config_path, _ag_config_path, ag_accounts_path)) = get_config_paths() else {
         return Err("Failed to get OpenCode config directory".to_string());
@@ -961,18 +1387,12 @@ pub fn sync_opencode_config(
     create_backup(&config_path)?;
 
     let mut config: Value = if config_path.exists() {
-        fs::read_to_string(&config_path)
-            .ok()
-            .and_then(|c| serde_json::from_str(&c).ok())
-            .unwrap_or_else(|| serde_json::json!({}))
+        parse_config_file(&config_path).unwrap_or_else(|| serde_json::json!({}))
     } else {
         serde_json::json!({})
     };
 
-    let model_refs: Option<Vec<&str>> = models_to_sync
-        .as_ref()
-        .map(|models| models.iter().map(|m| m.as_str()).collect());
-    config = apply_sync_to_config(config, proxy_url, api_key, model_refs.as_deref());
+    config = apply_sync_to_config(config, proxy_url, api_key, models_to_sync.as_deref());
 
     let tmp_path = config_path.with_extension("tmp");
     fs::write(&tmp_path, serde_json::to_string_pretty(&config).unwrap())
@@ -1153,18 +1573,30 @@ pub fn restore_opencode_config() -> Result<(), String> {
 
     let mut restored = false;
 
-    // Try new backup suffix first, fall back to old suffix for backward compatibility
-    let config_backup_new =
-        config_path.with_file_name(format!("{}{}", OPENCODE_CONFIG_FILE, BACKUP_SUFFIX));
-    let config_backup_old =
-        config_path.with_file_name(format!("{}{}", OPENCODE_CONFIG_FILE, OLD_BACKUP_SUFFIX));
-
-    if config_backup_new.exists() {
-        restore_backup_to_target(&config_backup_new, &config_path, "config")?;
-        restored = true;
-    } else if config_backup_old.exists() {
-        restore_backup_to_target(&config_backup_old, &config_path, "config")?;
-        restored = true;
+    // Backups are named after the config file they protected. A user may have been
+    // using opencode.json or opencode.jsonc, and the active path may now differ from
+    // whichever backup exists. Look for backups under both file names, preferring the
+    // active one, and restore the backup to its original (backup-name minus suffix)
+    // target path so we don't resurrect a stale parallel file.
+    let dir = config_path.parent();
+    let active_file_name = config_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(OPENCODE_CONFIG_FILE);
+    let config_candidates: [(&str, &str); 4] = [
+        (active_file_name, BACKUP_SUFFIX),
+        (active_file_name, OLD_BACKUP_SUFFIX),
+        (OPENCODE_CONFIG_FILE, BACKUP_SUFFIX),
+        (OPENCODE_CONFIG_FILE, OLD_BACKUP_SUFFIX),
+    ];
+    for (file_name, suffix) in &config_candidates {
+        let backup_path = config_path.with_file_name(format!("{}{}", file_name, suffix));
+        if backup_path.exists() {
+            let target = dir.map(|d| d.join(file_name)).unwrap_or_else(|| config_path.clone());
+            restore_backup_to_target(&backup_path, &target, "config")?;
+            restored = true;
+            break;
+        }
     }
 
     // Try new backup suffix first, fall back to old suffix for backward compatibility
@@ -1196,7 +1628,7 @@ fn apply_sync_to_config(
     mut config: Value,
     proxy_url: &str,
     api_key: &str,
-    models_to_sync: Option<&[&str]>,
+    models_to_sync: Option<&[ModelInput]>,
 ) -> Value {
     if !config.is_object() {
         config = serde_json::json!({});
@@ -1216,6 +1648,7 @@ fn apply_sync_to_config(
             ensure_provider_string_field(ag_provider, "npm", "@ai-sdk/anthropic");
             ensure_provider_string_field(ag_provider, "name", "Antigravity Manager");
             merge_provider_options(ag_provider, &normalized_url, api_key);
+            migrate_gemini_alias_models(ag_provider);
             merge_catalog_models(ag_provider, models_to_sync);
         }
     }
@@ -1259,6 +1692,388 @@ fn apply_clear_to_config(mut config: Value, proxy_url: Option<&str>, clear_legac
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::proxy::common::variant_mapping::{infer_tier, resolve_real_model};
+
+    /// Helper: build a ModelInput with just an id (no display name).
+    fn minput(id: &str) -> ModelInput {
+        ModelInput {
+            id: id.to_string(),
+            name: None,
+        }
+    }
+
+    /// Helper: build a ModelInput carrying a display name.
+    fn minput_named(id: &str, name: &str) -> ModelInput {
+        ModelInput {
+            id: id.to_string(),
+            name: Some(name.to_string()),
+        }
+    }
+
+    #[test]
+    fn merge_catalog_models_normalizes_aliases_to_canonical() {
+        let mut provider = serde_json::json!({ "models": {} });
+        let inputs = [minput("gemini-3.1-pro-high"), minput("gemini-3.1-pro-low")];
+
+        merge_catalog_models(&mut provider, Some(&inputs));
+
+        let models = provider["models"].as_object().expect("models object");
+        assert_eq!(models.len(), 1);
+        assert!(models.contains_key("gemini-3.1-pro"));
+        assert!(!models.contains_key("gemini-3.1-pro-high"));
+        assert!(!models.contains_key("gemini-3.1-pro-low"));
+    }
+
+    #[test]
+    fn merge_catalog_models_keeps_one_pro_and_one_flash_for_legacy_inputs() {
+        let mut provider = serde_json::json!({ "models": {} });
+        let inputs = [
+            minput("gemini-3.1-pro-high"),
+            minput("gemini-3.1-pro-low"),
+            minput("gemini-3-flash"),
+        ];
+
+        merge_catalog_models(&mut provider, Some(&inputs));
+
+        let models = provider["models"].as_object().expect("models object");
+        assert_eq!(models.len(), 2);
+        assert!(models.contains_key("gemini-3.1-pro"));
+        assert!(models.contains_key("gemini-3.5-flash"));
+    }
+
+    #[test]
+    fn apply_sync_migrates_old_alias_keys_to_canonical() {
+        let config = serde_json::json!({
+            "provider": {
+                ANTIGRAVITY_PROVIDER_ID: {
+                    "models": {
+                        "gemini-3.1-pro-high": { "from_high": true },
+                        "gemini-3.1-pro-low": { "from_low": true },
+                        "custom-model": { "preserved": true }
+                    }
+                }
+            }
+        });
+
+        let updated = apply_sync_to_config(config, "http://localhost:8045", "key", Some(&[]));
+        let models = updated["provider"][ANTIGRAVITY_PROVIDER_ID]["models"]
+            .as_object()
+            .expect("models object");
+        let canonical = models
+            .get("gemini-3.1-pro")
+            .and_then(Value::as_object)
+            .expect("canonical model");
+
+        assert_eq!(canonical.get("from_high"), Some(&Value::Bool(true)));
+        assert_eq!(canonical.get("from_low"), Some(&Value::Bool(true)));
+        assert!(!models.contains_key("gemini-3.1-pro-high"));
+        assert!(!models.contains_key("gemini-3.1-pro-low"));
+        assert_eq!(
+            models.get("custom-model"),
+            Some(&serde_json::json!({ "preserved": true }))
+        );
+    }
+
+    #[test]
+    fn apply_sync_keeps_non_conflicting_user_fields() {
+        let config = serde_json::json!({
+            "provider": {
+                ANTIGRAVITY_PROVIDER_ID: {
+                    "models": {
+                        "gemini-3.1-pro": { "canonical_only": "keep" },
+                        "gemini-3.1-pro-high": { "alias_only": "also keep" }
+                    }
+                }
+            }
+        });
+
+        let updated = apply_sync_to_config(config, "http://localhost:8045", "key", Some(&[]));
+        let canonical = updated["provider"][ANTIGRAVITY_PROVIDER_ID]["models"]
+            ["gemini-3.1-pro"]
+            .as_object()
+            .expect("canonical model");
+
+        assert_eq!(
+            canonical.get("canonical_only"),
+            Some(&Value::String("keep".to_string()))
+        );
+        assert_eq!(
+            canonical.get("alias_only"),
+            Some(&Value::String("also keep".to_string()))
+        );
+    }
+
+    #[test]
+    fn apply_sync_warns_on_conflicts_and_canonical_wins() {
+        use std::sync::{Arc, Mutex};
+        use tracing::{Event, Level, Subscriber};
+        use tracing_subscriber::{
+            layer::{Context, SubscriberExt},
+            registry::LookupSpan,
+            Layer,
+        };
+
+        #[derive(Clone)]
+        struct WarnCapture(Arc<Mutex<usize>>);
+
+        impl<S> Layer<S> for WarnCapture
+        where
+            S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+        {
+            fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
+                if *event.metadata().level() == Level::WARN {
+                    *self.0.lock().expect("warning counter lock") += 1;
+                }
+            }
+        }
+
+        let config = serde_json::json!({
+            "provider": {
+                ANTIGRAVITY_PROVIDER_ID: {
+                    "models": {
+                        "gemini-3.1-pro": { "custom": "canonical" },
+                        "gemini-3.1-pro-high": { "custom": "alias" }
+                    }
+                }
+            }
+        });
+        let warnings = Arc::new(Mutex::new(0));
+        let subscriber = tracing_subscriber::registry().with(WarnCapture(warnings.clone()));
+        let updated = tracing::subscriber::with_default(subscriber, || {
+            apply_sync_to_config(config, "http://localhost:8045", "key", Some(&[]))
+        });
+
+        assert_eq!(
+            updated["provider"][ANTIGRAVITY_PROVIDER_ID]["models"]["gemini-3.1-pro"]["custom"],
+            "canonical"
+        );
+        assert_eq!(*warnings.lock().expect("warning counter lock"), 1);
+    }
+
+    fn preserved_catalog_json_snapshot(models: &[ModelDef]) -> String {
+        let entries = models
+            .iter()
+            .filter(|model| {
+                model.id.starts_with("claude-")
+                    || model.id == "gemini-3-pro-image"
+                    || model.id.starts_with("gemini-2.5-")
+            })
+            .map(|model| serde_json::json!({ "id": model.id, "model": build_model_json(model) }))
+            .collect::<Vec<_>>();
+
+        serde_json::to_string(&entries).unwrap()
+    }
+
+    #[test]
+    fn catalog_preserves_non_gemini3_variant_json_snapshot() {
+        let expected = vec![
+            ModelDef {
+                id: "claude-sonnet-4-6",
+                name: "Claude Sonnet 4.6",
+                context_limit: 200_000,
+                output_limit: 64_000,
+                input_modalities: &["text", "image", "pdf"],
+                output_modalities: &["text"],
+                reasoning: false,
+                variant_type: None,
+            },
+            ModelDef {
+                id: "claude-sonnet-4-6-thinking",
+                name: "Claude Sonnet 4.6 Thinking",
+                context_limit: 200_000,
+                output_limit: 64_000,
+                input_modalities: &["text", "image", "pdf"],
+                output_modalities: &["text"],
+                reasoning: true,
+                variant_type: Some(VariantType::ClaudeThinking),
+            },
+            ModelDef {
+                id: "claude-opus-4-5-thinking",
+                name: "Claude Opus 4.5 Thinking",
+                context_limit: 200_000,
+                output_limit: 64_000,
+                input_modalities: &["text", "image", "pdf"],
+                output_modalities: &["text"],
+                reasoning: true,
+                variant_type: Some(VariantType::ClaudeThinking),
+            },
+            ModelDef {
+                id: "claude-opus-4-6-thinking",
+                name: "Claude Opus 4.6 Thinking",
+                context_limit: 200_000,
+                output_limit: 64_000,
+                input_modalities: &["text", "image", "pdf"],
+                output_modalities: &["text"],
+                reasoning: true,
+                variant_type: Some(VariantType::ClaudeThinking),
+            },
+            ModelDef {
+                id: "gemini-3-pro-image",
+                name: "Gemini 3 Pro Image",
+                context_limit: 1_048_576,
+                output_limit: 65_535,
+                input_modalities: &["text", "image", "pdf"],
+                output_modalities: &["text", "image"],
+                reasoning: false,
+                variant_type: None,
+            },
+            ModelDef {
+                id: "gemini-2.5-flash",
+                name: "Gemini 2.5 Flash",
+                context_limit: 1_048_576,
+                output_limit: 65_536,
+                input_modalities: &["text", "image", "pdf"],
+                output_modalities: &["text"],
+                reasoning: false,
+                variant_type: None,
+            },
+            ModelDef {
+                id: "gemini-2.5-flash-lite",
+                name: "Gemini 2.5 Flash Lite",
+                context_limit: 1_048_576,
+                output_limit: 65_536,
+                input_modalities: &["text", "image", "pdf"],
+                output_modalities: &["text"],
+                reasoning: false,
+                variant_type: None,
+            },
+            ModelDef {
+                id: "gemini-2.5-flash-thinking",
+                name: "Gemini 2.5 Flash Thinking",
+                context_limit: 1_048_576,
+                output_limit: 65_536,
+                input_modalities: &["text", "image", "pdf"],
+                output_modalities: &["text"],
+                reasoning: true,
+                variant_type: Some(VariantType::Gemini25Thinking),
+            },
+            ModelDef {
+                id: "gemini-2.5-pro",
+                name: "Gemini 2.5 Pro",
+                context_limit: 1_048_576,
+                output_limit: 65_536,
+                input_modalities: &["text", "image", "pdf"],
+                output_modalities: &["text"],
+                reasoning: true,
+                variant_type: None,
+            },
+        ];
+
+        assert_eq!(
+            preserved_catalog_json_snapshot(&build_model_catalog()),
+            preserved_catalog_json_snapshot(&expected)
+        );
+    }
+
+    #[test]
+    fn catalog_uses_canonical_gemini_family_entries() {
+        let catalog = build_model_catalog();
+        let variant_ids = catalog
+            .iter()
+            .filter(|model| {
+                matches!(
+                    model.variant_type,
+                    Some(VariantType::Gemini3Pro) | Some(VariantType::Gemini3Flash)
+                )
+            })
+            .map(|model| model.id)
+            .collect::<std::collections::BTreeSet<_>>();
+        let canonical_ids = GEMINI_FAMILIES
+            .iter()
+            .map(|family| family.canonical_id)
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert_eq!(variant_ids, canonical_ids);
+
+        for family in GEMINI_FAMILIES {
+            let model = catalog
+                .iter()
+                .find(|model| model.id == family.canonical_id)
+                .unwrap();
+            assert_eq!(model.name, family.display_name);
+            assert_eq!(model.context_limit, family.context_limit);
+            assert_eq!(model.output_limit, family.output_limit);
+            assert_eq!(model.input_modalities, family.input_modalities);
+            assert_eq!(model.output_modalities, family.output_modalities);
+            assert_eq!(model.reasoning, family.reasoning);
+
+            match family.canonical_id {
+                "gemini-3.1-pro" => {
+                    assert!(matches!(model.variant_type, Some(VariantType::Gemini3Pro)));
+                }
+                "gemini-3.5-flash" => {
+                    assert!(matches!(model.variant_type, Some(VariantType::Gemini3Flash)));
+                }
+                _ => panic!("unexpected Gemini family: {}", family.canonical_id),
+            }
+        }
+    }
+
+    #[test]
+    fn catalog_marks_gemini_31_flash_lite_as_non_variant() {
+        let catalog = build_model_catalog();
+        let flash_lite = catalog
+            .iter()
+            .find(|model| model.id == "gemini-3.1-flash-lite")
+            .unwrap();
+
+        assert!(matches!(flash_lite.variant_type, None));
+    }
+
+    #[test]
+    fn build_variants_pro_resolve_to_real_ids() {
+        let variants = build_variants_object(Some(VariantType::Gemini3Pro))
+            .expect("Gemini 3.1 Pro variants must be configured");
+
+        for (name, expected_id) in [
+            ("low", "gemini-3.1-pro-low"),
+            ("high", "gemini-pro-agent"),
+        ] {
+            let variant = &variants[name];
+            let budget = variant["thinking"]["budget_tokens"]
+                .as_u64()
+                .expect("variant must expose thinking.budget_tokens") as u32;
+
+            assert_eq!(variant["budgetTokens"], budget);
+            assert_eq!(variant["thinkingConfig"]["thinkingBudget"], budget);
+            assert_eq!(
+                resolve_real_model("gemini-3.1-pro", infer_tier(Some(budget)))
+                    .expect("Gemini 3.1 Pro tier must resolve")
+                    .id,
+                expected_id
+            );
+        }
+
+        assert_eq!(variants.as_object().expect("variants must be an object").len(), 2);
+    }
+
+    #[test]
+    fn build_variants_flash_resolve_to_real_ids() {
+        let variants = build_variants_object(Some(VariantType::Gemini3Flash))
+            .expect("Gemini 3.5 Flash variants must be configured");
+
+        for (name, expected_id) in [
+            ("low", "gemini-3.5-flash-extra-low"),
+            ("medium", "gemini-3.5-flash-low"),
+            ("high", "gemini-3-flash-agent"),
+        ] {
+            let variant = &variants[name];
+            let budget = variant["thinking"]["budget_tokens"]
+                .as_u64()
+                .expect("variant must expose thinking.budget_tokens") as u32;
+
+            assert_eq!(variant["budgetTokens"], budget);
+            assert_eq!(variant["thinkingConfig"]["thinkingBudget"], budget);
+            assert_eq!(
+                resolve_real_model("gemini-3.5-flash", infer_tier(Some(budget)))
+                    .expect("Gemini 3.5 Flash tier must resolve")
+                    .id,
+                expected_id
+            );
+        }
+
+        assert_eq!(variants.as_object().expect("variants must be an object").len(), 3);
+    }
 
     #[test]
     fn test_extract_version_opencode_format() {
@@ -1421,8 +2236,8 @@ mod tests {
             "should have claude-sonnet-4-6"
         );
         assert!(
-            models.contains_key("gemini-3.1-pro-high"),
-            "should have gemini-3.1-pro-high"
+            models.contains_key("gemini-3.1-pro"),
+            "should have gemini-3.1-pro"
         );
         assert!(
             models.contains_key("gemini-2.5-pro"),
@@ -1439,13 +2254,13 @@ mod tests {
     #[test]
     fn test_sync_with_filtered_models() {
         let config = serde_json::json!({});
-        let models_to_sync = &["claude-sonnet-4-6", "gemini-3.1-pro-high"];
+        let models_to_sync = [minput("claude-sonnet-4-6"), minput("gemini-3.1-pro")];
 
         let result = apply_sync_to_config(
             config,
             "http://localhost:3000",
             "test-api-key",
-            Some(models_to_sync),
+            Some(&models_to_sync),
         );
 
         let provider = result.get("provider").unwrap();
@@ -1453,7 +2268,9 @@ mod tests {
         let models = ag.get("models").unwrap().as_object().unwrap();
 
         assert!(models.contains_key("claude-sonnet-4-6"));
-        assert!(models.contains_key("gemini-3.1-pro-high"));
+        let pro_model = models.get("gemini-3.1-pro").unwrap();
+        assert_eq!(pro_model.get("name").unwrap(), "Gemini 3.1 Pro");
+        assert_eq!(pro_model["limit"]["output"], 65_535);
         assert!(
             !models.contains_key("gemini-2.5-pro"),
             "should not have unselected models"
@@ -1649,6 +2466,386 @@ mod tests {
             "empty provider object should be removed"
         );
     }
+
+    /// Regression: model ids not present in the hardcoded catalog must still be
+    /// written to the config (previously silently dropped). A minimal `{ "name": ... }`
+    /// entry is valid per the OpenCode schema.
+    #[test]
+    fn test_sync_creates_fallback_model_for_unknown_id() {
+        let config = serde_json::json!({});
+        // "some-new-model" is deliberately not in build_model_catalog()
+        let models_to_sync = [minput("some-new-model")];
+
+        let result = apply_sync_to_config(
+            config,
+            "http://localhost:3000",
+            "test-api-key",
+            Some(&models_to_sync),
+        );
+
+        let models = result
+            .get("provider")
+            .unwrap()
+            .get(ANTIGRAVITY_PROVIDER_ID)
+            .unwrap()
+            .get("models")
+            .unwrap()
+            .as_object()
+            .unwrap();
+
+        assert!(
+            models.contains_key("some-new-model"),
+            "unknown model id must still be written, not dropped"
+        );
+        let entry = models.get("some-new-model").unwrap();
+        assert!(
+            entry.get("name").is_some(),
+            "fallback entry must at least have a name"
+        );
+    }
+
+    /// Mixing known catalog ids with unknown ids should write all of them.
+    #[test]
+    fn test_sync_filtered_models_with_known_and_unknown_ids() {
+        let config = serde_json::json!({});
+        let models_to_sync = [
+            minput("claude-sonnet-4-6"),
+            minput("gemini-3.1-pro"),
+            minput("custom-future-model"),
+        ];
+
+        let result = apply_sync_to_config(
+            config,
+            "http://localhost:3000",
+            "test-api-key",
+            Some(&models_to_sync),
+        );
+
+        let models = result
+            .get("provider")
+            .unwrap()
+            .get(ANTIGRAVITY_PROVIDER_ID)
+            .unwrap()
+            .get("models")
+            .unwrap()
+            .as_object()
+            .unwrap();
+
+        // Known ids get full catalog metadata
+        let claude = models.get("claude-sonnet-4-6").unwrap();
+        assert_eq!(claude.get("name").unwrap(), "Claude Sonnet 4.6");
+        assert!(claude.get("limit").is_some());
+
+        // Unknown id gets a minimal fallback entry
+        let custom = models.get("custom-future-model").unwrap();
+        assert!(custom.get("name").is_some());
+        assert_eq!(models["gemini-3.1-pro"]["limit"]["output"], 65_535);
+    }
+
+    /// Fallback entries should not clobber a model object the user already defined.
+    #[test]
+    fn test_sync_fallback_preserves_user_defined_model() {
+        let config = serde_json::json!({
+            "provider": {
+                "antigravity-manager": {
+                    "models": {
+                        "custom-future-model": {
+                            "name": "My Custom Name",
+                            "limit": { "context": 128000, "output": 4096 }
+                        }
+                    }
+                }
+            }
+        });
+        let models_to_sync = [minput("custom-future-model")];
+
+        let result = apply_sync_to_config(
+            config,
+            "http://localhost:3000",
+            "test-api-key",
+            Some(&models_to_sync),
+        );
+
+        let entry = result
+            .get("provider")
+            .unwrap()
+            .get(ANTIGRAVITY_PROVIDER_ID)
+            .unwrap()
+            .get("models")
+            .unwrap()
+            .get("custom-future-model")
+            .unwrap();
+
+        // User's own name/limit must be preserved, not overwritten by the fallback.
+        assert_eq!(entry.get("name").unwrap(), "My Custom Name");
+        assert_eq!(
+            entry.get("limit").unwrap().get("context").unwrap(),
+            &serde_json::json!(128000)
+        );
+    }
+
+    /// The fallback name derivation should produce human-readable names.
+    /// The fallback name derivation should preserve version dots (e.g. "3.5").
+    #[test]
+    fn test_build_fallback_model_json_readable_name() {
+        // No display name: derived from id, dots preserved.
+        let entry = build_fallback_model_json("gemini-2.5-pro", None);
+        assert_eq!(entry.get("name").unwrap(), "Gemini 2.5 Pro");
+
+        // 3.5 should stay together, not split into "3 5".
+        let entry = build_fallback_model_json("gemini-3.5-flash-low", None);
+        assert_eq!(entry.get("name").unwrap(), "Gemini 3.5 Flash Low");
+    }
+
+    /// When the frontend provides a display name, it must be used verbatim so the
+    /// config shows the same name the user saw (e.g. "Gemini 3.5 Flash (High)").
+    #[test]
+    fn test_build_fallback_model_json_uses_display_name() {
+        let entry = build_fallback_model_json(
+            "gemini-3.5-flash-high",
+            Some("Gemini 3.5 Flash (High)"),
+        );
+        assert_eq!(entry.get("name").unwrap(), "Gemini 3.5 Flash (High)");
+    }
+
+    /// Fallback entries for known families should pick up sensible limit/modalities.
+    #[test]
+    fn test_build_fallback_model_json_series_defaults() {
+        // A gemini-3.x id gets 1M context + multimodal input.
+        let entry = build_fallback_model_json("gemini-3.5-flash-low", None);
+        let limit = entry.get("limit").unwrap();
+        assert_eq!(limit.get("context").unwrap(), &serde_json::json!(1_048_576));
+        assert!(entry.get("modalities").is_some());
+
+        // A claude id gets 200k context.
+        let entry = build_fallback_model_json("claude-sonnet-4-9", None);
+        let limit = entry.get("limit").unwrap();
+        assert_eq!(limit.get("context").unwrap(), &serde_json::json!(200_000));
+
+        // An unknown family (not gemini/claude) only gets a name.
+        let entry = build_fallback_model_json("acme-model-1", None);
+        assert!(entry.get("limit").is_none());
+        assert!(entry.get("name").is_some());
+    }
+
+    /// resolve_active_config_file_name should prefer .jsonc when None is passed
+    /// (pure helper path), and the default file should be opencode.json.
+    #[test]
+    fn test_resolve_active_config_file_name_default() {
+        // Without probing a directory, the default is opencode.json.
+        assert_eq!(resolve_active_config_file_name(None), OPENCODE_CONFIG_FILE);
+    }
+
+    #[test]
+    fn test_resolve_active_config_file_name_prefers_existing_jsonc() {
+        // Create a temp dir that has only opencode.jsonc and confirm it is preferred.
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let dir = tmp.path().to_path_buf();
+        std::fs::write(dir.join(OPENCODE_CONFIG_FILE_JSONC), "{}").expect("write jsonc");
+        assert_eq!(
+            resolve_active_config_file_name(Some(&dir)),
+            OPENCODE_CONFIG_FILE_JSONC
+        );
+    }
+
+    #[test]
+    fn test_resolve_active_config_file_name_falls_back_to_json() {
+        // A temp dir with no config files at all defaults to opencode.json.
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let dir = tmp.path().to_path_buf();
+        assert_eq!(
+            resolve_active_config_file_name(Some(&dir)),
+            OPENCODE_CONFIG_FILE
+        );
+    }
+
+    /// strip_jsonc_comments must remove line and block comments while preserving
+    /// `//` and `/* */` that appear inside string values.
+    #[test]
+    fn test_strip_jsonc_comments_line_and_block() {
+        let input = r#"{
+  // a line comment
+  "key": "value", /* trailing block comment */
+  "url": "https://example.com/path" // not a comment inside string
+}"#;
+        let stripped = strip_jsonc_comments(input);
+        // The resulting string must be valid JSON.
+        let parsed: Value =
+            serde_json::from_str(&stripped).expect("stripped jsonc must be valid JSON");
+        assert_eq!(parsed.get("key").unwrap(), "value");
+        // The URL's // must be preserved (it is inside a string).
+        assert_eq!(
+            parsed.get("url").unwrap(),
+            "https://example.com/path"
+        );
+    }
+
+    #[test]
+    fn test_strip_jsonc_comments_preserves_escaped_quotes() {
+        // A string containing an escaped quote followed by // must not confuse the scanner.
+        let input = r##"{"msg": "a \"quoted//\" end", "n": 1 // comment
+}"##;
+        let stripped = strip_jsonc_comments(input);
+        let parsed: Value =
+            serde_json::from_str(&stripped).expect("stripped jsonc must be valid JSON");
+        assert_eq!(parsed.get("msg").unwrap(), "a \"quoted//\" end");
+        assert_eq!(parsed.get("n").unwrap(), 1);
+    }
+
+    /// strip_jsonc_trailing_commas must drop a comma right before `}` or `]` (with
+    /// optional whitespace between), while keeping commas that separate real elements.
+    #[test]
+    fn test_strip_jsonc_trailing_commas() {
+        let input = "{\n  \"a\": 1,\n  \"b\": 2,\n}"; // trailing comma before }
+        let stripped = strip_jsonc_trailing_commas(input);
+        let parsed: Value =
+            serde_json::from_str(&stripped).expect("stripped must be valid JSON");
+        assert_eq!(parsed.get("a").unwrap(), 1);
+        assert_eq!(parsed.get("b").unwrap(), 2);
+    }
+
+    #[test]
+    fn test_strip_jsonc_trailing_commas_in_nested_array() {
+        // trailing comma before ] and before }, with whitespace/newlines in between.
+        let input = "{\n  \"arr\": [1, 2, 3,],\n  \"obj\": { \"k\": \"v\", },\n}";
+        let stripped = strip_jsonc_trailing_commas(input);
+        let parsed: Value =
+            serde_json::from_str(&stripped).expect("stripped must be valid JSON");
+        assert_eq!(parsed.get("arr").unwrap().as_array().unwrap().len(), 3);
+        assert_eq!(
+            parsed.get("obj").unwrap().get("k").unwrap(),
+            "v"
+        );
+    }
+
+    #[test]
+    fn test_strip_jsonc_trailing_commas_keeps_real_commas_in_strings() {
+        // A comma inside a string must NOT be removed even if followed by }.
+        let input = "{\"msg\": \"hello, }\",}";
+        let stripped = strip_jsonc_trailing_commas(input);
+        let parsed: Value =
+            serde_json::from_str(&stripped).expect("stripped must be valid JSON");
+        assert_eq!(parsed.get("msg").unwrap(), "hello, }");
+    }
+
+    /// parse_config_file must read a jsonc file with BOTH comments and trailing commas
+    /// — this is the regression for the user-reported "config destroyed" case where a
+    /// trailing comma made serde_json fail and the whole config was replaced with {}.
+    #[test]
+    fn test_parse_config_file_handles_jsonc_comments_and_trailing_commas() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let path = tmp.path().join("opencode.jsonc");
+        std::fs::write(
+            &path,
+            r#"{
+  // user's config with a trailing comma (valid JSONC, invalid strict JSON)
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "myown": { "name": "My Own Provider" },
+  },
+}"#,
+        )
+        .unwrap();
+
+        let parsed = parse_config_file(&path).expect("jsonc with trailing comma must parse");
+        assert_eq!(
+            parsed
+                .get("provider")
+                .unwrap()
+                .get("myown")
+                .unwrap()
+                .get("name")
+                .unwrap(),
+            "My Own Provider"
+        );
+    }
+
+    /// parse_config_file must read a jsonc file (with comments) into a Value.
+    #[test]
+    fn test_parse_config_file_handles_jsonc_comments() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let path = tmp.path().join("opencode.jsonc");
+        std::fs::write(
+            &path,
+            r#"{
+  // my opencode config
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "myown": { "name": "My Own Provider" }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let parsed = parse_config_file(&path).expect("jsonc file must parse");
+        assert_eq!(
+            parsed
+                .get("provider")
+                .unwrap()
+                .get("myown")
+                .unwrap()
+                .get("name")
+                .unwrap(),
+            "My Own Provider"
+        );
+    }
+
+    /// The frontend-provided display name must flow through to the config for models
+    /// that aren't in the catalog. This is the regression for the user-reported case
+    /// where "Gemini 3.5 Flash (High)" became a stripped "Gemini 3 5 Flash Low".
+    #[test]
+    fn test_sync_uses_frontend_display_name_for_unknown_model() {
+        let config = serde_json::json!({});
+        let models_to_sync = [
+            minput_named("gemini-3.5-flash-low", "Gemini 3.5 Flash (High)"),
+            minput_named("gemini-3-flash-agent", "Gemini 3 Flash Agent"),
+        ];
+
+        let result = apply_sync_to_config(
+            config,
+            "http://localhost:3000",
+            "test-api-key",
+            Some(&models_to_sync),
+        );
+
+        let models = result
+            .get("provider")
+            .unwrap()
+            .get(ANTIGRAVITY_PROVIDER_ID)
+            .unwrap()
+            .get("models")
+            .unwrap()
+            .as_object()
+            .unwrap();
+
+        // The display name must be used as-is, preserving parentheses/variant info.
+        assert_eq!(
+            models
+                .get("gemini-3.5-flash-low")
+                .unwrap()
+                .get("name")
+                .unwrap(),
+            "Gemini 3.5 Flash (High)"
+        );
+        assert_eq!(
+            models
+                .get("gemini-3-flash-agent")
+                .unwrap()
+                .get("name")
+                .unwrap(),
+            "Gemini 3 Flash Agent"
+        );
+
+        // And because these are gemini-3.x ids, they should also get series defaults.
+        assert!(
+            models
+                .get("gemini-3.5-flash-low")
+                .unwrap()
+                .get("limit")
+                .is_some(),
+            "gemini-3.x fallback should include limit/modalities"
+        );
+    }
 }
 
 pub fn read_opencode_config_content(file_name: Option<String>) -> Result<String, String> {
@@ -1659,22 +2856,28 @@ pub fn read_opencode_config_content(file_name: Option<String>) -> Result<String,
     // Allowlist of permitted file names
     let allowed_files = [
         OPENCODE_CONFIG_FILE,
+        OPENCODE_CONFIG_FILE_JSONC,
         ANTIGRAVITY_CONFIG_FILE,
         ANTIGRAVITY_ACCOUNTS_FILE,
     ];
 
-    // Determine which file to read
+    // Determine which file to read. Both opencode.json and opencode.jsonc map to the
+    // active opencode config path (which is resolved by probing the directory), so a
+    // caller asking for "opencode.json" still gets the user's actual config when it
+    // happens to be opencode.jsonc.
     let target_path = match file_name.as_deref() {
         Some(name) if name == ANTIGRAVITY_CONFIG_FILE => ag_config_path,
         Some(name) if name == ANTIGRAVITY_ACCOUNTS_FILE => ag_accounts_path,
-        Some(name) if name == OPENCODE_CONFIG_FILE => opencode_path,
+        Some(name) if name == OPENCODE_CONFIG_FILE || name == OPENCODE_CONFIG_FILE_JSONC => {
+            opencode_path
+        }
         Some(name) => {
             return Err(format!(
                 "Invalid file name: {}. Allowed: {:?}",
                 name, allowed_files
             ))
         }
-        None => opencode_path, // Default to opencode.json
+        None => opencode_path, // Default to the active opencode config (json or jsonc)
     };
 
     if !target_path.exists() {
@@ -1698,6 +2901,7 @@ pub async fn get_opencode_sync_status(proxy_url: String) -> Result<OpencodeStatu
             current_base_url,
             files: vec![
                 OPENCODE_CONFIG_FILE.to_string(),
+                OPENCODE_CONFIG_FILE_JSONC.to_string(),
                 ANTIGRAVITY_CONFIG_FILE.to_string(),
                 ANTIGRAVITY_ACCOUNTS_FILE.to_string(),
             ],
@@ -1708,11 +2912,37 @@ pub async fn get_opencode_sync_status(proxy_url: String) -> Result<OpencodeStatu
 }
 
 #[tauri::command]
+pub fn get_canonical_families() -> Vec<CanonicalFamilyDto> {
+    GEMINI_FAMILIES
+        .iter()
+        .map(|family| {
+            let mut normalized_match_ids = HashSet::new();
+            let mut match_ids = Vec::new();
+
+            for match_id in std::iter::once(family.canonical_id)
+                .chain(family.aliases.iter().map(|(alias, _)| *alias))
+                .chain(family.tiers.iter().map(|(_, spec)| spec.id))
+            {
+                if normalized_match_ids.insert(match_id.to_lowercase()) {
+                    match_ids.push(match_id.to_string());
+                }
+            }
+
+            CanonicalFamilyDto {
+                canonical_id: family.canonical_id.to_string(),
+                display_name: family.display_name.to_string(),
+                match_ids,
+            }
+        })
+        .collect()
+}
+
+#[tauri::command]
 pub async fn execute_opencode_sync(
     proxy_url: String,
     api_key: String,
     sync_accounts: Option<bool>,
-    models: Option<Vec<String>>,
+    models: Option<Vec<ModelInput>>,
 ) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         sync_opencode_config(&proxy_url, &api_key, sync_accounts.unwrap_or(false), models)
@@ -1783,8 +3013,9 @@ fn clear_opencode_config(proxy_url: Option<String>, clear_legacy: bool) -> Resul
         let content = fs::read_to_string(&config_path)
             .map_err(|e| format!("Failed to read config: {}", e))?;
 
-        let config: Value =
-            serde_json::from_str(&content).map_err(|e| format!("Failed to parse config: {}", e))?;
+        // Tolerate JSONC (comments + trailing commas) when the user's config is opencode.jsonc.
+        let config: Value = parse_jsonc(&content)
+            .ok_or_else(|| "Failed to parse config (not valid JSON/JSONC)".to_string())?;
         let config = apply_clear_to_config(config, proxy_url.as_deref(), clear_legacy);
 
         // Write updated config
@@ -1872,4 +3103,74 @@ pub async fn execute_opencode_clear(
     clear_legacy: Option<bool>,
 ) -> Result<(), String> {
     clear_opencode_config(proxy_url, clear_legacy.unwrap_or(false))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_families_expose_the_complete_public_dto() {
+        let families = get_canonical_families();
+
+        assert_eq!(families.len(), GEMINI_FAMILIES.len());
+        assert_eq!(
+            families,
+            vec![
+                CanonicalFamilyDto {
+                    canonical_id: "gemini-3.5-flash".to_string(),
+                    display_name: "Gemini 3.5 Flash".to_string(),
+                    match_ids: vec![
+                        "gemini-3.5-flash".to_string(),
+                        "gemini-3.5-flash-high".to_string(),
+                        "gemini-3.5-flash-medium".to_string(),
+                        "gemini-3.5-flash-low".to_string(),
+                        "gemini-3-flash".to_string(),
+                        "gemini-3.5-flash-extra-low".to_string(),
+                        "gemini-3-flash-agent".to_string(),
+                    ],
+                },
+                CanonicalFamilyDto {
+                    canonical_id: "gemini-3.1-pro".to_string(),
+                    display_name: "Gemini 3.1 Pro".to_string(),
+                    match_ids: vec![
+                        "gemini-3.1-pro".to_string(),
+                        "gemini-3.1-pro-high".to_string(),
+                        "gemini-pro".to_string(),
+                        "gemini-3.1-pro-low".to_string(),
+                        "gemini-pro-agent".to_string(),
+                    ],
+                },
+            ]
+        );
+
+        let serialized = serde_json::to_string(&families).unwrap();
+        assert!(!serialized.contains("thinking_budget"));
+        assert!(!serialized.contains("max_output_tokens"));
+    }
+
+    #[test]
+    fn canonical_families_match_ids_are_unique_globally_after_normalization() {
+        let mut owners = HashMap::new();
+
+        for family in get_canonical_families() {
+            let mut family_match_ids = HashSet::new();
+            for match_id in &family.match_ids {
+                let normalized = match_id.to_lowercase();
+                assert!(
+                    family_match_ids.insert(normalized.clone()),
+                    "{} contains duplicate match ID {}",
+                    family.canonical_id,
+                    match_id
+                );
+                assert!(
+                    owners
+                        .insert(normalized.clone(), family.canonical_id.clone())
+                        .is_none(),
+                    "{} belongs to multiple canonical families",
+                    normalized
+                );
+            }
+        }
+    }
 }

--- a/src-tauri/src/proxy/opencode_sync.rs
+++ b/src-tauri/src/proxy/opencode_sync.rs
@@ -996,25 +996,17 @@ fn build_claude_thinking_variant(budget: u32) -> Value {
     })
 }
 
-/// Look up a Gemini variant's registered thinking budget.
-fn gemini_variant_budget(canonical_id: &str, tier: VariantTier) -> Option<u32> {
-    GEMINI_FAMILIES
-        .iter()
-        .find(|family| family.canonical_id == canonical_id)
-        .and_then(|family| {
-            family
-                .tiers
-                .iter()
-                .find(|(candidate_tier, _)| *candidate_tier == tier)
-        })
-        .map(|(_, spec)| spec.thinking_budget)
-}
-
-/// Build Gemini 3 style variant with the OpenCode thinking budget fields.
-fn build_gemini3_variant(budget: u32) -> Value {
-    let mut variant = build_claude_thinking_variant(budget);
-    variant["budgetTokens"] = Value::from(budget);
-    variant
+/// Build Gemini 3 effort-based variant for the @ai-sdk/anthropic SDK.
+///
+/// The provider serializes `{ "effort": "<tier>" }` as `output_config.effort`
+/// on the outgoing Anthropic request. No thinking-budget fields are used.
+fn build_gemini3_effort_variant(tier: VariantTier) -> Value {
+    let effort = match tier {
+        VariantTier::Low => "low",
+        VariantTier::Medium => "medium",
+        VariantTier::High => "high",
+    };
+    serde_json::json!({ "effort": effort })
 }
 
 /// Build Gemini 2.5 thinking variant with thinkingConfig and thinking
@@ -1046,17 +1038,11 @@ fn build_variants_object(variant_type: Option<VariantType>) -> Option<Value> {
             let mut variants = serde_json::Map::new();
             variants.insert(
                 "low".to_string(),
-                build_gemini3_variant(gemini_variant_budget(
-                    "gemini-3.1-pro",
-                    VariantTier::Low,
-                )?),
+                build_gemini3_effort_variant(VariantTier::Low),
             );
             variants.insert(
                 "high".to_string(),
-                build_gemini3_variant(gemini_variant_budget(
-                    "gemini-3.1-pro",
-                    VariantTier::High,
-                )?),
+                build_gemini3_effort_variant(VariantTier::High),
             );
             Some(Value::Object(variants))
         }
@@ -1064,24 +1050,15 @@ fn build_variants_object(variant_type: Option<VariantType>) -> Option<Value> {
             let mut variants = serde_json::Map::new();
             variants.insert(
                 "low".to_string(),
-                build_gemini3_variant(gemini_variant_budget(
-                    "gemini-3.5-flash",
-                    VariantTier::Low,
-                )?),
+                build_gemini3_effort_variant(VariantTier::Low),
             );
             variants.insert(
                 "medium".to_string(),
-                build_gemini3_variant(gemini_variant_budget(
-                    "gemini-3.5-flash",
-                    VariantTier::Medium,
-                )?),
+                build_gemini3_effort_variant(VariantTier::Medium),
             );
             variants.insert(
                 "high".to_string(),
-                build_gemini3_variant(gemini_variant_budget(
-                    "gemini-3.5-flash",
-                    VariantTier::High,
-                )?),
+                build_gemini3_effort_variant(VariantTier::High),
             );
             Some(Value::Object(variants))
         }
@@ -1692,7 +1669,7 @@ fn apply_clear_to_config(mut config: Value, proxy_url: Option<&str>, clear_legac
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proxy::common::variant_mapping::{infer_tier, resolve_real_model};
+    use crate::proxy::common::variant_mapping::resolve_real_model;
 
     /// Helper: build a ModelInput with just an id (no display name).
     fn minput(id: &str) -> ModelInput {
@@ -2020,6 +1997,16 @@ mod tests {
         assert!(matches!(flash_lite.variant_type, None));
     }
 
+    /// Map an Anthropic SDK effort string to the internal VariantTier.
+    fn effort_to_tier(effort: &str) -> VariantTier {
+        match effort {
+            "low" => VariantTier::Low,
+            "medium" => VariantTier::Medium,
+            "high" => VariantTier::High,
+            _ => panic!("unrecognized effort variant: {effort}"),
+        }
+    }
+
     #[test]
     fn build_variants_pro_resolve_to_real_ids() {
         let variants = build_variants_object(Some(VariantType::Gemini3Pro))
@@ -2030,14 +2017,13 @@ mod tests {
             ("high", "gemini-pro-agent"),
         ] {
             let variant = &variants[name];
-            let budget = variant["thinking"]["budget_tokens"]
-                .as_u64()
-                .expect("variant must expose thinking.budget_tokens") as u32;
+            let effort = variant["effort"]
+                .as_str()
+                .expect("Gemini 3 variant must expose effort string");
 
-            assert_eq!(variant["budgetTokens"], budget);
-            assert_eq!(variant["thinkingConfig"]["thinkingBudget"], budget);
+            let tier = effort_to_tier(effort);
             assert_eq!(
-                resolve_real_model("gemini-3.1-pro", infer_tier(Some(budget)))
+                resolve_real_model("gemini-3.1-pro", tier)
                     .expect("Gemini 3.1 Pro tier must resolve")
                     .id,
                 expected_id
@@ -2045,6 +2031,12 @@ mod tests {
         }
 
         assert_eq!(variants.as_object().expect("variants must be an object").len(), 2);
+
+        // Verify the JSON shape contains only `effort` — no budget fields
+        let low = &variants["low"];
+        assert_eq!(low.as_object().unwrap().len(), 1);
+        assert!(low.get("effort").is_some());
+        assert!(low.get("thinking").is_none());
     }
 
     #[test]
@@ -2058,14 +2050,13 @@ mod tests {
             ("high", "gemini-3-flash-agent"),
         ] {
             let variant = &variants[name];
-            let budget = variant["thinking"]["budget_tokens"]
-                .as_u64()
-                .expect("variant must expose thinking.budget_tokens") as u32;
+            let effort = variant["effort"]
+                .as_str()
+                .expect("Gemini 3 variant must expose effort string");
 
-            assert_eq!(variant["budgetTokens"], budget);
-            assert_eq!(variant["thinkingConfig"]["thinkingBudget"], budget);
+            let tier = effort_to_tier(effort);
             assert_eq!(
-                resolve_real_model("gemini-3.5-flash", infer_tier(Some(budget)))
+                resolve_real_model("gemini-3.5-flash", tier)
                     .expect("Gemini 3.5 Flash tier must resolve")
                     .id,
                 expected_id
@@ -2073,6 +2064,12 @@ mod tests {
         }
 
         assert_eq!(variants.as_object().expect("variants must be an object").len(), 3);
+
+        // Verify the JSON shape contains only `effort` — no budget fields
+        let low = &variants["low"];
+        assert_eq!(low.as_object().unwrap().len(), 1);
+        assert!(low.get("effort").is_some());
+        assert!(low.get("thinking").is_none());
     }
 
     #[test]
@@ -3106,7 +3103,7 @@ pub async fn execute_opencode_clear(
 }
 
 #[cfg(test)]
-mod tests {
+mod canonical_family_tests {
     use super::*;
 
     #[test]

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -587,6 +587,10 @@ impl AxumServer {
                 "/proxy/opencode/config",
                 post(admin_get_opencode_config_content),
             )
+            .route(
+                "/proxy/opencode/families",
+                get(admin_get_opencode_families),
+            )
             .route("/proxy/droid/status", post(admin_get_droid_sync_status))
             .route("/proxy/droid/sync", post(admin_execute_droid_sync))
             .route("/proxy/droid/restore", post(admin_execute_droid_restore))
@@ -3688,6 +3692,10 @@ async fn admin_get_opencode_sync_status(
         })
 }
 
+async fn admin_get_opencode_families() -> impl IntoResponse {
+    Json(crate::proxy::opencode_sync::get_canonical_families())
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct OpencodeSyncRequest {
@@ -3695,7 +3703,7 @@ struct OpencodeSyncRequest {
     api_key: String,
     #[serde(default)]
     sync_accounts: bool,
-    pub models: Option<Vec<String>>,
+    pub models: Option<Vec<crate::proxy::opencode_sync::ModelInput>>,
 }
 
 async fn admin_execute_opencode_sync(

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from 'react';
 import { ArrowRightLeft, RefreshCw, Trash2, Download, Info, Lock, Ban, Diamond, Gem, Circle, ToggleLeft, ToggleRight, Fingerprint, Sparkles, Tag, X, Check, Clock, Bot, Repeat2, Terminal } from 'lucide-react';
-import { Account } from '../../types/account';
+import { Account, ModelQuota } from '../../types/account';
 import { cn } from '../../utils/cn';
 import { useTranslation } from 'react-i18next';
 import { useConfigStore } from '../../stores/useConfigStore';
 import { QuotaItem } from './QuotaItem';
-import { MODEL_CONFIG, sortModels, categorizeModel, getModelProtectionKey } from '../../config/modelConfig';
+import { MODEL_CONFIG, sortModels, getModelProtectionKey, resolveQuotaModels, ensurePinnedImageSelector } from '../../config/modelConfig';
 import { getValidationBlockedStatusLabel } from './accountValidationStatus';
 import { getLiveLimitForModel } from '../../utils/liveLimit';
 
@@ -96,13 +96,28 @@ function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, is
             // Filter for pinned or defaults
             const pinned = config?.pinned_quota_models?.models;
             if (pinned && pinned.length > 0) {
-                // 使用 categorizeModel 做 family-aware 匹配，确保旧模型 ID 也能匹配到新 canonical ID
-                const pinnedCategories = new Set(pinned.map(p => categorizeModel(p)));
-                models = accountModels.filter(m => {
-                    const category = categorizeModel(m.id);
-                    if (category === 'other') return pinned.includes(m.id);
-                    return pinnedCategories.has(category);
-                });
+                const selections = resolveQuotaModels(
+                    accountModels.map(m => m.data),
+                    ensurePinnedImageSelector(pinned),
+                );
+                models = selections
+                    .map(sel => sel.model ? accountModels.find(am => am.data === sel.model) : undefined)
+                    .filter((m): m is typeof accountModels[number] => m !== undefined);
+                // 也保留无配额数据的 pinned 模型（显示 0%）
+                for (const sel of selections) {
+                    if (!sel.model) {
+                        const selectorConfig = MODEL_CONFIG[sel.selectorId.toLowerCase()];
+                        if (selectorConfig) {
+                            models = [...models, {
+                                id: sel.selectorId,
+                                label: selectorConfig.shortLabel || selectorConfig.label,
+                                protectedKey: selectorConfig.protectedKey,
+                                Icon: selectorConfig.Icon,
+                                data: { name: sel.selectorId, percentage: 0 } as ModelQuota,
+                            }];
+                        }
+                    }
+                }
             } else {
                 // Default fallback: show known default models, plus we show all dynamic pinned models
                 // 暂时退化：如果没有 config 就不阻拦了？不，没有 pinned 就显示内置+有 display_name 的。

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -5,7 +5,7 @@ import { cn } from '../../utils/cn';
 import { useTranslation } from 'react-i18next';
 import { useConfigStore } from '../../stores/useConfigStore';
 import { QuotaItem } from './QuotaItem';
-import { MODEL_CONFIG, sortModels, categorizeModel } from '../../config/modelConfig';
+import { MODEL_CONFIG, sortModels, categorizeModel, getModelProtectionKey } from '../../config/modelConfig';
 import { getValidationBlockedStatusLabel } from './accountValidationStatus';
 import { getLiveLimitForModel } from '../../utils/liveLimit';
 
@@ -82,7 +82,7 @@ function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, is
             return {
                 id: m.name,
                 label: m.display_name || fullConfig?.shortLabel || fullConfig?.label || m.name,
-                protectedKey: fullConfig?.protectedKey || m.name,
+                protectedKey: getModelProtectionKey(m.name) ?? fullConfig?.protectedKey ?? m.name,
                 Icon: iconMap.get(m.name) || Bot,
                 data: m
             };

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -5,7 +5,7 @@ import { cn } from '../../utils/cn';
 import { useTranslation } from 'react-i18next';
 import { useConfigStore } from '../../stores/useConfigStore';
 import { QuotaItem } from './QuotaItem';
-import { MODEL_CONFIG, sortModels } from '../../config/modelConfig';
+import { MODEL_CONFIG, sortModels, categorizeModel } from '../../config/modelConfig';
 import { getValidationBlockedStatusLabel } from './accountValidationStatus';
 import { getLiveLimitForModel } from '../../utils/liveLimit';
 
@@ -96,7 +96,13 @@ function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, is
             // Filter for pinned or defaults
             const pinned = config?.pinned_quota_models?.models;
             if (pinned && pinned.length > 0) {
-                models = accountModels.filter(m => pinned.includes(m.id));
+                // 使用 categorizeModel 做 family-aware 匹配，确保旧模型 ID 也能匹配到新 canonical ID
+                const pinnedCategories = new Set(pinned.map(p => categorizeModel(p)));
+                models = accountModels.filter(m => {
+                    const category = categorizeModel(m.id);
+                    if (category === 'other') return pinned.includes(m.id);
+                    return pinnedCategories.has(category);
+                });
             } else {
                 // Default fallback: show known default models, plus we show all dynamic pinned models
                 // 暂时退化：如果没有 config 就不阻拦了？不，没有 pinned 就显示内置+有 display_name 的。

--- a/src/components/accounts/AccountRow.tsx
+++ b/src/components/accounts/AccountRow.tsx
@@ -4,7 +4,7 @@ import { getQuotaColor, formatTimeRemaining, getTimeRemainingColor } from '../..
 import { cn } from '../../utils/cn';
 import { useTranslation } from 'react-i18next';
 import { formatCompactDuration, getLiveLimitForModel, getLiveLimitState } from '../../utils/liveLimit';
-import { categorizeModel, getModelProtectionKey, findQuotaModel } from '../../config/modelConfig';
+import { getModelProtectionKey, findQuotaModel, findImageQuotaModel } from '../../config/modelConfig';
 
 interface AccountRowProps {
     account: Account;
@@ -30,10 +30,9 @@ function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSw
     const geminiProModel = findQuotaModel(account.quota?.models, 'gemini-pro');
     const geminiFlashModel = findQuotaModel(account.quota?.models, 'gemini-flash');
 
-    const geminiImageModel = account.quota?.models.find(m =>
-        categorizeModel(m.name) === 'gemini-flash-image' || categorizeModel(m.name) === 'gemini-pro-image'
-    );
-    const liveImageLimit = getLiveLimitForModel(account, geminiImageModel?.name, getModelProtectionKey(geminiImageModel?.name || '') ?? undefined);
+    const geminiImageModel = findImageQuotaModel(account.quota?.models);
+    const imageProtectionKey = getModelProtectionKey(geminiImageModel?.name || '');
+    const liveImageLimit = getLiveLimitForModel(account, geminiImageModel?.name, imageProtectionKey ?? undefined);
     const liveImageState = getLiveLimitState(liveImageLimit);
     const isImageLiveLimited = liveImageState.shouldShow;
     const imageLimitTitle = liveImageLimit
@@ -249,7 +248,7 @@ function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSw
                             <div className="relative z-10 w-full flex items-center text-[10px] font-mono leading-none">
                                 <span className="w-[64px] text-gray-500 dark:text-gray-400 font-bold pr-1 flex items-center gap-1" title={imageLimitTitle}>
                                     {isImageLiveLimited && <Clock className={cn("w-2.5 h-2.5 shrink-0 z-10", liveImageState.isActive ? "text-rose-500" : "text-amber-500")} />}
-                                    {(account.protected_models?.includes('gemini-3.1-flash-image') || account.protected_models?.includes('gemini-3-pro-image')) && <Lock className="w-2.5 h-2.5 text-rose-500 shrink-0 z-10" />}
+                                    {(imageProtectionKey && account.protected_models?.includes(imageProtectionKey)) && <Lock className="w-2.5 h-2.5 text-rose-500 shrink-0 z-10" />}
                                     <span className="truncate">G3 Image</span>
                                 </span>
                                 <div className="flex-1 flex justify-center">

--- a/src/components/accounts/AccountRow.tsx
+++ b/src/components/accounts/AccountRow.tsx
@@ -4,6 +4,7 @@ import { getQuotaColor, formatTimeRemaining, getTimeRemainingColor } from '../..
 import { cn } from '../../utils/cn';
 import { useTranslation } from 'react-i18next';
 import { formatCompactDuration, getLiveLimitForModel, getLiveLimitState } from '../../utils/liveLimit';
+import { categorizeModel, getModelProtectionKey } from '../../config/modelConfig';
 
 interface AccountRowProps {
     account: Account;
@@ -27,21 +28,15 @@ function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSw
     const { t } = useTranslation();
     // [重构] 按组聚合查找逻辑，优先显示组内配额最低的型号以与锁定状态（🔒）对齐
     const geminiProModel = account.quota?.models
-        .filter(m =>
-            m.name.toLowerCase() === 'gemini-3-pro-high'
-            || m.name.toLowerCase() === 'gemini-3-pro-low'
-            || m.name.toLowerCase() === 'gemini-3.1-pro-high'
-            || m.name.toLowerCase() === 'gemini-3.1-pro-low'
-        )
+        .filter(m => categorizeModel(m.name) === 'gemini-pro')
         .sort((a, b) => (a.percentage || 0) - (b.percentage || 0))[0];
 
-    const geminiFlashModel = account.quota?.models.find(m => m.name.toLowerCase() === 'gemini-3-flash');
+    const geminiFlashModel = account.quota?.models.find(m => categorizeModel(m.name) === 'gemini-flash');
 
-    const geminiImageModel = account.quota?.models.find(m => {
-        const name = m.name.toLowerCase();
-        return name === 'gemini-3.1-flash-image' || name === 'gemini-3-pro-image';
-    });
-    const liveImageLimit = getLiveLimitForModel(account, geminiImageModel?.name, 'gemini-3.1-flash-image');
+    const geminiImageModel = account.quota?.models.find(m =>
+        categorizeModel(m.name) === 'gemini-flash-image' || categorizeModel(m.name) === 'gemini-pro-image'
+    );
+    const liveImageLimit = getLiveLimitForModel(account, geminiImageModel?.name, getModelProtectionKey(geminiImageModel?.name || '') ?? undefined);
     const liveImageState = getLiveLimitState(liveImageLimit);
     const isImageLiveLimited = liveImageState.shouldShow;
     const imageLimitTitle = liveImageLimit

--- a/src/components/accounts/AccountRow.tsx
+++ b/src/components/accounts/AccountRow.tsx
@@ -4,7 +4,7 @@ import { getQuotaColor, formatTimeRemaining, getTimeRemainingColor } from '../..
 import { cn } from '../../utils/cn';
 import { useTranslation } from 'react-i18next';
 import { formatCompactDuration, getLiveLimitForModel, getLiveLimitState } from '../../utils/liveLimit';
-import { categorizeModel, getModelProtectionKey } from '../../config/modelConfig';
+import { categorizeModel, getModelProtectionKey, findQuotaModel } from '../../config/modelConfig';
 
 interface AccountRowProps {
     account: Account;
@@ -26,12 +26,9 @@ interface AccountRowProps {
 
 function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSwitching = false, onSwitch, onRefresh, onViewDetails, onExport, onDelete, onToggleProxy, onViewDevice }: AccountRowProps) {
     const { t } = useTranslation();
-    // [重构] 按组聚合查找逻辑，优先显示组内配额最低的型号以与锁定状态（🔒）对齐
-    const geminiProModel = account.quota?.models
-        .filter(m => categorizeModel(m.name) === 'gemini-pro')
-        .sort((a, b) => (a.percentage || 0) - (b.percentage || 0))[0];
-
-    const geminiFlashModel = account.quota?.models.find(m => categorizeModel(m.name) === 'gemini-flash');
+    // [重构] 按优先级查找配额模型
+    const geminiProModel = findQuotaModel(account.quota?.models, 'gemini-pro');
+    const geminiFlashModel = findQuotaModel(account.quota?.models, 'gemini-flash');
 
     const geminiImageModel = account.quota?.models.find(m =>
         categorizeModel(m.name) === 'gemini-flash-image' || categorizeModel(m.name) === 'gemini-pro-image'
@@ -50,13 +47,7 @@ function AccountRow({ account, selected, onSelect, isCurrent, isRefreshing, isSw
         ].filter(Boolean).join(' ')
         : 'Gemini 3.1 Flash Image';
 
-    const claudeGroupNames = [
-        'claude-opus-4-6-thinking',
-        'claude'
-    ];
-    const claudeModel = account.quota?.models
-        .filter(m => claudeGroupNames.includes(m.name.toLowerCase()))
-        .sort((a, b) => (a.percentage || 0) - (b.percentage || 0))[0];
+    const claudeModel = findQuotaModel(account.quota?.models, 'claude');
     const isDisabled = Boolean(account.disabled);
 
     // 颜色映射，避免动态类名被 Tailwind purge

--- a/src/components/accounts/AccountTable.tsx
+++ b/src/components/accounts/AccountTable.tsx
@@ -52,7 +52,7 @@ import { cn } from '../../utils/cn';
 
 import { useConfigStore } from '../../stores/useConfigStore';
 import { QuotaItem } from './QuotaItem';
-import { MODEL_CONFIG, sortModels } from '../../config/modelConfig';
+import { MODEL_CONFIG, sortModels, resolveQuotaModels, ensurePinnedImageSelector } from '../../config/modelConfig';
 import { categorizeModel, getModelProtectionKey } from '../../utils/modelCategory';
 import { getValidationBlockedStatusLabel } from './accountValidationStatus';
 import { getLiveLimitForModel } from '../../utils/liveLimit';
@@ -126,28 +126,6 @@ interface AccountRowContentProps {
 // ============================================================================
 
 
-
-// ============================================================================
-const MODEL_ID_ALIASES: Record<string, string[]> = {
-    'gemini-3-pro-high': ['gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3-pro-preview', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3.1-pro-preview', 'gemini-3.1-pro', 'gemini-pro-agent'],
-    'gemini-3-pro-low': ['gemini-3-pro-low', 'gemini-3-pro-high', 'gemini-3-pro-preview', 'gemini-3.1-pro-low', 'gemini-3.1-pro-high', 'gemini-3.1-pro-preview', 'gemini-3.1-pro', 'gemini-pro-agent'],
-    'gemini-3-pro-preview': ['gemini-3-pro-preview', 'gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3.1-pro-preview', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3.1-pro', 'gemini-pro-agent'],
-    'gemini-3.1-pro-high': ['gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3.1-pro-preview', 'gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3-pro-preview', 'gemini-3.1-pro', 'gemini-pro-agent'],
-    'gemini-3.1-pro-low': ['gemini-3.1-pro-low', 'gemini-3.1-pro-high', 'gemini-3.1-pro-preview', 'gemini-3-pro-low', 'gemini-3-pro-high', 'gemini-3-pro-preview', 'gemini-3.1-pro', 'gemini-pro-agent'],
-    'gemini-3.1-pro-preview': ['gemini-3.1-pro-preview', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3-pro-preview', 'gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3.1-pro', 'gemini-pro-agent'],
-    'gemini-3.1-pro': ['gemini-3.1-pro', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3.1-pro-preview', 'gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3-pro-preview', 'gemini-pro-agent'],
-    'gemini-pro-agent': ['gemini-pro-agent', 'gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3-pro-preview', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3.1-pro-preview', 'gemini-3.1-pro'],
-    'gemini-3-flash': ['gemini-3-flash', 'gemini-3.5-flash', 'gemini-3-flash-agent'],
-    'gemini-3.5-flash': ['gemini-3.5-flash', 'gemini-3-flash', 'gemini-3-flash-agent'],
-    'gemini-3-flash-agent': ['gemini-3-flash-agent', 'gemini-3-flash', 'gemini-3.5-flash'],
-    'claude-sonnet-4-5': ['claude-sonnet-4-5', 'claude-sonnet-4-6', 'claude-opus-4-6-thinking'],
-    'claude-sonnet-4-6': ['claude-sonnet-4-6', 'claude-sonnet-4-5', 'claude-opus-4-6-thinking'],
-    'claude-opus-4-6-thinking': ['claude-opus-4-6-thinking', 'claude-sonnet-4-5', 'claude-sonnet-4-6'],
-};
-
-function getModelAliases(modelId: string): string[] {
-    return MODEL_ID_ALIASES[modelId] || [modelId];
-}
 
 function isModelProtected(protectedModels: string[] | undefined, modelName: string): boolean {
     if (!protectedModels || protectedModels.length === 0) return false;
@@ -322,7 +300,9 @@ function AccountRowContent({
     // 使用统一的模型配置
 
     // 获取要显示的模型列表
-    const pinnedModels = config?.pinned_quota_models?.models || Object.keys(MODEL_CONFIG);
+    const pinnedModels = ensurePinnedImageSelector(
+        config?.pinned_quota_models?.models || Object.keys(MODEL_CONFIG),
+    );
 
     // 根据 show_all 状态决定显示哪些模型
     const uniqueLabels = new Set<string>();
@@ -338,27 +318,23 @@ function AccountRowContent({
                     data: m
                 };
             })
-            : (() => {
-                const consumedModelNames = new Set<string>();
-                return pinnedModels.map(modelId => {
-                const m = account.quota?.models.find(m => (m.name === modelId || getModelAliases(modelId).includes(m.name.toLowerCase())) && !consumedModelNames.has(m.name.toLowerCase()));
-                if (m) consumedModelNames.add(m.name.toLowerCase());
-                const config = MODEL_CONFIG[modelId];
-                if (!config && !m) return null; // Safe guard for unknown models that aren't fetched
-                const label = m?.display_name || (config?.i18nKey ? t(config.i18nKey) : (config?.shortLabel || config?.label || modelId));
+            : resolveQuotaModels(account.quota?.models, pinnedModels).map(sel => {
+                const selectorConfig = MODEL_CONFIG[sel.selectorId.toLowerCase()];
+                const resolvedConfig = sel.model ? MODEL_CONFIG[sel.model.name.toLowerCase()] : undefined;
+                if (!selectorConfig && !sel.model) return null;
+                const label = sel.model?.display_name
+                    || (resolvedConfig?.shortLabel || resolvedConfig?.label)
+                    || (selectorConfig?.shortLabel || selectorConfig?.label)
+                    || (resolvedConfig?.i18nKey ? t(resolvedConfig.i18nKey) : undefined)
+                    || (selectorConfig?.i18nKey ? t(selectorConfig.i18nKey) : undefined)
+                    || sel.selectorId;
                 return {
-                    id: modelId,
-                    label: label,
-                    protectedKey: config?.protectedKey || modelId,
-                    data: m
+                    id: sel.model?.name.toLowerCase() ?? sel.selectorId.toLowerCase(),
+                    label,
+                    protectedKey: getModelProtectionKey(sel.model?.name ?? sel.selectorId) ?? resolvedConfig?.protectedKey ?? selectorConfig?.protectedKey ?? sel.selectorId,
+                    data: sel.model,
                 };
-            }).filter((item): item is {
-                id: string;
-                label: string;
-                protectedKey: string;
-                data: ModelQuota | undefined;
-            } => item !== null)   // closes .map().filter()
-        })()                     // closes (() => { ... })()
+            }).filter((item): item is { id: string; label: string; protectedKey: string; data: ModelQuota | undefined } => item !== null)
     ).filter(m => {
             // 过滤特定的 Claude/Gemini 思考变体 (在列表页隐藏)
             const isHiddenThinking = m.id.includes('thinking');

--- a/src/components/accounts/AccountTable.tsx
+++ b/src/components/accounts/AccountTable.tsx
@@ -129,14 +129,20 @@ interface AccountRowContentProps {
 
 // ============================================================================
 const MODEL_ID_ALIASES: Record<string, string[]> = {
-    'gemini-3-pro-high': ['gemini-3-pro-high', 'gemini-3.1-pro-high'],
-    'gemini-3-pro-low': ['gemini-3-pro-low', 'gemini-3.1-pro-low'],
-    'gemini-3-pro-preview': ['gemini-3-pro-preview', 'gemini-3.1-pro-preview'],
-    'gemini-3.1-pro-high': ['gemini-3.1-pro-high', 'gemini-3-pro-high'],
-    'gemini-3.1-pro-low': ['gemini-3.1-pro-low', 'gemini-3-pro-low'],
-    'gemini-3.1-pro-preview': ['gemini-3.1-pro-preview', 'gemini-3-pro-preview'],
-    'gemini-3.1-pro': ['gemini-3.1-pro', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3-pro-high', 'gemini-3-pro-low'],
-    'gemini-3.5-flash': ['gemini-3.5-flash', 'gemini-3-flash'],
+    'gemini-3-pro-high': ['gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3-pro-preview', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3.1-pro-preview', 'gemini-3.1-pro', 'gemini-pro-agent'],
+    'gemini-3-pro-low': ['gemini-3-pro-low', 'gemini-3-pro-high', 'gemini-3-pro-preview', 'gemini-3.1-pro-low', 'gemini-3.1-pro-high', 'gemini-3.1-pro-preview', 'gemini-3.1-pro', 'gemini-pro-agent'],
+    'gemini-3-pro-preview': ['gemini-3-pro-preview', 'gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3.1-pro-preview', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3.1-pro', 'gemini-pro-agent'],
+    'gemini-3.1-pro-high': ['gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3.1-pro-preview', 'gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3-pro-preview', 'gemini-3.1-pro', 'gemini-pro-agent'],
+    'gemini-3.1-pro-low': ['gemini-3.1-pro-low', 'gemini-3.1-pro-high', 'gemini-3.1-pro-preview', 'gemini-3-pro-low', 'gemini-3-pro-high', 'gemini-3-pro-preview', 'gemini-3.1-pro', 'gemini-pro-agent'],
+    'gemini-3.1-pro-preview': ['gemini-3.1-pro-preview', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3-pro-preview', 'gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3.1-pro', 'gemini-pro-agent'],
+    'gemini-3.1-pro': ['gemini-3.1-pro', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3.1-pro-preview', 'gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3-pro-preview', 'gemini-pro-agent'],
+    'gemini-pro-agent': ['gemini-pro-agent', 'gemini-3-pro-high', 'gemini-3-pro-low', 'gemini-3-pro-preview', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3.1-pro-preview', 'gemini-3.1-pro'],
+    'gemini-3-flash': ['gemini-3-flash', 'gemini-3.5-flash', 'gemini-3-flash-agent'],
+    'gemini-3.5-flash': ['gemini-3.5-flash', 'gemini-3-flash', 'gemini-3-flash-agent'],
+    'gemini-3-flash-agent': ['gemini-3-flash-agent', 'gemini-3-flash', 'gemini-3.5-flash'],
+    'claude-sonnet-4-5': ['claude-sonnet-4-5', 'claude-sonnet-4-6', 'claude-opus-4-6-thinking'],
+    'claude-sonnet-4-6': ['claude-sonnet-4-6', 'claude-sonnet-4-5', 'claude-opus-4-6-thinking'],
+    'claude-opus-4-6-thinking': ['claude-opus-4-6-thinking', 'claude-sonnet-4-5', 'claude-sonnet-4-6'],
 };
 
 function getModelAliases(modelId: string): string[] {
@@ -332,8 +338,11 @@ function AccountRowContent({
                     data: m
                 };
             })
-            : pinnedModels.map(modelId => {
-                const m = account.quota?.models.find(m => m.name === modelId || getModelAliases(modelId).includes(m.name.toLowerCase()));
+            : (() => {
+                const consumedModelNames = new Set<string>();
+                return pinnedModels.map(modelId => {
+                const m = account.quota?.models.find(m => (m.name === modelId || getModelAliases(modelId).includes(m.name.toLowerCase())) && !consumedModelNames.has(m.name.toLowerCase()));
+                if (m) consumedModelNames.add(m.name.toLowerCase());
                 const config = MODEL_CONFIG[modelId];
                 if (!config && !m) return null; // Safe guard for unknown models that aren't fetched
                 const label = m?.display_name || (config?.i18nKey ? t(config.i18nKey) : (config?.shortLabel || config?.label || modelId));
@@ -348,8 +357,9 @@ function AccountRowContent({
                 label: string;
                 protectedKey: string;
                 data: ModelQuota | undefined;
-            } => item !== null)
-        ).filter(m => {
+            } => item !== null)   // closes .map().filter()
+        })()                     // closes (() => { ... })()
+    ).filter(m => {
             // 过滤特定的 Claude/Gemini 思考变体 (在列表页隐藏)
             const isHiddenThinking = m.id.includes('thinking');
 

--- a/src/components/accounts/AccountTable.tsx
+++ b/src/components/accounts/AccountTable.tsx
@@ -46,13 +46,14 @@ import {
     Repeat2,
     Terminal,
 } from 'lucide-react';
-import { Account } from '../../types/account';
+import type { Account, ModelQuota } from '../../types/account';
 import { useTranslation } from 'react-i18next';
 import { cn } from '../../utils/cn';
 
 import { useConfigStore } from '../../stores/useConfigStore';
 import { QuotaItem } from './QuotaItem';
 import { MODEL_CONFIG, sortModels } from '../../config/modelConfig';
+import { categorizeModel, getModelProtectionKey } from '../../utils/modelCategory';
 import { getValidationBlockedStatusLabel } from './accountValidationStatus';
 import { getLiveLimitForModel } from '../../utils/liveLimit';
 
@@ -127,27 +128,6 @@ interface AccountRowContentProps {
 
 
 // ============================================================================
-// 模型分组配置
-// ============================================================================
-
-const MODEL_GROUPS = {
-    CLAUDE: [
-        'claude-opus-4-6-thinking',
-        'claude'
-    ],
-    GEMINI_PRO: [
-        'gemini-3.1-pro-high',
-        'gemini-3.1-pro-low',
-        'gemini-3.1-pro-preview',
-        'gemini-3-pro-high',
-        'gemini-3-pro-low',
-        'gemini-3-pro-preview'
-    ],
-    GEMINI_FLASH: [
-        'gemini-3-flash'
-    ]
-};
-
 const MODEL_ID_ALIASES: Record<string, string[]> = {
     'gemini-3-pro-high': ['gemini-3-pro-high', 'gemini-3.1-pro-high'],
     'gemini-3-pro-low': ['gemini-3-pro-low', 'gemini-3.1-pro-low'],
@@ -155,6 +135,8 @@ const MODEL_ID_ALIASES: Record<string, string[]> = {
     'gemini-3.1-pro-high': ['gemini-3.1-pro-high', 'gemini-3-pro-high'],
     'gemini-3.1-pro-low': ['gemini-3.1-pro-low', 'gemini-3-pro-low'],
     'gemini-3.1-pro-preview': ['gemini-3.1-pro-preview', 'gemini-3-pro-preview'],
+    'gemini-3.1-pro': ['gemini-3.1-pro', 'gemini-3.1-pro-high', 'gemini-3.1-pro-low', 'gemini-3-pro-high', 'gemini-3-pro-low'],
+    'gemini-3.5-flash': ['gemini-3.5-flash', 'gemini-3-flash'],
 };
 
 function getModelAliases(modelId: string): string[] {
@@ -165,33 +147,24 @@ function isModelProtected(protectedModels: string[] | undefined, modelName: stri
     if (!protectedModels || protectedModels.length === 0) return false;
     const lowerName = modelName.toLowerCase();
 
-    // Helper to check if any model in the group is protected
-    const isGroupProtected = (group: string[]) => {
-        return group.some(m => protectedModels.includes(m));
-    };
-
-    // UI Column Keys Mapping (for backward compatibility with hardcoded UI calls)
-    if (lowerName === 'gemini-pro') return isGroupProtected(MODEL_GROUPS.GEMINI_PRO);
-    if (lowerName === 'gemini-flash') return isGroupProtected(MODEL_GROUPS.GEMINI_FLASH);
-    if (lowerName === 'claude-sonnet') return isGroupProtected(MODEL_GROUPS.CLAUDE);
-
-    // 1. Gemini Pro Group
-    if (MODEL_GROUPS.GEMINI_PRO.some(m => lowerName === m)) {
-        return isGroupProtected(MODEL_GROUPS.GEMINI_PRO);
+    if (lowerName === 'gemini-pro') {
+        return protectedModels.some((model) =>
+            categorizeModel(model) === 'gemini-pro' && getModelProtectionKey(model) === 'gemini-3-pro-high',
+        );
+    }
+    if (lowerName === 'gemini-flash') {
+        return protectedModels.some((model) =>
+            categorizeModel(model) === 'gemini-flash' && getModelProtectionKey(model) === 'gemini-3-flash',
+        );
+    }
+    if (lowerName === 'claude-sonnet') {
+        return protectedModels.some((model) =>
+            categorizeModel(model) === 'claude' && getModelProtectionKey(model) === 'claude',
+        );
     }
 
-    // 2. Claude Group
-    if (MODEL_GROUPS.CLAUDE.some(m => lowerName === m)) {
-        return isGroupProtected(MODEL_GROUPS.CLAUDE);
-    }
-
-    // 3. Gemini Flash Group
-    if (MODEL_GROUPS.GEMINI_FLASH.some(m => lowerName === m)) {
-        return isGroupProtected(MODEL_GROUPS.GEMINI_FLASH);
-    }
-
-    // 兜底直接检查 (Strict check for exact match or normalized ID)
-    return protectedModels.includes(lowerName);
+    const protectionKey = getModelProtectionKey(lowerName);
+    return protectionKey ? protectedModels.includes(protectionKey) : false;
 }
 
 // ============================================================================
@@ -370,7 +343,12 @@ function AccountRowContent({
                     protectedKey: config?.protectedKey || modelId,
                     data: m
                 };
-            }).filter(Boolean) as any[]
+            }).filter((item): item is {
+                id: string;
+                label: string;
+                protectedKey: string;
+                data: ModelQuota | undefined;
+            } => item !== null)
         ).filter(m => {
             // 过滤特定的 Claude/Gemini 思考变体 (在列表页隐藏)
             const isHiddenThinking = m.id.includes('thinking');

--- a/src/components/dashboard/BestAccounts.tsx
+++ b/src/components/dashboard/BestAccounts.tsx
@@ -31,7 +31,7 @@ function BestAccounts({ accounts, currentAccountId, onSwitch }: BestAccountsProp
         .filter(a => a.id !== currentAccountId)
         .map(a => ({
             ...a,
-            quotaVal: a.quota?.models.find(m => m.name.toLowerCase().includes('claude'))?.percentage || 0,
+            quotaVal: findQuotaModel(a.quota?.models, 'claude')?.percentage || 0,
         }))
         .filter(a => a.quotaVal > 0)
         .sort((a, b) => b.quotaVal - a.quotaVal);

--- a/src/components/dashboard/BestAccounts.tsx
+++ b/src/components/dashboard/BestAccounts.tsx
@@ -1,6 +1,6 @@
 import { TrendingUp } from 'lucide-react';
 import { Account } from '../../types/account';
-import { categorizeModel } from '../../config/modelConfig';
+import { findQuotaModel } from '../../config/modelConfig';
 
 interface BestAccountsProps {
     accounts: Account[];
@@ -16,10 +16,8 @@ function BestAccounts({ accounts, currentAccountId, onSwitch }: BestAccountsProp
     const geminiSorted = accounts
         .filter(a => a.id !== currentAccountId)
         .map(a => {
-            const proQuota = (a.quota?.models || [])
-                .filter(m => categorizeModel(m.name) === 'gemini-pro')
-                .reduce((best, model) => Math.max(best, model.percentage || 0), 0);
-            const flashQuota = a.quota?.models.find(m => categorizeModel(m.name) === 'gemini-flash')?.percentage || 0;
+            const proQuota = findQuotaModel(a.quota?.models, 'gemini-pro')?.percentage || 0;
+            const flashQuota = findQuotaModel(a.quota?.models, 'gemini-flash')?.percentage || 0;
             // 综合评分：Pro 权重更高 (70%)，Flash 权重 30%
             return {
                 ...a,

--- a/src/components/dashboard/BestAccounts.tsx
+++ b/src/components/dashboard/BestAccounts.tsx
@@ -1,5 +1,6 @@
 import { TrendingUp } from 'lucide-react';
 import { Account } from '../../types/account';
+import { categorizeModel } from '../../config/modelConfig';
 
 interface BestAccountsProps {
     accounts: Account[];
@@ -16,14 +17,9 @@ function BestAccounts({ accounts, currentAccountId, onSwitch }: BestAccountsProp
         .filter(a => a.id !== currentAccountId)
         .map(a => {
             const proQuota = (a.quota?.models || [])
-                .filter(m =>
-                    m.name.toLowerCase() === 'gemini-3-pro-high'
-                    || m.name.toLowerCase() === 'gemini-3-pro-low'
-                    || m.name.toLowerCase() === 'gemini-3.1-pro-high'
-                    || m.name.toLowerCase() === 'gemini-3.1-pro-low'
-                )
+                .filter(m => categorizeModel(m.name) === 'gemini-pro')
                 .reduce((best, model) => Math.max(best, model.percentage || 0), 0);
-            const flashQuota = a.quota?.models.find(m => m.name.toLowerCase() === 'gemini-3-flash')?.percentage || 0;
+            const flashQuota = a.quota?.models.find(m => categorizeModel(m.name) === 'gemini-flash')?.percentage || 0;
             // 综合评分：Pro 权重更高 (70%)，Flash 权重 30%
             return {
                 ...a,

--- a/src/components/dashboard/CurrentAccount.tsx
+++ b/src/components/dashboard/CurrentAccount.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle, Mail, Diamond, Gem, Circle, Tag, Lock, Clock } from 'lucide-react';
 import { Account } from '../../types/account';
 import { formatTimeRemaining } from '../../utils/format';
-import { categorizeModel, getModelProtectionKey, getModelDisplayName, findQuotaModel } from '../../config/modelConfig';
+import { findQuotaModel, getModelProtectionKey, getModelDisplayName, findImageQuotaModel } from '../../config/modelConfig';
 
 interface CurrentAccountProps {
     account: Account | null;
@@ -29,10 +29,7 @@ function CurrentAccount({ account, onSwitch }: CurrentAccountProps) {
     const geminiProModel = findQuotaModel(account.quota?.models, 'gemini-pro');
     const geminiFlashModel = findQuotaModel(account.quota?.models, 'gemini-flash');
 
-    const geminiImageModel = account.quota?.models.find(m => {
-        const cat = categorizeModel(m.name);
-        return cat === 'gemini-flash-image' || cat === 'gemini-pro-image';
-    });
+    const geminiImageModel = findImageQuotaModel(account.quota?.models);
     const nowSeconds = Math.floor(Date.now() / 1000);
     const imageProtectionKey = getModelProtectionKey(geminiImageModel?.name || '');
     const liveImageLimit = imageProtectionKey
@@ -126,7 +123,7 @@ function CurrentAccount({ account, onSwitch }: CurrentAccountProps) {
                         <div className="flex justify-between items-baseline">
                             <span className="text-xs font-medium text-gray-600 dark:text-gray-400 flex items-center gap-1">
                                 {isImageLiveLimited && <Clock className="w-2.5 h-2.5 text-amber-500" />}
-                                {(account.protected_models?.includes('gemini-3.1-flash-image') || account.protected_models?.includes('gemini-3-pro-image')) && <Lock className="w-2.5 h-2.5 text-rose-500" />}
+                                {(imageProtectionKey && account.protected_models?.includes(imageProtectionKey)) && <Lock className="w-2.5 h-2.5 text-rose-500" />}
                                 {getModelDisplayName(geminiImageModel)}
                             </span>
                             <div className="flex items-center gap-2">

--- a/src/components/dashboard/CurrentAccount.tsx
+++ b/src/components/dashboard/CurrentAccount.tsx
@@ -1,6 +1,7 @@
 import { CheckCircle, Mail, Diamond, Gem, Circle, Tag, Lock, Clock } from 'lucide-react';
 import { Account } from '../../types/account';
 import { formatTimeRemaining } from '../../utils/format';
+import { categorizeModel, getModelProtectionKey, getModelDisplayName } from '../../config/modelConfig';
 
 interface CurrentAccountProps {
     account: Account | null;
@@ -26,24 +27,20 @@ function CurrentAccount({ account, onSwitch }: CurrentAccountProps) {
     }
 
     const geminiProModel = account.quota?.models
-        .filter(m =>
-            m.name.toLowerCase() === 'gemini-3-pro-high'
-            || m.name.toLowerCase() === 'gemini-3-pro-low'
-            || m.name.toLowerCase() === 'gemini-3.1-pro-high'
-            || m.name.toLowerCase() === 'gemini-3.1-pro-low'
-        )
+        .filter(m => categorizeModel(m.name) === 'gemini-pro')
         .sort((a, b) => (a.percentage || 0) - (b.percentage || 0))[0];
 
-    const geminiFlashModel = account.quota?.models.find(m => m.name.toLowerCase() === 'gemini-3-flash');
+    const geminiFlashModel = account.quota?.models.find(m => categorizeModel(m.name) === 'gemini-flash');
 
     const geminiImageModel = account.quota?.models.find(m => {
-        const name = m.name.toLowerCase();
-        return name === 'gemini-3.1-flash-image' || name === 'gemini-3-pro-image';
+        const cat = categorizeModel(m.name);
+        return cat === 'gemini-flash-image' || cat === 'gemini-pro-image';
     });
     const nowSeconds = Math.floor(Date.now() / 1000);
-    const liveImageLimit =
-        account.live_limited_models?.['gemini-3.1-flash-image'] ||
-        account.live_limited_models?.['gemini-3-pro-image'];
+    const imageProtectionKey = getModelProtectionKey(geminiImageModel?.name || '');
+    const liveImageLimit = imageProtectionKey
+        ? account.live_limited_models?.[imageProtectionKey]
+        : undefined;
     const isImageLiveLimited = Boolean(liveImageLimit && liveImageLimit.until > nowSeconds);
 
     const claudeGroupNames = [
@@ -108,7 +105,7 @@ function CurrentAccount({ account, onSwitch }: CurrentAccountProps) {
                         <div className="flex justify-between items-baseline">
                             <span className="text-xs font-medium text-gray-600 dark:text-gray-400 flex items-center gap-1">
                                 {(account.protected_models?.includes('gemini-3-pro-high') || account.protected_models?.includes('gemini-3.1-pro-high')) && <Lock className="w-2.5 h-2.5 text-rose-500" />}
-                                Gemini 3.1 Pro
+                                {getModelDisplayName(geminiProModel)}
                             </span>
                             <div className="flex items-center gap-2">
                                 <span className="text-[10px] text-gray-400 dark:text-gray-500" title={`${t('accounts.reset_time')}: ${new Date(geminiProModel.reset_time).toLocaleString()}`}>
@@ -139,7 +136,7 @@ function CurrentAccount({ account, onSwitch }: CurrentAccountProps) {
                             <span className="text-xs font-medium text-gray-600 dark:text-gray-400 flex items-center gap-1">
                                 {isImageLiveLimited && <Clock className="w-2.5 h-2.5 text-amber-500" />}
                                 {(account.protected_models?.includes('gemini-3.1-flash-image') || account.protected_models?.includes('gemini-3-pro-image')) && <Lock className="w-2.5 h-2.5 text-rose-500" />}
-                                Gemini 3.1 Flash Image
+                                {getModelDisplayName(geminiImageModel)}
                             </span>
                             <div className="flex items-center gap-2">
                                 <span className="text-[10px] text-gray-400 dark:text-gray-500" title={`${t('accounts.reset_time')}: ${new Date(geminiImageModel.reset_time).toLocaleString()}`}>
@@ -170,7 +167,7 @@ function CurrentAccount({ account, onSwitch }: CurrentAccountProps) {
                         <div className="flex justify-between items-baseline">
                             <span className="text-xs font-medium text-gray-600 dark:text-gray-400 flex items-center gap-1">
                                 {account.protected_models?.includes('gemini-3-flash') && <Lock className="w-2.5 h-2.5 text-rose-500" />}
-                                Gemini 3 Flash
+                                {getModelDisplayName(geminiFlashModel)}
                             </span>
                             <div className="flex items-center gap-2">
                                 <span className="text-[10px] text-gray-400 dark:text-gray-500" title={`${t('accounts.reset_time')}: ${new Date(geminiFlashModel.reset_time).toLocaleString()}`}>
@@ -201,7 +198,7 @@ function CurrentAccount({ account, onSwitch }: CurrentAccountProps) {
                         <div className="flex justify-between items-baseline">
                             <span className="text-xs font-medium text-gray-600 dark:text-gray-400 flex items-center gap-1">
                                 {account.protected_models?.includes('claude') && <Lock className="w-2.5 h-2.5 text-rose-500" />}
-                                Claude 系列
+                                {getModelDisplayName(claudeModel, t('common.claude_series', 'Claude 系列'))}
                             </span>
                             <div className="flex items-center gap-2">
                                 <span className="text-[10px] text-gray-400 dark:text-gray-500" title={`${t('accounts.reset_time')}: ${new Date(claudeModel.reset_time).toLocaleString()}`}>

--- a/src/components/dashboard/CurrentAccount.tsx
+++ b/src/components/dashboard/CurrentAccount.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle, Mail, Diamond, Gem, Circle, Tag, Lock, Clock } from 'lucide-react';
 import { Account } from '../../types/account';
 import { formatTimeRemaining } from '../../utils/format';
-import { categorizeModel, getModelProtectionKey, getModelDisplayName } from '../../config/modelConfig';
+import { categorizeModel, getModelProtectionKey, getModelDisplayName, findQuotaModel } from '../../config/modelConfig';
 
 interface CurrentAccountProps {
     account: Account | null;
@@ -26,11 +26,8 @@ function CurrentAccount({ account, onSwitch }: CurrentAccountProps) {
         );
     }
 
-    const geminiProModel = account.quota?.models
-        .filter(m => categorizeModel(m.name) === 'gemini-pro')
-        .sort((a, b) => (a.percentage || 0) - (b.percentage || 0))[0];
-
-    const geminiFlashModel = account.quota?.models.find(m => categorizeModel(m.name) === 'gemini-flash');
+    const geminiProModel = findQuotaModel(account.quota?.models, 'gemini-pro');
+    const geminiFlashModel = findQuotaModel(account.quota?.models, 'gemini-flash');
 
     const geminiImageModel = account.quota?.models.find(m => {
         const cat = categorizeModel(m.name);
@@ -43,13 +40,7 @@ function CurrentAccount({ account, onSwitch }: CurrentAccountProps) {
         : undefined;
     const isImageLiveLimited = Boolean(liveImageLimit && liveImageLimit.until > nowSeconds);
 
-    const claudeGroupNames = [
-        'claude-opus-4-6-thinking',
-        'claude'
-    ];
-    const claudeModel = account.quota?.models
-        .filter(m => claudeGroupNames.includes(m.name.toLowerCase()))
-        .sort((a, b) => (a.percentage || 0) - (b.percentage || 0))[0];
+    const claudeModel = findQuotaModel(account.quota?.models, 'claude');
 
     return (
         <div className="bg-white dark:bg-base-100 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-base-200 h-full flex flex-col">

--- a/src/components/layout/MiniView.tsx
+++ b/src/components/layout/MiniView.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { formatTimeRemaining, formatCompactNumber } from '../../utils/format';
 import { enterMiniMode, exitMiniMode } from '../../utils/windowManager';
+import { categorizeModel, getModelDisplayName } from '../../config/modelConfig';
 import { getVersion } from '@tauri-apps/api/app';
 import { listen } from '@tauri-apps/api/event';
 
@@ -136,15 +137,10 @@ export default function MiniView() {
 
     // Extract specific models to match AccountRow.tsx
     const geminiProModel = currentAccount?.quota?.models
-        .filter(m =>
-            m.name.toLowerCase() === 'gemini-3-pro-high'
-            || m.name.toLowerCase() === 'gemini-3-pro-low'
-            || m.name.toLowerCase() === 'gemini-3.1-pro-high'
-            || m.name.toLowerCase() === 'gemini-3.1-pro-low'
-        )
+        .filter(m => categorizeModel(m.name) === 'gemini-pro')
         .sort((a, b) => (a.percentage || 0) - (b.percentage || 0))[0];
 
-    const geminiFlashModel = currentAccount?.quota?.models.find(m => m.name.toLowerCase() === 'gemini-3-flash');
+    const geminiFlashModel = currentAccount?.quota?.models.find(m => categorizeModel(m.name) === 'gemini-flash');
 
     const claudeGroupNames = [
         'claude-opus-4-6-thinking',
@@ -276,9 +272,9 @@ export default function MiniView() {
                             {/* Models List */}
                             <AnimatePresence mode='popLayout'>
                                 <div className="space-y-4 !mt-0">
-                                    {renderModelRow(geminiProModel, 'Gemini 3.1 Pro', 'emerald')}
-                                    {renderModelRow(geminiFlashModel, 'Gemini 3 Flash', 'emerald')}
-                                    {renderModelRow(claudeModel, t('common.claude_series', 'Claude 系列'), 'cyan')}
+                                    {renderModelRow(geminiProModel, getModelDisplayName(geminiProModel), 'emerald')}
+                                    {renderModelRow(geminiFlashModel, getModelDisplayName(geminiFlashModel), 'emerald')}
+                                    {renderModelRow(claudeModel, getModelDisplayName(claudeModel, t('common.claude_series', 'Claude 系列')), 'cyan')}
 
                                     {!geminiProModel && !geminiFlashModel && !claudeModel && (
                                         <div className="text-center py-4 text-xs text-gray-400">

--- a/src/components/layout/MiniView.tsx
+++ b/src/components/layout/MiniView.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { formatTimeRemaining, formatCompactNumber } from '../../utils/format';
 import { enterMiniMode, exitMiniMode } from '../../utils/windowManager';
-import { categorizeModel, getModelDisplayName } from '../../config/modelConfig';
+import { getModelDisplayName, findQuotaModel } from '../../config/modelConfig';
 import { getVersion } from '@tauri-apps/api/app';
 import { listen } from '@tauri-apps/api/event';
 
@@ -136,19 +136,10 @@ export default function MiniView() {
 
 
     // Extract specific models to match AccountRow.tsx
-    const geminiProModel = currentAccount?.quota?.models
-        .filter(m => categorizeModel(m.name) === 'gemini-pro')
-        .sort((a, b) => (a.percentage || 0) - (b.percentage || 0))[0];
+    const geminiProModel = findQuotaModel(currentAccount?.quota?.models, 'gemini-pro');
+    const geminiFlashModel = findQuotaModel(currentAccount?.quota?.models, 'gemini-flash');
 
-    const geminiFlashModel = currentAccount?.quota?.models.find(m => categorizeModel(m.name) === 'gemini-flash');
-
-    const claudeGroupNames = [
-        'claude-opus-4-6-thinking',
-        'claude'
-    ];
-    const claudeModel = currentAccount?.quota?.models
-        .filter(m => claudeGroupNames.includes(m.name.toLowerCase()))
-        .sort((a, b) => (a.percentage || 0) - (b.percentage || 0))[0];
+    const claudeModel = findQuotaModel(currentAccount?.quota?.models, 'claude');
 
     // Helper to render a model row
     const renderModelRow = (model: any, displayName: string, colorClass: string) => {

--- a/src/components/proxy/CliSyncCard.tsx
+++ b/src/components/proxy/CliSyncCard.tsx
@@ -537,6 +537,7 @@ export const CliSyncCard = ({ proxyUrl, apiKey, className }: CliSyncCardProps) =
                     proxyUrl={proxyUrl}
                     apiKey={apiKey}
                     getFormattedProxyUrl={getFormattedProxyUrl}
+                    syncAccounts={syncAccounts}
                     onClose={() => setOpenCodeSyncModal(false)}
                     onSyncDone={() => checkStatus('OpenCode')}
                 />

--- a/src/components/proxy/OpenCodeSyncModal.tsx
+++ b/src/components/proxy/OpenCodeSyncModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RefreshCw, X, CodeXml } from 'lucide-react';
 import {
@@ -18,17 +18,17 @@ interface OpenCodeSyncModalProps {
     proxyUrl: string;
     apiKey: string;
     getFormattedProxyUrl: (app: 'Claude' | 'Codex' | 'Gemini' | 'OpenCode' | 'Droid') => string;
+    syncAccounts: boolean;
     onClose: () => void;
     onSyncDone: () => void;
 }
 
-export function OpenCodeSyncModal({ proxyUrl, apiKey, onClose, onSyncDone }: OpenCodeSyncModalProps) {
+export function OpenCodeSyncModal({ proxyUrl, apiKey, getFormattedProxyUrl, syncAccounts, onClose, onSyncDone }: OpenCodeSyncModalProps) {
     const { t } = useTranslation();
-    const { models: antigravityModels } = useProxyModels();
+    const { models: antigravityModels, canonicalFamilies } = useProxyModels();
     const [selectedModels, setSelectedModels] = useState<Set<string>>(new Set());
     const [previewModels, setPreviewModels] = useState<PreviewModelEntry[]>([]);
     const [syncing, setSyncing] = useState(false);
-    const [configLoaded, setConfigLoaded] = useState(false);
     const [hasAuthPlugin, setHasAuthPlugin] = useState(false);
     const [customBaseUrl, setCustomBaseUrl] = useState(proxyUrl);
 
@@ -54,26 +54,46 @@ export function OpenCodeSyncModal({ proxyUrl, apiKey, onClose, onSyncDone }: Ope
         setPreviewModels(newEntries);
     }, [antigravityModels, apiKey]);
 
-    // 初始加载 opencode.json
-    if (!configLoaded) {
-        setConfigLoaded(true);
+    // 初始加载 opencode 配置（json 或 jsonc，由后端探测决定实际文件）
+    useEffect(() => {
+        let cancelled = false;
         invoke<string>('get_opencode_config_content', { request: { fileName: 'opencode.json' } })
             .then(content => {
+                if (cancelled) return;
                 const parsed = JSON.parse(content);
                 const existingModelIds = new Set<string>();
 
+                const addModelId = (k: string) => {
+                    let canonicalId = k;
+                    if (canonicalFamilies && canonicalFamilies.length > 0) {
+                        for (const family of canonicalFamilies) {
+                            if (family.match_ids.includes(k.toLowerCase())) {
+                                canonicalId = family.canonical_id;
+                                break;
+                            }
+                        }
+                    }
+                    existingModelIds.add(canonicalId);
+                };
+
                 // Priority 1: Read from antigravity-manager provider
                 if (parsed.provider?.['antigravity-manager']?.models) {
-                    Object.keys(parsed.provider['antigravity-manager'].models).forEach(k => existingModelIds.add(k));
+                    for (const k of Object.keys(parsed.provider['antigravity-manager'].models)) {
+                        addModelId(k);
+                    }
                 }
 
                 // Fallback: legacy anthropic/google providers
                 if (existingModelIds.size === 0) {
                     if (parsed.provider?.anthropic?.models) {
-                        Object.keys(parsed.provider.anthropic.models).forEach(k => existingModelIds.add(k));
+                        for (const k of Object.keys(parsed.provider.anthropic.models)) {
+                            addModelId(k);
+                        }
                     }
                     if (parsed.provider?.google?.models) {
-                        Object.keys(parsed.provider.google.models).forEach(k => existingModelIds.add(k));
+                        for (const k of Object.keys(parsed.provider.google.models)) {
+                            addModelId(k);
+                        }
                     }
                 }
 
@@ -90,8 +110,11 @@ export function OpenCodeSyncModal({ proxyUrl, apiKey, onClose, onSyncDone }: Ope
                 setSelectedModels(existingModelIds);
                 rebuildPreview(existingModelIds);
             })
-            .catch(() => rebuildPreview(new Set()));
-    }
+            .catch(() => {
+                if (!cancelled) rebuildPreview(new Set());
+            });
+        return () => { cancelled = true; };
+    }, [rebuildPreview, canonicalFamilies]);
 
     const allSelected = antigravityModels.length > 0 && antigravityModels.every(m => selectedModels.has(m.id));
     const toggleAll = () => {
@@ -128,11 +151,18 @@ export function OpenCodeSyncModal({ proxyUrl, apiKey, onClose, onSyncDone }: Ope
     const executeOpenCodeSync = async () => {
         setSyncing(true);
         try {
-            const models = previewModels.map(m => m.model);
+            // Send both the model id and its display name so the backend can write a
+            // correct, recognizable `name` for models not in its catalog (instead of a
+            // machine-derived name that loses variant info like "(High)").
+            const models = previewModels.map(m => ({ id: m.model, name: m.displayName }));
+            // OpenCode follows the OpenAI protocol and requires a baseURL ending in /v1.
+            // If the user has overridden the BaseURL in the input box, honor it as-is;
+            // otherwise apply the canonical /v1 formatting via getFormattedProxyUrl.
+            const effectiveProxyUrl = customBaseUrl.trim() || getFormattedProxyUrl('OpenCode');
             await invoke('execute_opencode_sync', {
-                proxyUrl: customBaseUrl || proxyUrl,
+                proxyUrl: effectiveProxyUrl,
                 apiKey,
-                syncAccounts: true,
+                syncAccounts,
                 models
             });
             showToast(t('proxy.opencode_sync.toast.sync_success', { defaultValue: 'OpenCode 同步成功' }), 'success');
@@ -161,10 +191,10 @@ export function OpenCodeSyncModal({ proxyUrl, apiKey, onClose, onSyncDone }: Ope
                                 <h3 className="text-sm font-bold text-gray-900 dark:text-base-content">
                                     {t('proxy.config.opencode_sync.modal_title', { defaultValue: '选择 OpenCode 模型' })}
                                 </h3>
-                                <p className="text-[10px] text-gray-400 mt-0.5">~/.config/opencode/opencode.json</p>
+                                <p className="text-[10px] text-gray-400 mt-0.5">~/.config/opencode/opencode.json (or .jsonc)</p>
                             </div>
                         </div>
-                        <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-base-300 transition-colors">
+                        <button type="button" onClick={onClose} className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-base-300 transition-colors">
                             <X size={16} className="text-gray-400" />
                         </button>
                     </div>
@@ -174,7 +204,7 @@ export function OpenCodeSyncModal({ proxyUrl, apiKey, onClose, onSyncDone }: Ope
                 <div className="px-5 py-2 shrink-0 border-b border-gray-100 dark:border-base-200 bg-gray-50/50 dark:bg-base-200/30">
                     <div className="flex flex-col gap-1.5">
                         <div className="flex items-center justify-between">
-                            <label className="text-[10px] font-bold text-gray-400 uppercase tracking-wider">
+                            <label htmlFor="customBaseUrl" className="text-[10px] font-bold text-gray-400 uppercase tracking-wider">
                                 {t('proxy.config.opencode_sync.custom_base_url_label', { defaultValue: 'Custom Manager BaseURL' })}
                             </label>
                             <span className="text-[9px] text-gray-400 italic font-medium">
@@ -183,6 +213,7 @@ export function OpenCodeSyncModal({ proxyUrl, apiKey, onClose, onSyncDone }: Ope
                         </div>
                         <div className="relative group">
                             <input
+                                id="customBaseUrl"
                                 type="text"
                                 value={customBaseUrl}
                                 onChange={(e) => setCustomBaseUrl(e.target.value)}
@@ -191,6 +222,7 @@ export function OpenCodeSyncModal({ proxyUrl, apiKey, onClose, onSyncDone }: Ope
                             />
                             {customBaseUrl !== proxyUrl && (
                                 <button
+                                    type="button"
                                     onClick={() => setCustomBaseUrl(proxyUrl)}
                                     className="absolute right-2 top-1/2 -translate-y-1/2 text-[9px] text-blue-500 hover:text-blue-600 font-medium"
                                 >
@@ -208,7 +240,7 @@ export function OpenCodeSyncModal({ proxyUrl, apiKey, onClose, onSyncDone }: Ope
                             {t('proxy.config.opencode_sync.select_models', { defaultValue: '选择要同步的模型' })}
                             <span className="ml-2 text-gray-300">{selectedModels.size}/{antigravityModels.length}</span>
                         </span>
-                        <button onClick={toggleAll} className="text-[10px] text-blue-500 hover:text-blue-600 font-medium transition-colors">
+                        <button type="button" onClick={toggleAll} className="text-[10px] text-blue-500 hover:text-blue-600 font-medium transition-colors">
                             {allSelected ? t('common.deselect_all', { defaultValue: '取消全选' }) : t('common.select_all', { defaultValue: '全选' })}
                         </button>
                     </div>
@@ -223,6 +255,7 @@ export function OpenCodeSyncModal({ proxyUrl, apiKey, onClose, onSyncDone }: Ope
                                             const selected = selectedModels.has(m.id);
                                             return (
                                                 <button
+                                                    type="button"
                                                     key={m.id}
                                                     onClick={() => toggleModel(m.id)}
                                                     className={cn(
@@ -283,10 +316,11 @@ export function OpenCodeSyncModal({ proxyUrl, apiKey, onClose, onSyncDone }: Ope
 
                 {/* Footer */}
                 <div className="px-5 py-3 border-t border-gray-100 dark:border-base-200 flex items-center justify-end gap-2 shrink-0">
-                    <button className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-base-300 transition-colors" onClick={onClose}>
+                    <button type="button" className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-base-300 transition-colors" onClick={onClose}>
                         {t('common.cancel', { defaultValue: '取消' })}
                     </button>
                     <button
+                        type="button"
                         className={cn(
                             "px-4 py-1.5 text-xs font-bold rounded-lg transition-all flex items-center gap-1.5",
                             previewModels.length > 0

--- a/src/config/__tests__/modelConfig.test.ts
+++ b/src/config/__tests__/modelConfig.test.ts
@@ -6,7 +6,22 @@
  *
  * Run: npx tsx src/config/__tests__/modelConfig.test.ts
  */
-import { categorizeModel, getModelProtectionKey, getModelDisplayName, findQuotaModel, type ModelCategory } from '../../utils/modelCategory';
+import {
+    categorizeModel,
+    getModelProtectionKey,
+    getModelDisplayName,
+    findQuotaModel,
+    findImageQuotaModel,
+    ensurePinnedImageSelector,
+    DEFAULT_IMAGE_PIN_SELECTOR,
+    resolveQuotaModels,
+    type ModelCategory,
+} from '../../utils/modelCategory';
+// Compile-time guard: if findImageQuotaModel is removed from the config re-export,
+// the type alias test below fails with TS2724 on `pnpm tsc --noEmit`.
+function __noop<T>(): void { const _x: T[] = []; void _x; }
+type _ConfigFindImageQuotaModel = typeof import('../../config/modelConfig').findImageQuotaModel;
+__noop<_ConfigFindImageQuotaModel>();
 
 let passed = 0;
 let failed = 0;
@@ -119,10 +134,114 @@ const findCases: Array<[Array<{ name: string }>, ModelCategory, string | null]> 
 
 for (const [models, category, expected] of findCases) {
     test(`findQuotaModel(${category}, ${models.length} models)`, () => {
-        const result = findQuotaModel(models as any, category);
+        const result = findQuotaModel(models, category);
         assertEqual(result?.name ?? null, expected);
     });
 }
+
+// ── resolveQuotaModels image-selector regression ──────────────────────────────
+
+const imageModels = [{ name: 'gemini-3.1-flash-image', percentage: 80 }];
+
+test('resolveQuotaModels: legacy gemini-3-pro-image resolves flash-image + category:gemini-image', () => {
+    const results = resolveQuotaModels(imageModels, ['gemini-3-pro-image']);
+    assertEqual(results.length, 1);
+    assertEqual(results[0].selectionKey, 'category:gemini-image');
+    assertEqual(results[0].model?.name, 'gemini-3.1-flash-image');
+});
+
+test('resolveQuotaModels: current gemini-3.1-flash-image resolves same model + key', () => {
+    const results = resolveQuotaModels(imageModels, ['gemini-3.1-flash-image']);
+    assertEqual(results.length, 1);
+    assertEqual(results[0].selectionKey, 'category:gemini-image');
+    assertEqual(results[0].model?.name, 'gemini-3.1-flash-image');
+});
+
+test('resolveQuotaModels: both image selectors dedupe to one selection', () => {
+    const results = resolveQuotaModels(imageModels, ['gemini-3-pro-image', 'gemini-3.1-flash-image']);
+    assertEqual(results.length, 1);
+    assertEqual(results[0].selectionKey, 'category:gemini-image');
+    assertEqual(results[0].model?.name, 'gemini-3.1-flash-image');
+});
+
+test('resolveQuotaModels: legacy image selector with no image API model returns unresolved', () => {
+    const results = resolveQuotaModels([{ name: 'gemini-3.5-flash', percentage: 50 }], ['gemini-3-pro-image']);
+    assertEqual(results.length, 1);
+    assertEqual(results[0].selectionKey, 'category:gemini-image');
+    assertEqual(results[0].model, undefined);
+});
+
+// ── findImageQuotaModel ───────────────────────────────────────────────────
+
+const imageNameCases: Array<[Array<{ name: string }>, string | null]> = [
+    [[{ name: 'gemini-3.1-flash-image' }, { name: 'gemini-3-pro-image' }], 'gemini-3.1-flash-image'],
+    [[{ name: 'gemini-3-pro-image' }], 'gemini-3-pro-image'],
+    [[{ name: 'gemini-3.5-flash' }], null],
+];
+
+for (const [models, expected] of imageNameCases) {
+    test(`findImageQuotaModel(${models.length} models)`, () => {
+        const result = findImageQuotaModel(models);
+        assertEqual(result?.name ?? null, expected);
+    });
+}
+
+// ── ensurePinnedImageSelector (account management pin gap) ─────────────────
+
+test('ensurePinnedImageSelector: empty list gains default image pin', () => {
+    const result = ensurePinnedImageSelector([]);
+    assertEqual(result.length, 1);
+    assertEqual(result[0], DEFAULT_IMAGE_PIN_SELECTOR);
+});
+
+test('ensurePinnedImageSelector: live user pin list without image gains flash-image', () => {
+    const livePins = [
+        'gemini-3-pro-high',
+        'gemini-3-flash',
+        'claude-sonnet-4-5-thinking',
+        'gemini-3.1-pro-high',
+        'gemini-3.1-pro-low',
+        'claude-sonnet-4-6',
+    ];
+    const result = ensurePinnedImageSelector(livePins);
+    assertEqual(result.includes(DEFAULT_IMAGE_PIN_SELECTOR), true);
+    assertEqual(result.length, livePins.length + 1);
+});
+
+test('ensurePinnedImageSelector: existing flash-image pin is unchanged', () => {
+    const pins = ['gemini-pro-agent', 'gemini-3.1-flash-image'];
+    const result = ensurePinnedImageSelector(pins);
+    assertEqual(result.length, 2);
+    assertEqual(result.join(','), pins.join(','));
+});
+
+test('ensurePinnedImageSelector: existing pro-image pin is unchanged', () => {
+    const pins = ['gemini-3-pro-image', 'gemini-3-flash'];
+    const result = ensurePinnedImageSelector(pins);
+    assertEqual(result.length, 2);
+    assertEqual(result.includes(DEFAULT_IMAGE_PIN_SELECTOR), false);
+});
+
+test('resolveQuotaModels + ensurePinnedImageSelector: live pin gap resolves Gemini 3.1 Flash Image', () => {
+    const livePins = [
+        'gemini-3-pro-high',
+        'gemini-3-flash',
+        'claude-sonnet-4-5-thinking',
+        'gemini-3.1-pro-high',
+        'gemini-3.1-pro-low',
+        'claude-sonnet-4-6',
+    ];
+    const apiModels = [
+        { name: 'gemini-pro-agent', percentage: 80 },
+        { name: 'gemini-3-flash-agent', percentage: 70 },
+        { name: 'gemini-3.1-flash-image', percentage: 92, display_name: 'Gemini 3.1 Flash Image' },
+        { name: 'claude-sonnet-4-6', percentage: 50 },
+    ];
+    const results = resolveQuotaModels(apiModels, ensurePinnedImageSelector(livePins));
+    const image = results.find(r => r.selectionKey === 'category:gemini-image');
+    assertEqual(image?.model?.name, 'gemini-3.1-flash-image');
+    assertEqual(image?.model?.display_name, 'Gemini 3.1 Flash Image');
+});
 
 if (failed > 0) {
     throw new Error(`${failed} test(s) failed`);

--- a/src/config/__tests__/modelConfig.test.ts
+++ b/src/config/__tests__/modelConfig.test.ts
@@ -6,7 +6,7 @@
  *
  * Run: npx tsx src/config/__tests__/modelConfig.test.ts
  */
-import { categorizeModel, getModelProtectionKey, getModelDisplayName, type ModelCategory } from '../../utils/modelCategory';
+import { categorizeModel, getModelProtectionKey, getModelDisplayName, findQuotaModel, type ModelCategory } from '../../utils/modelCategory';
 
 let passed = 0;
 let failed = 0;
@@ -97,6 +97,30 @@ for (const [model, fallback, expected] of displayNameCases) {
             : `getModelDisplayName({name:'${model.name}'${model.display_name ? `, display_name:'${model.display_name}'` : ''}})`;
     test(label, () => {
         assertEqual(getModelDisplayName(model, fallback), expected);
+    });
+}
+
+// ── findQuotaModel ──────────────────────────────────────────────────────────
+
+const findCases: Array<[Array<{ name: string }>, ModelCategory, string | null]> = [
+    // Pro: preferred chain
+    [[{ name: 'gemini-pro-agent' }, { name: 'gemini-3.1-pro-low' }], 'gemini-pro', 'gemini-pro-agent'],
+    [[{ name: 'gemini-2.5-pro' }], 'gemini-pro', 'gemini-2.5-pro'],
+    // Flash: preferred chain
+    [[{ name: 'gemini-3-flash-agent' }, { name: 'gemini-3.5-flash-low' }], 'gemini-flash', 'gemini-3-flash-agent'],
+    // Claude: preferred chain
+    [[{ name: 'claude-sonnet-4-6' }, { name: 'claude-opus-4-6-thinking' }], 'claude', 'claude-sonnet-4-6'],
+    [[{ name: 'claude-opus-4-6-thinking' }], 'claude', 'claude-opus-4-6-thinking'],
+    // Empty
+    [[], 'gemini-pro', null],
+    // Fallback to categorizeModel
+    [[{ name: 'gemini-3.5-flash-extra-low' }], 'gemini-flash', 'gemini-3.5-flash-extra-low'],
+];
+
+for (const [models, category, expected] of findCases) {
+    test(`findQuotaModel(${category}, ${models.length} models)`, () => {
+        const result = findQuotaModel(models as any, category);
+        assertEqual(result?.name ?? null, expected);
     });
 }
 

--- a/src/config/__tests__/modelConfig.test.ts
+++ b/src/config/__tests__/modelConfig.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Standalone assertion script for categorizeModel and getModelProtectionKey.
+ *
+ * Imports from the standalone utils module (no @lobehub/icons dependency,
+ * runs under plain Node.js via npx tsx).
+ *
+ * Run: npx tsx src/config/__tests__/modelConfig.test.ts
+ */
+import { categorizeModel, getModelProtectionKey, getModelDisplayName, type ModelCategory } from '../../utils/modelCategory';
+
+let passed = 0;
+let failed = 0;
+
+function test(description: string, fn: () => void): void {
+    try {
+        fn();
+        passed++;
+    } catch (e: unknown) {
+        failed++;
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error(`  FAIL: ${description}  — ${msg}`);
+    }
+}
+
+function assertEqual<T>(actual: T, expected: T): void {
+    if (actual !== expected) {
+        throw new Error(`expected "${expected}", got "${actual}"`);
+    }
+}
+
+const categorizeCases: Array<[string, ModelCategory]> = [
+    // canonical
+    ['gemini-3.5-flash', 'gemini-flash'],
+    ['gemini-3.1-pro', 'gemini-pro'],
+    // physical / variants
+    ['gemini-3-flash-agent', 'gemini-flash'],
+    ['gemini-3.5-flash-low', 'gemini-flash'],
+    ['gemini-3.5-flash-extra-low', 'gemini-flash'],
+    ['gemini-pro-agent', 'gemini-pro'],
+    ['gemini-3.1-pro-low', 'gemini-pro'],
+    // legacy
+    ['gemini-3-flash', 'gemini-flash'],
+    ['gemini-3-pro-high', 'gemini-pro'],
+    ['gemini-3.1-pro-high', 'gemini-pro'],
+    ['gemini-3-pro-low', 'gemini-pro'],
+    // image split
+    ['gemini-3.1-flash-image', 'gemini-flash-image'],
+    ['gemini-3-pro-image', 'gemini-pro-image'],
+    ['imagen-3.0', 'gemini-pro-image'],
+    // claude
+    ['claude-sonnet-4-6', 'claude'],
+    ['claude-opus-4-6-thinking', 'claude'],
+    // edge / other providers
+    ['gpt-4o', 'other'],
+    ['gpt-oss-120b-medium', 'other'],
+];
+
+for (const [name, expected] of categorizeCases) {
+    test(`categorizeModel("${name}")`, () => {
+        assertEqual(categorizeModel(name), expected);
+    });
+}
+
+const protectionCases: Array<[string, string | null]> = [
+    ['gemini-3.5-flash', 'gemini-3-flash'],
+    ['gemini-3.1-pro', 'gemini-3-pro-high'],
+    ['gemini-3.1-flash-image', 'gemini-3.1-flash-image'],
+    ['gemini-3-pro-image', 'gemini-3-pro-image'],
+    ['claude-sonnet-4-6', 'claude'],
+    ['gpt-4o', null],
+];
+
+for (const [name, expected] of protectionCases) {
+    test(`getModelProtectionKey("${name}")`, () => {
+        assertEqual(getModelProtectionKey(name), expected);
+    });
+}
+
+// ── getModelDisplayName ──────────────────────────────────────────────────────
+
+type ModelInput = { name: string; display_name?: string } | null | undefined;
+
+const displayNameCases: Array<[ModelInput, string | undefined, string]> = [
+    [{ name: 'gemini-3-pro-high', display_name: 'Gemini 3.1 Pro High' }, undefined, 'Gemini 3.1 Pro High'],
+    [{ name: 'gemini-3-flash' }, undefined, 'gemini-3-flash'],
+    [{ name: 'gemini-3.1-flash-image', display_name: undefined }, undefined, 'gemini-3.1-flash-image'],
+    [undefined, 'Claude 系列', 'Claude 系列'],
+    [null, undefined, ''],
+    [{ name: 'claude-opus-4-6-thinking', display_name: 'Claude Opus 4.6 TK' }, undefined, 'Claude Opus 4.6 TK'],
+];
+
+for (const [model, fallback, expected] of displayNameCases) {
+    const label = model === null
+        ? 'getModelDisplayName(null)'
+        : model === undefined
+            ? `getModelDisplayName(undefined, '${fallback}')`
+            : `getModelDisplayName({name:'${model.name}'${model.display_name ? `, display_name:'${model.display_name}'` : ''}})`;
+    test(label, () => {
+        assertEqual(getModelDisplayName(model, fallback), expected);
+    });
+}
+
+if (failed > 0) {
+    throw new Error(`${failed} test(s) failed`);
+}

--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -325,4 +325,15 @@ export function sortModels<T extends { id: string }>(models: T[]): T[] {
 
 // ── 模型分类与保护键（实现在 src/utils/modelCategory.ts，此处只 re-export）───
 
-export { categorizeModel, getModelProtectionKey, getModelDisplayName, findQuotaModel, type ModelCategory } from '../utils/modelCategory';
+export {
+    categorizeModel,
+    getModelProtectionKey,
+    getModelDisplayName,
+    findQuotaModel,
+    findImageQuotaModel,
+    ensurePinnedImageSelector,
+    DEFAULT_IMAGE_PIN_SELECTOR,
+    resolveQuotaModels,
+    type ModelCategory,
+    type QuotaModelSelection,
+} from '../utils/modelCategory';

--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -100,6 +100,26 @@ export const MODEL_CONFIG: Record<string, ModelConfig> = {
         group: 'Gemini 3',
         tags: ['pro'],
     },
+    'gemini-3-flash-agent': {
+        label: 'Gemini 3.5 Flash (High)',
+        shortLabel: 'G3.5 Flash',
+        protectedKey: 'gemini-flash',
+        Icon: Gemini.Color,
+        i18nKey: 'proxy.model.flash_preview',
+        i18nDescKey: 'proxy.model.flash_preview',
+        group: 'Gemini 3',
+        tags: ['flash', 'high'],
+    },
+    'gemini-pro-agent': {
+        label: 'Gemini 3.1 Pro (High)',
+        shortLabel: 'G3.1 Pro',
+        protectedKey: 'gemini-pro',
+        Icon: Gemini.Color,
+        i18nKey: 'proxy.model.pro_high',
+        i18nDescKey: 'proxy.model.pro_high',
+        group: 'Gemini 3',
+        tags: ['pro', 'high'],
+    },
     'gemini-3.1-pro-low': {
         label: 'Gemini 3.1 Pro Low',
         shortLabel: 'G3.1 Low',
@@ -305,4 +325,4 @@ export function sortModels<T extends { id: string }>(models: T[]): T[] {
 
 // ── 模型分类与保护键（实现在 src/utils/modelCategory.ts，此处只 re-export）───
 
-export { categorizeModel, getModelProtectionKey, getModelDisplayName, type ModelCategory } from '../utils/modelCategory';
+export { categorizeModel, getModelProtectionKey, getModelDisplayName, findQuotaModel, type ModelCategory } from '../utils/modelCategory';

--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -80,6 +80,26 @@ export const MODEL_CONFIG: Record<string, ModelConfig> = {
         group: 'Gemini 3',
         tags: ['image'],
     },
+    'gemini-3.5-flash': {
+        label: 'Gemini 3.5 Flash',
+        shortLabel: 'G3.5 Flash',
+        protectedKey: 'gemini-flash',
+        Icon: Gemini.Color,
+        i18nKey: 'proxy.model.flash_preview',
+        i18nDescKey: 'proxy.model.flash_preview',
+        group: 'Gemini 3',
+        tags: ['flash'],
+    },
+    'gemini-3.1-pro': {
+        label: 'Gemini 3.1 Pro',
+        shortLabel: 'G3.1 Pro',
+        protectedKey: 'gemini-pro',
+        Icon: Gemini.Color,
+        i18nKey: 'proxy.model.pro_high',
+        i18nDescKey: 'proxy.model.pro_high',
+        group: 'Gemini 3',
+        tags: ['pro'],
+    },
     'gemini-3.1-pro-low': {
         label: 'Gemini 3.1 Pro Low',
         shortLabel: 'G3.1 Low',
@@ -282,3 +302,7 @@ export function sortModels<T extends { id: string }>(models: T[]): T[] {
         return a.id.localeCompare(b.id);
     });
 }
+
+// ── 模型分类与保护键（实现在 src/utils/modelCategory.ts，此处只 re-export）───
+
+export { categorizeModel, getModelProtectionKey, getModelDisplayName, type ModelCategory } from '../utils/modelCategory';

--- a/src/hooks/useProxyModels.tsx
+++ b/src/hooks/useProxyModels.tsx
@@ -1,18 +1,37 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo, useEffect, useState } from 'react';
 import { MODEL_CONFIG } from '../config/modelConfig';
 import { useAccountStore } from '../stores/useAccountStore';
 import { Bot } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { request } from '../utils/request';
+
+export interface CanonicalFamilyDto {
+    canonical_id: string;
+    display_name: string;
+    match_ids: string[];
+}
 
 export const useProxyModels = () => {
     const { t } = useTranslation();
     const { accounts, fetchAccounts } = useAccountStore();
+    const [canonicalFamilies, setCanonicalFamilies] = useState<CanonicalFamilyDto[]>([]);
 
     // 确保账号数据已加载（针对未触发 fetchAccounts 的页面，如 ApiProxy）
     useEffect(() => {
         if (accounts.length === 0) {
             fetchAccounts();
         }
+
+        let cancelled = false;
+        request<CanonicalFamilyDto[]>('get_canonical_families')
+            .then(data => {
+                if (!cancelled && data) {
+                    setCanonicalFamilies(data);
+                }
+            })
+            .catch(err => console.error('Failed to fetch canonical families:', err));
+
+        return () => { cancelled = true; };
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     const models = useMemo(() => {
@@ -21,9 +40,23 @@ export const useProxyModels = () => {
         const dynamicMap = new Map<string, { name: string; display_name?: string }>();
         for (const account of accounts) {
             for (const m of account.quota?.models ?? []) {
-                const key = m.name.toLowerCase();
-                if (!dynamicMap.has(key) || m.display_name) {
-                    dynamicMap.set(key, { name: m.name, display_name: m.display_name });
+                let key = m.name.toLowerCase();
+                let name = m.name;
+                let display_name = m.display_name;
+
+                if (canonicalFamilies.length > 0) {
+                    for (const family of canonicalFamilies) {
+                        if (family.match_ids.includes(key)) {
+                            key = family.canonical_id.toLowerCase();
+                            name = family.canonical_id;
+                            display_name = family.display_name;
+                            break;
+                        }
+                    }
+                }
+
+                if (!dynamicMap.has(key) || display_name) {
+                    dynamicMap.set(key, { name, display_name });
                 }
             }
         }
@@ -86,7 +119,7 @@ export const useProxyModels = () => {
         }
 
         return result;
-    }, [accounts, t]);
+    }, [accounts, t, canonicalFamilies]);
 
-    return { models };
+    return { models, canonicalFamilies };
 };

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import AddAccountDialog from '../components/accounts/AddAccountDialog';
 import { showToast } from '../components/common/ToastContainer';
 import BestAccounts from '../components/dashboard/BestAccounts';
-import { categorizeModel, findQuotaModel } from '../config/modelConfig';
+import { findImageQuotaModel, findQuotaModel } from '../config/modelConfig';
 import CurrentAccount from '../components/dashboard/CurrentAccount';
 import { exportAccounts } from '../services/accountService';
 import { useAccountStore } from '../stores/useAccountStore';
@@ -43,10 +43,7 @@ function Dashboard() {
             .filter(q => q > 0);
 
         const geminiImageQuotas = accounts
-            .map(a => a.quota?.models.find(m =>
-                categorizeModel(m.name) === 'gemini-flash-image' ||
-                categorizeModel(m.name) === 'gemini-pro-image'
-            )?.percentage || 0)
+            .map(a => findImageQuotaModel(a.quota?.models)?.percentage || 0)
             .filter(q => q > 0);
 
         const claudeQuotas = accounts

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import AddAccountDialog from '../components/accounts/AddAccountDialog';
 import { showToast } from '../components/common/ToastContainer';
 import BestAccounts from '../components/dashboard/BestAccounts';
-import { categorizeModel } from '../config/modelConfig';
+import { categorizeModel, findQuotaModel } from '../config/modelConfig';
 import CurrentAccount from '../components/dashboard/CurrentAccount';
 import { exportAccounts } from '../services/accountService';
 import { useAccountStore } from '../stores/useAccountStore';
@@ -36,9 +36,7 @@ function Dashboard() {
     // 计算统计数据
     const stats = useMemo(() => {
         const getGeminiProQuota = (a: Account) =>
-            (a.quota?.models || [])
-                .filter(m => categorizeModel(m.name) === 'gemini-pro')
-                .reduce((best, model) => Math.max(best, model.percentage || 0), 0);
+            findQuotaModel(a.quota?.models, 'gemini-pro')?.percentage || 0;
 
         const geminiQuotas = accounts
             .map(a => getGeminiProQuota(a))
@@ -52,13 +50,13 @@ function Dashboard() {
             .filter(q => q > 0);
 
         const claudeQuotas = accounts
-            .map(a => a.quota?.models.find(m => m.name.toLowerCase() === 'claude-sonnet-4-6' || m.name.toLowerCase() === 'claude-sonnet-4-5')?.percentage || 0)
+            .map(a => findQuotaModel(a.quota?.models, 'claude')?.percentage || 0)
             .filter(q => q > 0);
 
         const lowQuotaCount = accounts.filter(a => {
             if (a.quota?.is_forbidden) return false;
             const gemini = getGeminiProQuota(a);
-            const claude = a.quota?.models.find(m => m.name.toLowerCase() === 'claude-sonnet-4-6' || m.name.toLowerCase() === 'claude-sonnet-4-5')?.percentage || 0;
+            const claude = findQuotaModel(a.quota?.models, 'claude')?.percentage || 0;
             return gemini < 20 || claude < 20;
         }).length;
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import AddAccountDialog from '../components/accounts/AddAccountDialog';
 import { showToast } from '../components/common/ToastContainer';
 import BestAccounts from '../components/dashboard/BestAccounts';
+import { categorizeModel } from '../config/modelConfig';
 import CurrentAccount from '../components/dashboard/CurrentAccount';
 import { exportAccounts } from '../services/accountService';
 import { useAccountStore } from '../stores/useAccountStore';
@@ -36,12 +37,7 @@ function Dashboard() {
     const stats = useMemo(() => {
         const getGeminiProQuota = (a: Account) =>
             (a.quota?.models || [])
-                .filter(m =>
-                    m.name.toLowerCase() === 'gemini-3-pro-high'
-                    || m.name.toLowerCase() === 'gemini-3-pro-low'
-                    || m.name.toLowerCase() === 'gemini-3.1-pro-high'
-                    || m.name.toLowerCase() === 'gemini-3.1-pro-low'
-                )
+                .filter(m => categorizeModel(m.name) === 'gemini-pro')
                 .reduce((best, model) => Math.max(best, model.percentage || 0), 0);
 
         const geminiQuotas = accounts
@@ -50,8 +46,8 @@ function Dashboard() {
 
         const geminiImageQuotas = accounts
             .map(a => a.quota?.models.find(m =>
-                m.name.toLowerCase() === 'gemini-3.1-flash-image' ||
-                m.name.toLowerCase() === 'gemini-3-pro-image'
+                categorizeModel(m.name) === 'gemini-flash-image' ||
+                categorizeModel(m.name) === 'gemini-pro-image'
             )?.percentage || 0)
             .filter(q => q > 0);
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -65,7 +65,7 @@ function Settings() {
             monitored_models: []
         },
         pinned_quota_models: {
-            models: ['gemini-3-pro-high', 'gemini-3-flash', 'gemini-3-pro-image', 'claude-opus-4-6-thinking']
+            models: ['gemini-pro-agent', 'gemini-3-flash-agent', 'gemini-3.1-flash-image', 'claude-opus-4-6-thinking']
         },
         cloudflared: {
             enabled: false,

--- a/src/utils/modelCategory.ts
+++ b/src/utils/modelCategory.ts
@@ -64,3 +64,69 @@ export function getModelProtectionKey(name: string): string | null {
         default: return null;
     }
 }
+
+/**
+ * 在任意图片类别中查找第一个实际模型。
+ * 用于让新旧 image selector 共享同一配额槽位。
+ */
+export function findImageQuotaModel<T extends { name: string }>(
+    models: T[] | undefined,
+): T | undefined {
+    if (!models || models.length === 0) return undefined;
+    return models.find(m => {
+        const c = categorizeModel(m.name);
+        return c === 'gemini-flash-image' || c === 'gemini-pro-image';
+    });
+}
+
+/** 账号管理 pin 列表缺省图像选择器时补入代表 Image，与仪表盘对齐。 */
+export const DEFAULT_IMAGE_PIN_SELECTOR = 'gemini-3.1-flash-image';
+
+export function ensurePinnedImageSelector(selectorIds: string[] | undefined): string[] {
+    const pinned = selectorIds ? [...selectorIds] : [];
+    const hasImage = pinned.some(id => {
+        const category = categorizeModel(id);
+        return category === 'gemini-flash-image' || category === 'gemini-pro-image';
+    });
+    if (hasImage) return pinned;
+    pinned.push(DEFAULT_IMAGE_PIN_SELECTOR);
+    return pinned;
+}
+
+export interface QuotaModelSelection<T> {
+    selectorId: string;
+    selectionKey: string;
+    model: T | undefined;
+}
+
+export function resolveQuotaModels<T extends { name: string }>(
+    models: T[] | undefined,
+    selectorIds: string[],
+): QuotaModelSelection<T>[] {
+    const seen = new Set<string>();
+    const results: QuotaModelSelection<T>[] = [];
+
+    for (const selectorId of selectorIds) {
+        const normalizedId = selectorId.trim().toLowerCase();
+        const category = categorizeModel(normalizedId);
+
+        const isImage = category === 'gemini-pro-image' || category === 'gemini-flash-image';
+        const selectionKey = isImage
+            ? 'category:gemini-image'
+            : category === 'other'
+                ? `model:${normalizedId}`
+                : `category:${category}`;
+
+        if (seen.has(selectionKey)) continue;
+        seen.add(selectionKey);
+
+        const model = isImage
+            ? findImageQuotaModel(models)
+            : category === 'other'
+                ? models?.find(m => m.name.trim().toLowerCase() === normalizedId)
+                : findQuotaModel(models, category);
+
+        results.push({ selectorId, selectionKey, model });
+    }
+    return results;
+}

--- a/src/utils/modelCategory.ts
+++ b/src/utils/modelCategory.ts
@@ -31,6 +31,29 @@ export function getModelDisplayName(
     return fallback ?? '';
 }
 
+/**
+ * 按优先级查找配额模型：先精确匹配首选名，再按类别 fallback。
+ */
+export function findQuotaModel<T extends { name: string }>(
+    models: T[] | undefined,
+    category: ModelCategory,
+): T | undefined {
+    if (!models || models.length === 0) return undefined;
+    const preferred: Partial<Record<ModelCategory, string[]>> = {
+        'gemini-pro': ['gemini-pro-agent', 'gemini-3.1-pro-high', 'gemini-3.1-pro', 'gemini-3.1-pro-low', 'gemini-2.5-pro'],
+        'gemini-flash': ['gemini-3-flash-agent', 'gemini-3-flash', 'gemini-3.5-flash'],
+        'claude': ['claude-sonnet-4-6', 'claude-opus-4-6-thinking'],
+    };
+    const names = preferred[category];
+    if (names) {
+        for (const name of names) {
+            const found = models.find(m => m.name === name);
+            if (found) return found;
+        }
+    }
+    return models.find(m => categorizeModel(m.name) === category);
+}
+
 export function getModelProtectionKey(name: string): string | null {
     switch (categorizeModel(name)) {
         case 'gemini-flash': return 'gemini-3-flash';

--- a/src/utils/modelCategory.ts
+++ b/src/utils/modelCategory.ts
@@ -1,0 +1,43 @@
+/**
+ * 模型分类工具函数（无 React / icons 依赖，可在 Node 环境直接导入）
+ */
+
+export type ModelCategory = 'gemini-pro' | 'gemini-flash' | 'gemini-pro-image' | 'gemini-flash-image' | 'claude' | 'other';
+
+export function categorizeModel(name: string): ModelCategory {
+    const n = name.trim().toLowerCase();
+    const isGemini = n.startsWith('gemini-');
+    const isImage = (isGemini && n.includes('image')) || n.startsWith('image') || n.startsWith('imagen');
+    if (isImage) return n.includes('flash') ? 'gemini-flash-image' : 'gemini-pro-image';
+    if (isGemini && n.includes('flash')) return 'gemini-flash';
+    if (isGemini && n.includes('pro')) return 'gemini-pro';
+    if (n.includes('claude') || n.includes('opus') || n.includes('sonnet') || n.includes('haiku')) return 'claude';
+    return 'other';
+}
+
+export interface ModelDisplayNameInput {
+    name: string;
+    display_name?: string;
+}
+
+export function getModelDisplayName(
+    model: ModelDisplayNameInput | null | undefined,
+    fallback?: string,
+): string {
+    if (model) {
+        if (model.display_name) return model.display_name;
+        if (model.name) return model.name;
+    }
+    return fallback ?? '';
+}
+
+export function getModelProtectionKey(name: string): string | null {
+    switch (categorizeModel(name)) {
+        case 'gemini-flash': return 'gemini-3-flash';
+        case 'gemini-pro': return 'gemini-3-pro-high';
+        case 'gemini-flash-image': return 'gemini-3.1-flash-image';
+        case 'gemini-pro-image': return 'gemini-3-pro-image';
+        case 'claude': return 'claude';
+        default: return null;
+    }
+}

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -73,6 +73,7 @@ const COMMAND_MAPPING: Record<string, { url: string; method: 'GET' | 'POST' | 'D
   'execute_opencode_restore': { url: '/api/proxy/opencode/restore', method: 'POST' },
   'execute_opencode_clear': { url: '/api/proxy/opencode/clear', method: 'POST' },
   'get_opencode_config_content': { url: '/api/proxy/opencode/config', method: 'POST' },
+  'get_canonical_families': { url: '/api/proxy/opencode/families', method: 'GET' },
 
   // Stats
   'get_token_stats_hourly': { url: '/api/stats/token/hourly', method: 'GET' },


### PR DESCRIPTION
## 概述

统一仪表盘/账号管理的配额模型查找逻辑，支持新 Gemini 模型与 API 显示名回退。

> **依赖 #3255**：本 PR 基于变体映射 PR，canonical agent 名由 #3255 提供。建议 #3255 合并后，本 PR 将自动仅显示配额相关 3 个提交。

## 改动

- **新增 `modelCategory.ts`**：统一模型分类（`categorizeModel`）、显示名回退（`getModelDisplayName`）、按类别配额查找（`findQuotaModel`/`findImageQuotaModel`/`resolveQuotaModels`）与图像选择器保护
- **`modelConfig.ts`**：新增 `gemini-3.5-flash`、`gemini-3.1-pro` 条目
- **6 处组件去重**：账号表格/卡片/行、仪表盘当前/最佳账号、迷你视图、主仪表盘删除重复的 inline filter/sort，统一调用 `findQuotaModel`
- **`AccountTable`** 删除散落的 `MODEL_GROUPS`/`MODEL_ID_ALIASES` 硬编码别名表
- **显示名回退**：优先读 API `display_name`，缺失时回退到配置
- **新增 `modelConfig.test.ts`**：覆盖分类、查找与图像选择器回归

## 验证

- `cargo check` 通过
- `tsc --noEmit` 0 错误
- `modelConfig.test.ts` 全部通过

## 提交

1. `feat(quota): 仪表盘配额显示动态化与模型显示名回退`
2. `feat(quota): 模型别名归一与 agent 代表模型查找`
3. `refactor(quota): 统一配额查找为 resolveQuotaModels 与图像选择保护`