### PR TITLE
fix(claude): treat gemini-pro-agent as a thinking model to fix thought_signature 400

### DIFF
--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -495,7 +495,7 @@ pub fn transform_claude_request_in(
     // Only models with "-thinking" suffix or Claude models support thinking
     // Regular Gemini models (gemini-2.5-flash, gemini-2.5-pro) do NOT support thinking
     // [FIX #1557] Allow "pro" models (e.g. gemini-3-pro, gemini-2.0-pro) to be recognized as thinking capable
-    let target_model_supports_thinking = model_supports_thinking(mapped_model);
+    let target_model_supports_thinking = model_supports_thinking(&mapped_model);
 
     if is_thinking_enabled && !target_model_supports_thinking {
         tracing::warn!(
@@ -558,7 +558,7 @@ pub fn transform_claude_request_in(
         {
             // [FIX #2167] Flash / gemini-pro-agent 无签名时使用哨兵值而不是禁用 thinking
             // 禁用 thinking 会导致模型失去思考能力，哨兵值可让 Gemini 跳过签名校验
-            if model_keeps_thinking_without_signature(mapped_model) {
+            if model_keeps_thinking_without_signature(&mapped_model) {
                 tracing::info!(
                     "[Thinking-Mode] [FIX #2167] No signature for model function calls. \
                      Will rely on sentinel injection in build_contents."
@@ -3230,7 +3230,7 @@ mod tests {
 
         // Regular non-thinking Gemini models stay excluded.
         assert!(!model_supports_thinking("gemini-2.5-pro"));
-        assert!(!model_supports_thinking("gemini-2.5-flash-lite"));
+        assert!(!model_supports_thinking("gemini-1.5-pro"));
     }
 
     #[test]

--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -495,13 +495,7 @@ pub fn transform_claude_request_in(
     // Only models with "-thinking" suffix or Claude models support thinking
     // Regular Gemini models (gemini-2.5-flash, gemini-2.5-pro) do NOT support thinking
     // [FIX #1557] Allow "pro" models (e.g. gemini-3-pro, gemini-2.0-pro) to be recognized as thinking capable
-    let target_model_supports_thinking = mapped_model.contains("-thinking")
-        || mapped_model.starts_with("claude-")
-        || mapped_model.contains("gemini-2.0-pro")
-        || (mapped_model.contains("gemini-3-pro") && !mapped_model.contains("-high") && !mapped_model.contains("-low"))
-        || (mapped_model.contains("gemini-3.1-pro") && !mapped_model.contains("-high") && !mapped_model.contains("-low"))
-        // [FIX #2167] gemini-*-flash 支持 thinking，必须纳入识别范围
-        || (mapped_model.contains("gemini") && (mapped_model.contains("flash") || mapped_model.contains("-flash-")));
+    let target_model_supports_thinking = model_supports_thinking(mapped_model);
 
     if is_thinking_enabled && !target_model_supports_thinking {
         tracing::warn!(
@@ -562,13 +556,11 @@ pub fn transform_claude_request_in(
                 &session_id,
             )
         {
-            // [FIX #2167] Flash 模型无签名时使用哨兵值而不是禁用 thinking
+            // [FIX #2167] Flash / gemini-pro-agent 无签名时使用哨兵值而不是禁用 thinking
             // 禁用 thinking 会导致模型失去思考能力，哨兵值可让 Gemini 跳过签名校验
-            let is_flash_model = mapped_model.contains("gemini-3-flash")
-                || mapped_model.contains("gemini-3.1-flash");
-            if is_flash_model {
+            if model_keeps_thinking_without_signature(mapped_model) {
                 tracing::info!(
-                    "[Thinking-Mode] [FIX #2167] No signature for flash model function calls. \
+                    "[Thinking-Mode] [FIX #2167] No signature for model function calls. \
                      Will rely on sentinel injection in build_contents."
                 );
                 // 保持 is_thinking_enabled = true，由 build_contents 内的哨兵处理覆盖
@@ -772,6 +764,42 @@ fn should_enable_thinking_by_default(model: &str) -> bool {
     }
 
     false
+}
+
+/// Whether the mapped target model supports Gemini `thinkingConfig`.
+///
+/// `gemini-pro-agent` is the mapped target of `gemini-3.1-pro-high` /
+/// `gemini-3-pro-high` (`model_mapping.rs`) and is a forced-thinking Pro agent
+/// model. It is kept in sync with the OpenAI protocol path
+/// (`openai/request.rs` `is_gemini_3_thinking` includes `-pro-agent`) and the
+/// model spec `SPEC_PRO_AGENT { include_thoughts: true }` (`variant_mapping.rs`).
+fn model_supports_thinking(mapped_model: &str) -> bool {
+    mapped_model.contains("-thinking")
+        || mapped_model.starts_with("claude-")
+        || mapped_model.contains("gemini-2.0-pro")
+        || mapped_model.contains("gemini-pro-agent")
+        || (mapped_model.contains("gemini-3-pro")
+            && !mapped_model.contains("-high")
+            && !mapped_model.contains("-low"))
+        || (mapped_model.contains("gemini-3.1-pro")
+            && !mapped_model.contains("-high")
+            && !mapped_model.contains("-low"))
+        // [FIX #2167] gemini-*-flash 支持 thinking，必须纳入识别范围
+        || (mapped_model.contains("gemini")
+            && (mapped_model.contains("flash") || mapped_model.contains("-flash-")))
+}
+
+/// Whether a model should keep thinking enabled (and rely on the
+/// `skip_thought_signature_validator` sentinel injected by `build_contents`)
+/// when no valid signature is available, instead of disabling thinking.
+///
+/// `gemini-pro-agent` is a forced-thinking model: disabling thinking leaves
+/// historical `functionCall` parts without `thought_signature`, which Gemini
+/// rejects with HTTP 400.
+fn model_keeps_thinking_without_signature(mapped_model: &str) -> bool {
+    mapped_model.contains("gemini-3-flash")
+        || mapped_model.contains("gemini-3.1-flash")
+        || mapped_model.contains("gemini-pro-agent")
 }
 
 /// Minimum length for a valid thought_signature
@@ -3184,5 +3212,35 @@ mod tests {
             "Older Gemini models should NOT have mixed tools"
         );
         assert!(has_functions);
+    }
+
+    #[test]
+    fn test_model_supports_thinking() {
+        // gemini-pro-agent is the mapped target of gemini-3.1-pro-high /
+        // gemini-3-pro-high and is a forced-thinking Pro agent model.
+        assert!(model_supports_thinking("gemini-pro-agent"));
+        assert!(model_supports_thinking("gemini-3-pro"));
+        assert!(model_supports_thinking("gemini-3-pro-preview"));
+        assert!(model_supports_thinking("gemini-3.1-pro"));
+        assert!(model_supports_thinking("gemini-3.1-pro-preview"));
+        assert!(model_supports_thinking("gemini-2.0-pro"));
+        assert!(model_supports_thinking("gemini-3-flash"));
+        assert!(model_supports_thinking("gemini-3.1-flash"));
+        assert!(model_supports_thinking("claude-opus-4-6-thinking"));
+
+        // Regular non-thinking Gemini models stay excluded.
+        assert!(!model_supports_thinking("gemini-2.5-pro"));
+        assert!(!model_supports_thinking("gemini-2.5-flash-lite"));
+    }
+
+    #[test]
+    fn test_model_keeps_thinking_without_signature() {
+        assert!(model_keeps_thinking_without_signature("gemini-3-flash"));
+        assert!(model_keeps_thinking_without_signature("gemini-3.1-flash"));
+        assert!(model_keeps_thinking_without_signature("gemini-pro-agent"));
+        assert!(!model_keeps_thinking_without_signature("gemini-3.1-pro"));
+        assert!(!model_keeps_thinking_without_signature(
+            "gemini-3.1-pro-preview"
+        ));
     }
 }


### PR DESCRIPTION
## 关联 Issue
Closes #3288

## 问题
Claude Code CLI 使用 `gemini-3.1-pro-high`（会被 `model_mapping.rs` 映射为 `gemini-pro-agent`）时，多轮工具调用出现：

```
API Error: 400 Function call is missing a thought_signature in functionCall parts. ...
Additional data, function call `default_api:Skill`, position 2.
```

## 根因
- `gemini-3.1-pro-high` / `gemini-3-pro-high` 在 Claude 协议路径被映射为 `gemini-pro-agent`（`src-tauri/src/proxy/common/model_mapping.rs:78,82`）。
- `target_model_supports_thinking`（`src-tauri/src/proxy/mappers/claude/request.rs`）从未把 `gemini-pro-agent` 识别为思考模型 → thinking 被强制关闭 → `functionCall` 不带 `thought_signature` → Gemini 3.1 返回 400。
- 这与项目自身其他路径不一致：
  - OpenAI 协议路径 `openai/request.rs` 的 `is_gemini_3_thinking` 明确包含 `-pro-agent` / `gemini-pro`；
  - 模型规格 `variant_mapping.rs` 的 `SPEC_PRO_AGENT { include_thoughts: true }`。

## 修改
1. 抽出 `model_supports_thinking()`，并把 `gemini-pro-agent` 纳入 thinking-capable（与 OpenAI 路径及 `SPEC_PRO_AGENT` 对齐）。
2. 抽出 `model_keeps_thinking_without_signature()`：无签名兜底时，`gemini-pro-agent` 与 flash 模型一样“保持 thinking + 由 build_contents 注入 `skip_thought_signature_validator` 哨兵”，而不是关闭 thinking（避免历史 functionCall 缺签名再次 400）。
3. 保留 v4.2.3 对字面 `-high/-low` 名字的排除（那是 Issue #3182 的 workaround，不做改动，避免复发 Invalid Argument）。
4. 补充单元测试。

## 验证
- `rustfmt --check`（本文件）通过。
- 本地 `cargo test --lib proxy::mappers::claude::request`：本次新增的两个测试通过；模块内另有 4 个失败为 v4.5.2 既存问题（`test_claude_adaptive_global_config` 在上游 v4.5.2 单独运行同样失败；其余 3 个为共享全局配置导致的顺序 flake，单独运行通过），与本次改动无关。
- CI：`cargo fmt -- --check` / `cargo clippy --all-targets --all-features` / `cargo test`。

## 兼容性说明
- 只影响 Claude 协议 mapper 的 thinking 判定，不影响 OpenAI 协议路径。
- 该改动使 `gemini-3.1-pro-high`（`gemini-pro-agent`）恢复思考能力并正确携带/注入 `thought_signature`；不触碰 `-high/-low` 排除逻辑。
