### PR TITLE
feat(proxy): add MiniMax provider support

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -418,6 +418,8 @@ pub async fn save_config(
         instance.axum_server.update_security(&config.proxy).await;
         // 更新 z.ai 配置
         instance.axum_server.update_zai(&config.proxy).await;
+        // Update MiniMax configuration.
+        instance.axum_server.update_minimax(&config.proxy).await;
         // 更新实验性配置
         instance
             .axum_server

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -169,7 +169,8 @@ pub async fn internal_start_proxy_service(
     if active_accounts == 0 {
         let zai_enabled = config.zai.enabled
             && !matches!(config.zai.dispatch_mode, crate::proxy::ZaiDispatchMode::Off);
-        if !zai_enabled {
+        let minimax_enabled = config.minimax.enabled;
+        if !zai_enabled && !minimax_enabled {
             tracing::warn!("沒有可用賬號，反代邏輯將暫停，請通過管理界面添加。");
             return Ok(ProxyStatus {
                 running: false,
@@ -250,6 +251,7 @@ pub async fn ensure_admin_server(
         config.user_agent_override.clone(),
         crate::proxy::ProxySecurityConfig::from_proxy_config(&config),
         config.zai.clone(),
+        config.minimax.clone(),
         monitor,
         config.experimental.clone(),
         config.debug_logging.clone(),

--- a/src-tauri/src/proxy/config.rs
+++ b/src-tauri/src/proxy/config.rs
@@ -355,6 +355,88 @@ impl Default for ZaiConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MiniMaxRegion {
+    GlobalEn,
+    CnZh,
+}
+
+impl Default for MiniMaxRegion {
+    fn default() -> Self {
+        Self::GlobalEn
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MiniMaxRegionalEndpoints {
+    #[serde(default = "default_minimax_global_openai_base_url")]
+    pub global_openai_base_url: String,
+    #[serde(default = "default_minimax_global_anthropic_base_url")]
+    pub global_anthropic_base_url: String,
+    #[serde(default = "default_minimax_cn_openai_base_url")]
+    pub cn_openai_base_url: String,
+    #[serde(default = "default_minimax_cn_anthropic_base_url")]
+    pub cn_anthropic_base_url: String,
+}
+
+impl Default for MiniMaxRegionalEndpoints {
+    fn default() -> Self {
+        Self {
+            global_openai_base_url: default_minimax_global_openai_base_url(),
+            global_anthropic_base_url: default_minimax_global_anthropic_base_url(),
+            cn_openai_base_url: default_minimax_cn_openai_base_url(),
+            cn_anthropic_base_url: default_minimax_cn_anthropic_base_url(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MiniMaxPricing {
+    pub input: f64,
+    pub output: f64,
+    pub cache_read: f64,
+    pub cache_write: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MiniMaxModelConfig {
+    pub model_id: String,
+    pub context_window: u64,
+    pub pricing_usd_per_million_tokens: MiniMaxPricing,
+    pub input_modalities: Vec<String>,
+    pub thinking: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MiniMaxConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub api_key: String,
+    #[serde(default)]
+    pub region: MiniMaxRegion,
+    #[serde(default)]
+    pub endpoints: MiniMaxRegionalEndpoints,
+    #[serde(default)]
+    pub model_mapping: HashMap<String, String>,
+    #[serde(default = "default_minimax_models")]
+    pub models: Vec<MiniMaxModelConfig>,
+}
+
+impl Default for MiniMaxConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            api_key: String::new(),
+            region: MiniMaxRegion::GlobalEn,
+            endpoints: MiniMaxRegionalEndpoints::default(),
+            model_mapping: HashMap::new(),
+            models: default_minimax_models(),
+        }
+    }
+}
+
 /// 实验性功能配置 (Feature Flags)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExperimentalConfig {
@@ -619,6 +701,10 @@ pub struct ProxyConfig {
     #[serde(default)]
     pub zai: ZaiConfig,
 
+    /// MiniMax provider configuration.
+    #[serde(default)]
+    pub minimax: MiniMaxConfig,
+
     /// 自定义 User-Agent 请求头 (可选覆盖)
     #[serde(default)]
     pub user_agent_override: Option<String>,
@@ -691,6 +777,7 @@ impl Default for ProxyConfig {
             debug_logging: DebugLoggingConfig::default(),
             upstream_proxy: UpstreamProxyConfig::default(),
             zai: ZaiConfig::default(),
+            minimax: MiniMaxConfig::default(),
             scheduling: crate::proxy::sticky_config::StickySessionConfig::default(),
             experimental: ExperimentalConfig::default(),
             security_monitor: SecurityMonitorConfig::default(),
@@ -711,6 +798,51 @@ fn default_request_timeout() -> u64 {
 
 fn default_zai_base_url() -> String {
     "https://api.z.ai/api/anthropic".to_string()
+}
+
+fn default_minimax_global_openai_base_url() -> String {
+    "https://api.minimax.io/v1".to_string()
+}
+
+fn default_minimax_global_anthropic_base_url() -> String {
+    "https://api.minimax.io/anthropic".to_string()
+}
+
+fn default_minimax_cn_openai_base_url() -> String {
+    "https://api.minimaxi.com/v1".to_string()
+}
+
+fn default_minimax_cn_anthropic_base_url() -> String {
+    "https://api.minimaxi.com/anthropic".to_string()
+}
+
+fn default_minimax_models() -> Vec<MiniMaxModelConfig> {
+    vec![
+        MiniMaxModelConfig {
+            model_id: "MiniMax-M3".to_string(),
+            context_window: 1_000_000,
+            pricing_usd_per_million_tokens: MiniMaxPricing {
+                input: 0.6,
+                output: 2.4,
+                cache_read: 0.12,
+                cache_write: None,
+            },
+            input_modalities: vec!["text".to_string(), "image".to_string(), "video".to_string()],
+            thinking: vec!["adaptive".to_string(), "disabled".to_string()],
+        },
+        MiniMaxModelConfig {
+            model_id: "MiniMax-M2.7".to_string(),
+            context_window: 204_800,
+            pricing_usd_per_million_tokens: MiniMaxPricing {
+                input: 0.3,
+                output: 1.2,
+                cache_read: 0.06,
+                cache_write: Some(0.375),
+            },
+            input_modalities: vec!["text".to_string()],
+            thinking: vec!["always_on".to_string()],
+        },
+    ]
 }
 
 fn default_zai_opus_model() -> String {

--- a/src-tauri/src/proxy/handlers/claude.rs
+++ b/src-tauri/src/proxy/handlers/claude.rs
@@ -390,6 +390,23 @@ pub async fn handle_messages(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
+    let incoming_model = body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let minimax = state.minimax.read().await.clone();
+    if crate::proxy::providers::minimax::should_route(&minimax, &incoming_model) {
+        return crate::proxy::providers::minimax::forward_anthropic_json(
+            &state,
+            axum::http::Method::POST,
+            "/v1/messages",
+            &headers,
+            body,
+        )
+        .await;
+    }
+
     // [FIX] 保存原始请求体的完整副本，用于日志记录
     // 这确保了即使结构体定义遗漏字段，日志也能完整记录所有参数
     let original_body = body.clone();
@@ -1915,7 +1932,7 @@ pub async fn handle_list_models(State(state): State<AppState>) -> impl IntoRespo
 
     let model_ids = get_all_dynamic_models(&state.custom_mapping, Some(&state.token_manager)).await;
 
-    let data: Vec<_> = model_ids
+    let mut data: Vec<_> = model_ids
         .into_iter()
         .map(|id| {
             json!({
@@ -1926,6 +1943,8 @@ pub async fn handle_list_models(State(state): State<AppState>) -> impl IntoRespo
             })
         })
         .collect();
+    let minimax = state.minimax.read().await.clone();
+    data.extend(crate::proxy::providers::minimax::model_entries(&minimax));
 
     Json(json!({
         "object": "list",
@@ -1939,6 +1958,22 @@ pub async fn handle_count_tokens(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
+    let minimax = state.minimax.read().await.clone();
+    let incoming_model = body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if crate::proxy::providers::minimax::should_route(&minimax, incoming_model) {
+        return crate::proxy::providers::minimax::forward_anthropic_json(
+            &state,
+            axum::http::Method::POST,
+            "/v1/messages/count_tokens",
+            &headers,
+            body,
+        )
+        .await;
+    }
+
     let zai = state.zai.read().await.clone();
     let zai_enabled =
         zai.enabled && !matches!(zai.dispatch_mode, crate::proxy::ZaiDispatchMode::Off);

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -272,12 +272,25 @@ pub async fn handle_chat_completions(
     headers: HeaderMap, // [CHANGED] Extract headers
     Json(mut body): Json<Value>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    // [NEW] Check for Image Model Redirection
-    let model_name = body
+    let incoming_model = body
         .get("model")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_lowercase();
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let minimax = state.minimax.read().await.clone();
+    if crate::proxy::providers::minimax::should_route(&minimax, &incoming_model) {
+        return Ok(crate::proxy::providers::minimax::forward_openai_json(
+            &state,
+            axum::http::Method::POST,
+            "/v1/chat/completions",
+            &headers,
+            body,
+        )
+        .await);
+    }
+
+    // [NEW] Check for Image Model Redirection
+    let model_name = incoming_model.to_lowercase();
     // [FIX] Only redirect non-native image aliases (dall-e / midjourney) to the
     // images-generations shim. Native Gemini image models (gemini-3-pro-image*) must
     // flow through the normal pipeline (transform_openai_request -> resolve_request_config),
@@ -1331,8 +1344,26 @@ fn web_tools_guidance_message() -> Value {
 pub async fn handle_completions(
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(mut body): Json<Value>,
 ) -> Response {
+    let incoming_model = body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let minimax = state.minimax.read().await.clone();
+    if crate::proxy::providers::minimax::should_route(&minimax, &incoming_model) {
+        return crate::proxy::providers::minimax::forward_openai_json(
+            &state,
+            axum::http::Method::POST,
+            uri.path(),
+            &headers,
+            body,
+        )
+        .await;
+    }
+
     debug!(
         "Received /v1/completions or /v1/responses payload: {:?}",
         body
@@ -2947,7 +2978,7 @@ pub async fn handle_list_models(State(state): State<AppState>) -> impl IntoRespo
 
     let model_ids = get_all_dynamic_models(&state.custom_mapping, Some(&state.token_manager)).await;
 
-    let data: Vec<_> = model_ids
+    let mut data: Vec<_> = model_ids
         .into_iter()
         .map(|id| {
             json!({
@@ -2958,6 +2989,8 @@ pub async fn handle_list_models(State(state): State<AppState>) -> impl IntoRespo
             })
         })
         .collect();
+    let minimax = state.minimax.read().await.clone();
+    data.extend(crate::proxy::providers::minimax::model_entries(&minimax));
 
     Json(json!({
         "object": "list",

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -37,6 +37,8 @@ pub use config::update_thinking_budget_config;
 pub use config::ProxyAuthMode;
 pub use config::ProxyConfig;
 pub use config::ProxyPoolConfig;
+pub use config::MiniMaxConfig;
+pub use config::MiniMaxRegion;
 pub use config::ZaiConfig;
 pub use config::ZaiDispatchMode;
 pub use security::ProxySecurityConfig;

--- a/src-tauri/src/proxy/providers/minimax.rs
+++ b/src-tauri/src/proxy/providers/minimax.rs
@@ -1,0 +1,494 @@
+use axum::{
+    body::Body,
+    http::{header, HeaderMap, HeaderValue, Method, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use bytes::Bytes;
+use futures::StreamExt;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use tokio::time::Duration;
+
+use crate::proxy::config::{MiniMaxConfig, MiniMaxModelConfig, MiniMaxRegion};
+use crate::proxy::server::AppState;
+
+#[derive(Clone, Copy)]
+enum MiniMaxProtocol {
+    OpenAi,
+    Anthropic,
+}
+
+pub fn resolve_model(config: &MiniMaxConfig, incoming: &str) -> Option<String> {
+    let incoming = incoming.trim();
+    let mapped = config
+        .model_mapping
+        .get(incoming)
+        .or_else(|| config.model_mapping.get(&incoming.to_ascii_lowercase()))
+        .map(String::as_str)
+        .unwrap_or(incoming)
+        .trim();
+    let candidate = if mapped.to_ascii_lowercase().starts_with("minimax:") {
+        mapped.get(8..).unwrap_or_default().trim()
+    } else {
+        mapped
+    };
+
+    config
+        .models
+        .iter()
+        .find(|model| model.model_id.eq_ignore_ascii_case(candidate))
+        .map(|model| model.model_id.clone())
+}
+
+pub fn should_route(config: &MiniMaxConfig, incoming: &str) -> bool {
+    config.enabled && resolve_model(config, incoming).is_some()
+}
+
+pub fn model_entries(config: &MiniMaxConfig) -> Vec<Value> {
+    if !config.enabled {
+        return Vec::new();
+    }
+
+    config
+        .models
+        .iter()
+        .map(|model| {
+            json!({
+                "id": &model.model_id,
+                "object": "model",
+                "created": 0,
+                "owned_by": "minimax",
+                "context_window": model.context_window,
+                "input_modalities": &model.input_modalities,
+                "thinking": &model.thinking,
+                "pricing_usd_per_million_tokens": &model.pricing_usd_per_million_tokens,
+            })
+        })
+        .collect()
+}
+
+fn selected_base_url(config: &MiniMaxConfig, protocol: MiniMaxProtocol) -> &str {
+    match (&config.region, protocol) {
+        (MiniMaxRegion::GlobalEn, MiniMaxProtocol::OpenAi) => {
+            &config.endpoints.global_openai_base_url
+        }
+        (MiniMaxRegion::GlobalEn, MiniMaxProtocol::Anthropic) => {
+            &config.endpoints.global_anthropic_base_url
+        }
+        (MiniMaxRegion::CnZh, MiniMaxProtocol::OpenAi) => {
+            &config.endpoints.cn_openai_base_url
+        }
+        (MiniMaxRegion::CnZh, MiniMaxProtocol::Anthropic) => {
+            &config.endpoints.cn_anthropic_base_url
+        }
+    }
+}
+
+fn join_base_url(base: &str, path: &str) -> Result<String, String> {
+    let base = base.trim().trim_end_matches('/');
+    if base.is_empty() {
+        return Err("MiniMax base URL is empty".to_string());
+    }
+
+    let mut path = path.trim();
+    if base.ends_with("/v1") && path.starts_with("/v1/") {
+        path = path.get(3..).unwrap_or(path);
+    }
+    let path = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{}", path)
+    };
+
+    Ok(format!("{}{}", base, path))
+}
+
+fn build_client(
+    upstream_proxy: Option<crate::proxy::config::UpstreamProxyConfig>,
+    timeout_secs: u64,
+) -> Result<reqwest::Client, String> {
+    let mut builder = reqwest::Client::builder().timeout(Duration::from_secs(timeout_secs.max(5)));
+
+    if let Some(config) = upstream_proxy {
+        if config.enabled && !config.url.is_empty() {
+            let url = crate::proxy::config::normalize_proxy_url(&config.url);
+            let proxy = reqwest::Proxy::all(&url)
+                .map_err(|e| format!("Invalid upstream proxy URL: {}", e))?;
+            builder = builder.proxy(proxy);
+        }
+    }
+
+    builder
+        .tcp_nodelay(true)
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {}", e))
+}
+
+fn copy_passthrough_headers(incoming: &HeaderMap) -> HeaderMap {
+    let mut out = HeaderMap::new();
+
+    for (key, value) in incoming.iter() {
+        match key.as_str().to_ascii_lowercase().as_str() {
+            "content-type" | "accept" | "accept-encoding" | "cache-control"
+            | "anthropic-version" | "anthropic-beta" | "user-agent" => {
+                out.insert(key.clone(), value.clone());
+            }
+            _ => {}
+        }
+    }
+
+    out
+}
+
+fn collect_content_modalities(value: &Value, modalities: &mut HashSet<String>) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_content_modalities(item, modalities);
+            }
+        }
+        Value::Object(map) => {
+            if let Some(kind) = map.get("type").and_then(Value::as_str) {
+                match kind.to_ascii_lowercase().as_str() {
+                    "image" | "image_url" | "input_image" => {
+                        modalities.insert("image".to_string());
+                    }
+                    "video" | "video_url" | "input_video" => {
+                        modalities.insert("video".to_string());
+                    }
+                    "audio" | "audio_url" | "input_audio" => {
+                        modalities.insert("audio".to_string());
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(content) = map.get("content") {
+                collect_content_modalities(content, modalities);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn request_modalities(body: &Value) -> HashSet<String> {
+    let mut modalities = HashSet::from(["text".to_string()]);
+    for field in ["messages", "input"] {
+        if let Some(value) = body.get(field) {
+            collect_content_modalities(value, &mut modalities);
+        }
+    }
+    modalities
+}
+
+fn validate_modalities(model: &MiniMaxModelConfig, body: &Value) -> Result<(), String> {
+    let requested = request_modalities(body);
+    let allowed: HashSet<_> = model
+        .input_modalities
+        .iter()
+        .map(|modality| modality.to_ascii_lowercase())
+        .collect();
+    let unsupported: Vec<_> = requested.difference(&allowed).cloned().collect();
+
+    if unsupported.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{} does not support input modalities: {}",
+            model.model_id,
+            unsupported.join(", ")
+        ))
+    }
+}
+
+fn normalize_request(config: &MiniMaxConfig, mut body: Value) -> Result<Value, String> {
+    let incoming = body
+        .get("model")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "MiniMax requests require a model".to_string())?;
+    let model_id = resolve_model(config, incoming)
+        .ok_or_else(|| format!("Unsupported MiniMax model: {}", incoming))?;
+    let model = config
+        .models
+        .iter()
+        .find(|model| model.model_id == model_id)
+        .ok_or_else(|| format!("Missing MiniMax metadata for {}", model_id))?;
+
+    validate_modalities(model, &body)?;
+
+    if model.thinking.iter().any(|mode| mode == "always_on")
+        && body
+            .get("thinking")
+            .and_then(|thinking| thinking.get("type"))
+            .and_then(Value::as_str)
+            .is_some_and(|kind| kind.eq_ignore_ascii_case("disabled"))
+    {
+        return Err(format!("{} does not support disabled thinking", model_id));
+    }
+
+    if model.thinking.iter().any(|mode| mode == "adaptive") {
+        if let Some(thinking) = body.get_mut("thinking").and_then(Value::as_object_mut) {
+            if thinking
+                .get("type")
+                .and_then(Value::as_str)
+                .is_some_and(|kind| kind.eq_ignore_ascii_case("enabled"))
+            {
+                thinking.insert("type".to_string(), Value::String("adaptive".to_string()));
+                thinking.remove("budget_tokens");
+                thinking.remove("budgetTokens");
+                thinking.remove("budget");
+            }
+        }
+    }
+
+    body["model"] = Value::String(model_id);
+    Ok(body)
+}
+
+fn error_response(status: StatusCode, message: impl Into<String>) -> Response {
+    (
+        status,
+        Json(json!({
+            "error": {
+                "type": "invalid_request_error",
+                "message": message.into(),
+            }
+        })),
+    )
+        .into_response()
+}
+
+async fn forward_json(
+    state: &AppState,
+    protocol: MiniMaxProtocol,
+    method: Method,
+    path: &str,
+    incoming_headers: &HeaderMap,
+    body: Value,
+) -> Response {
+    let config = state.minimax.read().await.clone();
+    if !config.enabled {
+        return error_response(StatusCode::BAD_REQUEST, "MiniMax is disabled");
+    }
+    if config.api_key.trim().is_empty() {
+        return error_response(StatusCode::BAD_REQUEST, "MiniMax API key is not set");
+    }
+
+    let body = match normalize_request(&config, body) {
+        Ok(body) => body,
+        Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
+    };
+    let url = match join_base_url(selected_base_url(&config, protocol), path) {
+        Ok(url) => url,
+        Err(error) => return error_response(StatusCode::BAD_REQUEST, error),
+    };
+    let upstream_proxy = state.upstream_proxy.read().await.clone();
+    let client = match build_client(Some(upstream_proxy), state.request_timeout) {
+        Ok(client) => client,
+        Err(error) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, error),
+    };
+
+    let mut headers = copy_passthrough_headers(incoming_headers);
+    let auth = match HeaderValue::from_str(&format!("Bearer {}", config.api_key)) {
+        Ok(value) => value,
+        Err(_) => return error_response(StatusCode::BAD_REQUEST, "Invalid MiniMax API key"),
+    };
+    headers.insert(header::AUTHORIZATION, auth);
+    headers
+        .entry(header::CONTENT_TYPE)
+        .or_insert(HeaderValue::from_static("application/json"));
+
+    let body = match serde_json::to_vec(&body) {
+        Ok(body) => body,
+        Err(error) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to encode MiniMax request: {}", error),
+            )
+        }
+    };
+    let response = match client
+        .request(method, url)
+        .headers(headers)
+        .body(body)
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            return error_response(
+                StatusCode::BAD_GATEWAY,
+                format!("MiniMax upstream request failed: {}", error),
+            )
+        }
+    };
+
+    let status = StatusCode::from_u16(response.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let mut outgoing = Response::builder().status(status);
+    if let Some(content_type) = response.headers().get(header::CONTENT_TYPE) {
+        outgoing = outgoing.header(header::CONTENT_TYPE, content_type.clone());
+    }
+    let stream = response.bytes_stream().map(|chunk| match chunk {
+        Ok(bytes) => Ok::<Bytes, std::io::Error>(bytes),
+        Err(error) => Ok(Bytes::from(format!("MiniMax upstream stream error: {}", error))),
+    });
+
+    outgoing.body(Body::from_stream(stream)).unwrap_or_else(|_| {
+        error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to build MiniMax response",
+        )
+    })
+}
+
+pub async fn forward_openai_json(
+    state: &AppState,
+    method: Method,
+    path: &str,
+    incoming_headers: &HeaderMap,
+    body: Value,
+) -> Response {
+    forward_json(
+        state,
+        MiniMaxProtocol::OpenAi,
+        method,
+        path,
+        incoming_headers,
+        body,
+    )
+    .await
+}
+
+pub async fn forward_anthropic_json(
+    state: &AppState,
+    method: Method,
+    path: &str,
+    incoming_headers: &HeaderMap,
+    body: Value,
+) -> Response {
+    forward_json(
+        state,
+        MiniMaxProtocol::Anthropic,
+        method,
+        path,
+        incoming_headers,
+        body,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_all_regional_protocol_endpoints() {
+        let mut config = MiniMaxConfig::default();
+        assert_eq!(
+            join_base_url(
+                selected_base_url(&config, MiniMaxProtocol::OpenAi),
+                "/v1/chat/completions"
+            )
+            .unwrap(),
+            "https://api.minimax.io/v1/chat/completions"
+        );
+        assert_eq!(
+            join_base_url(
+                selected_base_url(&config, MiniMaxProtocol::Anthropic),
+                "/v1/messages"
+            )
+            .unwrap(),
+            "https://api.minimax.io/anthropic/v1/messages"
+        );
+
+        config.region = MiniMaxRegion::CnZh;
+        assert_eq!(
+            join_base_url(
+                selected_base_url(&config, MiniMaxProtocol::OpenAi),
+                "/v1/chat/completions"
+            )
+            .unwrap(),
+            "https://api.minimaxi.com/v1/chat/completions"
+        );
+        assert_eq!(
+            join_base_url(
+                selected_base_url(&config, MiniMaxProtocol::Anthropic),
+                "/v1/messages"
+            )
+            .unwrap(),
+            "https://api.minimaxi.com/anthropic/v1/messages"
+        );
+    }
+
+    #[test]
+    fn resolves_exact_prefixed_and_mapped_models() {
+        let mut config = MiniMaxConfig::default();
+        config
+            .model_mapping
+            .insert("fast".to_string(), "MiniMax-M2.7".to_string());
+
+        assert_eq!(resolve_model(&config, "minimax-m3").as_deref(), Some("MiniMax-M3"));
+        assert_eq!(
+            resolve_model(&config, "minimax:MiniMax-M2.7").as_deref(),
+            Some("MiniMax-M2.7")
+        );
+        assert_eq!(resolve_model(&config, "fast").as_deref(), Some("MiniMax-M2.7"));
+        assert_eq!(resolve_model(&config, "unknown"), None);
+    }
+
+    #[test]
+    fn normalizes_adaptive_thinking_and_rejects_disabled_always_on_thinking() {
+        let config = MiniMaxConfig::default();
+        let adaptive = normalize_request(
+            &config,
+            json!({
+                "model": "MiniMax-M3",
+                "messages": [{"role": "user", "content": "hello"}],
+                "thinking": {"type": "enabled", "budget_tokens": 4096}
+            }),
+        )
+        .unwrap();
+        assert_eq!(adaptive["thinking"]["type"], "adaptive");
+        assert!(adaptive["thinking"].get("budget_tokens").is_none());
+
+        let error = normalize_request(
+            &config,
+            json!({
+                "model": "MiniMax-M2.7",
+                "messages": [{"role": "user", "content": "hello"}],
+                "thinking": {"type": "disabled"}
+            }),
+        )
+        .unwrap_err();
+        assert!(error.contains("does not support disabled thinking"));
+    }
+
+    #[test]
+    fn validates_model_input_modalities() {
+        let config = MiniMaxConfig::default();
+        normalize_request(
+            &config,
+            json!({
+                "model": "MiniMax-M3",
+                "messages": [{
+                    "role": "user",
+                    "content": [{"type": "video_url", "video_url": {"url": "https://example.test/a.mp4"}}]
+                }]
+            }),
+        )
+        .unwrap();
+
+        let error = normalize_request(
+            &config,
+            json!({
+                "model": "MiniMax-M2.7",
+                "messages": [{
+                    "role": "user",
+                    "content": [{"type": "image_url", "image_url": {"url": "https://example.test/a.png"}}]
+                }]
+            }),
+        )
+        .unwrap_err();
+        assert!(error.contains("image"));
+    }
+}

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -1,1 +1,2 @@
+pub mod minimax;
 pub mod zai_anthropic;

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -98,6 +98,7 @@ pub struct AppState {
     pub upstream_proxy: Arc<tokio::sync::RwLock<crate::proxy::config::UpstreamProxyConfig>>,
     pub upstream: Arc<crate::proxy::upstream::client::UpstreamClient>,
     pub zai: Arc<RwLock<crate::proxy::ZaiConfig>>,
+    pub minimax: Arc<RwLock<crate::proxy::MiniMaxConfig>>,
     pub provider_rr: Arc<AtomicUsize>,
     pub zai_vision_mcp: Arc<crate::proxy::zai_vision_mcp::ZaiVisionMcpState>,
     pub monitor: Arc<crate::proxy::monitor::ProxyMonitor>,
@@ -264,6 +265,7 @@ pub struct AxumServer {
     upstream: Arc<crate::proxy::upstream::client::UpstreamClient>,
     security_state: Arc<RwLock<crate::proxy::ProxySecurityConfig>>,
     zai_state: Arc<RwLock<crate::proxy::ZaiConfig>>,
+    minimax_state: Arc<RwLock<crate::proxy::MiniMaxConfig>>,
     experimental: Arc<RwLock<crate::proxy::config::ExperimentalConfig>>,
     debug_logging: Arc<RwLock<crate::proxy::config::DebugLoggingConfig>>,
     #[allow(dead_code)] // 预留给 cloudflared 运行状态查询与后续控制
@@ -321,6 +323,12 @@ impl AxumServer {
         tracing::info!("z.ai 配置已热更新");
     }
 
+    pub async fn update_minimax(&self, config: &crate::proxy::config::ProxyConfig) {
+        let mut minimax = self.minimax_state.write().await;
+        *minimax = config.minimax.clone();
+        tracing::info!("MiniMax configuration hot-reloaded");
+    }
+
     pub async fn update_experimental(&self, config: &crate::proxy::config::ProxyConfig) {
         let mut exp = self.experimental.write().await;
         *exp = config.experimental.clone();
@@ -357,6 +365,7 @@ impl AxumServer {
         user_agent_override: Option<String>,
         security_config: crate::proxy::ProxySecurityConfig,
         zai_config: crate::proxy::ZaiConfig,
+        minimax_config: crate::proxy::MiniMaxConfig,
         monitor: Arc<crate::proxy::monitor::ProxyMonitor>,
         experimental_config: crate::proxy::config::ExperimentalConfig,
         debug_logging: crate::proxy::config::DebugLoggingConfig,
@@ -375,6 +384,7 @@ impl AxumServer {
         proxy_pool_manager.clone().start_health_check_loop();
         let security_state = Arc::new(RwLock::new(security_config));
         let zai_state = Arc::new(RwLock::new(zai_config));
+        let minimax_state = Arc::new(RwLock::new(minimax_config));
         let provider_rr = Arc::new(AtomicUsize::new(0));
         let zai_vision_mcp_state = Arc::new(crate::proxy::zai_vision_mcp::ZaiVisionMcpState::new());
         let experimental_state = Arc::new(RwLock::new(experimental_config));
@@ -401,6 +411,7 @@ impl AxumServer {
                 u
             },
             zai: zai_state.clone(),
+            minimax: minimax_state.clone(),
             provider_rr: provider_rr.clone(),
             zai_vision_mcp: zai_vision_mcp_state,
             monitor: monitor.clone(),
@@ -822,6 +833,7 @@ impl AxumServer {
             upstream: state.upstream.clone(),
             security_state,
             zai_state,
+            minimax_state,
             experimental: experimental_state.clone(),
             debug_logging: debug_logging_state.clone(),
             cloudflared_state,
@@ -1455,6 +1467,12 @@ async fn admin_save_config(
     {
         let mut zai = state.zai.write().await;
         *zai = new_config.clone().proxy.zai;
+    }
+
+    // Update MiniMax configuration.
+    {
+        let mut minimax = state.minimax.write().await;
+        *minimax = new_config.clone().proxy.minimax;
     }
 
     // 更新实验性配置

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -704,6 +704,19 @@
           "auto": "Auto (Recommended)"
         }
       },
+      "minimax": {
+        "title": "MiniMax Provider",
+        "region": "Region",
+        "regions": {
+          "global_en": "Global",
+          "cn_zh": "China"
+        },
+        "api_key": "API Key",
+        "api_key_placeholder": "Enter the MiniMax API key",
+        "openai_base_url": "OpenAI-compatible base URL",
+        "anthropic_base_url": "Anthropic-compatible base URL",
+        "context_window": "Context window"
+      },
       "zai": {
         "title": "z.ai (GLM) Provider",
         "title_tooltip": "Optional Anthropic-compatible upstream for Claude protocol. Only affects Anthropic endpoints; Google account routing remains unchanged.",

--- a/src/pages/ApiProxy.tsx
+++ b/src/pages/ApiProxy.tsx
@@ -858,6 +858,31 @@ export default function ApiProxy() {
         saveConfig(newConfig);
     };
 
+    const updateMiniMaxConfig = (updates: Partial<NonNullable<ProxyConfig['minimax']>>) => {
+        if (!appConfig?.proxy.minimax) return;
+        const newConfig = {
+            ...appConfig,
+            proxy: {
+                ...appConfig.proxy,
+                minimax: {
+                    ...appConfig.proxy.minimax,
+                    ...updates
+                }
+            }
+        };
+        saveConfig(newConfig);
+    };
+
+    const updateMiniMaxEndpoints = (updates: Partial<NonNullable<ProxyConfig['minimax']>['endpoints']>) => {
+        if (!appConfig?.proxy.minimax) return;
+        updateMiniMaxConfig({
+            endpoints: {
+                ...appConfig.proxy.minimax.endpoints,
+                ...updates
+            }
+        });
+    };
+
     const handleToggle = async () => {
         if (!appConfig) return;
         setLoading(true);
@@ -1532,6 +1557,113 @@ print(response.choices[0].message.content)`;
                                     apiKey={appConfig.proxy.api_key}
                                 />
                             </CollapsibleCard>
+
+                            {appConfig.proxy.minimax && (
+                                <CollapsibleCard
+                                    title={t('proxy.config.minimax.title')}
+                                    icon={<BrainCircuit size={18} className="text-violet-500" />}
+                                    enabled={appConfig.proxy.minimax.enabled}
+                                    onToggle={(checked) => updateMiniMaxConfig({ enabled: checked })}
+                                >
+                                    <div className="space-y-4">
+                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                            <div className="space-y-1">
+                                                <label className="text-[11px] font-medium text-gray-500 dark:text-gray-400">
+                                                    {t('proxy.config.minimax.region')}
+                                                </label>
+                                                <select
+                                                    className="select select-sm select-bordered w-full text-xs"
+                                                    value={appConfig.proxy.minimax.region}
+                                                    onChange={(event) => updateMiniMaxConfig({ region: event.target.value as NonNullable<ProxyConfig['minimax']>['region'] })}
+                                                >
+                                                    <option value="global_en">{t('proxy.config.minimax.regions.global_en')}</option>
+                                                    <option value="cn_zh">{t('proxy.config.minimax.regions.cn_zh')}</option>
+                                                </select>
+                                            </div>
+                                            <div className="space-y-1">
+                                                <label className="text-[11px] font-medium text-gray-500 dark:text-gray-400">
+                                                    {t('proxy.config.minimax.api_key')}
+                                                </label>
+                                                <input
+                                                    type="password"
+                                                    value={appConfig.proxy.minimax.api_key}
+                                                    onChange={(event) => updateMiniMaxConfig({ api_key: event.target.value })}
+                                                    placeholder={t('proxy.config.minimax.api_key_placeholder')}
+                                                    className="input input-sm input-bordered w-full font-mono text-xs"
+                                                />
+                                            </div>
+                                        </div>
+
+                                        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+                                            <div className="space-y-3 rounded-lg border border-gray-100 dark:border-base-200 p-3">
+                                                <h4 className="text-[11px] font-bold text-gray-400 uppercase tracking-widest">
+                                                    {t('proxy.config.minimax.regions.global_en')}
+                                                </h4>
+                                                <label className="block space-y-1">
+                                                    <span className="text-[10px] text-gray-500">{t('proxy.config.minimax.openai_base_url')}</span>
+                                                    <input
+                                                        type="url"
+                                                        className="input input-xs input-bordered w-full font-mono"
+                                                        value={appConfig.proxy.minimax.endpoints.global_openai_base_url}
+                                                        onChange={(event) => updateMiniMaxEndpoints({ global_openai_base_url: event.target.value })}
+                                                    />
+                                                </label>
+                                                <label className="block space-y-1">
+                                                    <span className="text-[10px] text-gray-500">{t('proxy.config.minimax.anthropic_base_url')}</span>
+                                                    <input
+                                                        type="url"
+                                                        className="input input-xs input-bordered w-full font-mono"
+                                                        value={appConfig.proxy.minimax.endpoints.global_anthropic_base_url}
+                                                        onChange={(event) => updateMiniMaxEndpoints({ global_anthropic_base_url: event.target.value })}
+                                                    />
+                                                </label>
+                                            </div>
+                                            <div className="space-y-3 rounded-lg border border-gray-100 dark:border-base-200 p-3">
+                                                <h4 className="text-[11px] font-bold text-gray-400 uppercase tracking-widest">
+                                                    {t('proxy.config.minimax.regions.cn_zh')}
+                                                </h4>
+                                                <label className="block space-y-1">
+                                                    <span className="text-[10px] text-gray-500">{t('proxy.config.minimax.openai_base_url')}</span>
+                                                    <input
+                                                        type="url"
+                                                        className="input input-xs input-bordered w-full font-mono"
+                                                        value={appConfig.proxy.minimax.endpoints.cn_openai_base_url}
+                                                        onChange={(event) => updateMiniMaxEndpoints({ cn_openai_base_url: event.target.value })}
+                                                    />
+                                                </label>
+                                                <label className="block space-y-1">
+                                                    <span className="text-[10px] text-gray-500">{t('proxy.config.minimax.anthropic_base_url')}</span>
+                                                    <input
+                                                        type="url"
+                                                        className="input input-xs input-bordered w-full font-mono"
+                                                        value={appConfig.proxy.minimax.endpoints.cn_anthropic_base_url}
+                                                        onChange={(event) => updateMiniMaxEndpoints({ cn_anthropic_base_url: event.target.value })}
+                                                    />
+                                                </label>
+                                            </div>
+                                        </div>
+
+                                        <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+                                            {appConfig.proxy.minimax.models.map((model) => (
+                                                <div key={model.model_id} className="rounded-lg bg-gray-50 dark:bg-base-200/50 p-3 text-xs space-y-2">
+                                                    <div className="font-semibold text-gray-800 dark:text-gray-100">{model.model_id}</div>
+                                                    <div className="text-gray-500">
+                                                        {t('proxy.config.minimax.context_window')}: {model.context_window.toLocaleString()}
+                                                    </div>
+                                                    <div className="flex flex-wrap gap-1">
+                                                        {model.input_modalities.map((modality) => (
+                                                            <span key={modality} className="badge badge-sm badge-ghost">{modality}</span>
+                                                        ))}
+                                                        {model.thinking.map((mode) => (
+                                                            <span key={mode} className="badge badge-sm badge-secondary">{mode}</span>
+                                                        ))}
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                </CollapsibleCard>
+                            )}
 
                             {/* z.ai (GLM) Dispatcher */}
                             <CollapsibleCard

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -17,6 +17,7 @@ export interface ProxyConfig {
     debug_logging?: DebugLoggingConfig;
     upstream_proxy: UpstreamProxyConfig;
     zai?: ZaiConfig;
+    minimax?: MiniMaxConfig;
     scheduling?: StickySessionConfig;
     experimental?: ExperimentalConfig;
     user_agent_override?: string;
@@ -94,6 +95,39 @@ export interface ZaiConfig {
     model_mapping?: Record<string, string>;
     models: ZaiModelDefaults;
     mcp: ZaiMcpConfig;
+}
+
+export type MiniMaxRegion = 'global_en' | 'cn_zh';
+
+export interface MiniMaxRegionalEndpoints {
+    global_openai_base_url: string;
+    global_anthropic_base_url: string;
+    cn_openai_base_url: string;
+    cn_anthropic_base_url: string;
+}
+
+export interface MiniMaxPricing {
+    input: number;
+    output: number;
+    cache_read: number;
+    cache_write: number | null;
+}
+
+export interface MiniMaxModelConfig {
+    model_id: string;
+    context_window: number;
+    pricing_usd_per_million_tokens: MiniMaxPricing;
+    input_modalities: string[];
+    thinking: string[];
+}
+
+export interface MiniMaxConfig {
+    enabled: boolean;
+    api_key: string;
+    region: MiniMaxRegion;
+    endpoints: MiniMaxRegionalEndpoints;
+    model_mapping?: Record<string, string>;
+    models: MiniMaxModelConfig[];
 }
 
 export interface ScheduledWarmupConfig {


### PR DESCRIPTION
## Summary

- add configurable MiniMax provider routing for OpenAI-compatible and Anthropic-compatible proxy requests
- support global and China endpoints, MiniMax-M3 and MiniMax-M2.7 metadata, model mapping, thinking validation, and modality validation
- expose MiniMax configuration and model metadata in the proxy UI and model listings

## Validation

- `git diff --check`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml minimax --lib`
- `npm run build`
- secret scan on `git diff HEAD --no-ext-diff`