### PR TITLE
fix: repair Dockerfile.backend local build

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,4 +1,5 @@
 # --- Backend Build Stage (no frontend build) ---
+ARG FRONTEND_IMAGE=antigravity-manager:latest
 FROM rust:1-slim-bookworm AS backend-builder
 ARG USE_MIRROR=auto
 
@@ -25,6 +26,12 @@ RUN apt-get update && apt-get install -y \
     librsvg2-dev \
     libsoup-3.0-dev \
     libjavascriptcoregtk-4.1-dev \
+    perl \
+    cmake \
+    golang-go \
+    clang \
+    libclang-dev \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Use Aliyun mirror for Cargo if needed (Sparse Index)
@@ -40,6 +47,10 @@ RUN if [ "$USE_MIRROR" = "true" ] || ( [ "$USE_MIRROR" = "auto" ] && ! timeout 3
 WORKDIR /app
 COPY src-tauri ./src-tauri
 COPY src/locales ./src/locales
+
+# tauri::generate_context! requires ../dist to exist at compile time.
+# The real frontend dist is provided at runtime via ABV_DIST_PATH.
+RUN mkdir -p /app/dist && echo '<html><body>placeholder</body></html>' > /app/dist/index.html
 
 WORKDIR /app/src-tauri
 RUN --mount=type=cache,target=/root/.cargo/registry \


### PR DESCRIPTION
## 问题 / Problem

`docker/Dockerfile.backend`（`docker-compose.backend.yml` 使用的本地构建路径）当前无法构建成功，三处问题。注：release 流程使用的 `docker/Dockerfile` 不受影响（本就包含完整依赖），此修复仅针对本地/自托管构建路径。

Refs: https://github.com/lbjlaq/Antigravity-Manager/issues/3294

### 1. 缺 boring-sys2 编译工具链

rquest 依赖 boring-sys2 4.x，其 build script 需要 `git`（`ensure_patches_applied` 执行 `git init` + apply patches）、`cmake`、Go 等，builder stage 未安装导致 panic：

```
thread 'main' panicked at boring-sys2-4.15.15/build/main.rs:573:44:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

**修复**：builder stage 依赖与 `docker/Dockerfile` 对齐，补齐 `perl cmake golang-go clang libclang-dev git`。

### 2. `tauri::generate_context!` 编译期要求 `../dist` 存在

backend 构建不包含前端，proc macro 直接 panic：

```
error: proc macro panicked
  --> src/lib.rs:614:16
   = help: message: The `frontendDist` configuration is set to `"../dist"` but this path doesn't exist
```

**修复**：`cargo build` 前创建占位 `/app/dist/index.html`。运行时静态资源由 `ABV_DIST_PATH=/app/dist`（从 `FRONTEND_IMAGE` 复制的真实 dist）提供，占位符无功能影响。

### 3. `FRONTEND_IMAGE` ARG 声明位置不兼容新版 BuildKit

ARG 在两个 stage 之间声明，新版 BuildKit（Docker 29.x）在第二个 `FROM` 处求值为空：

```
ERROR: failed to solve: base name (${FRONTEND_IMAGE}) should not be blank
```

**修复**：将 `ARG FRONTEND_IMAGE` 前移到首个 `FROM` 之前（对旧版 BuildKit 同样兼容）。

## 测试 / Testing

- 修复后 `docker build -f docker/Dockerfile.backend` 完整通过（debian bookworm，`rust:1-slim-bookworm` builder）
- 产出镜像 headless 运行正常（`/health` 200），Gemini API 端到端验证通过
