### PR TITLE
feat: Add 5H/Weekly quota view switcher & refactor Smart Warmup to be 7-Day Weekly Reset-Aware

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -362,10 +362,9 @@ pub fn run() {
 
                     info!("Headless proxy service is running.");
 
-                    // [DISABLED] Start smart scheduler (Automatic warmup disabled as per user request)
-                    // modules::scheduler::start_scheduler(None, proxy_state.clone());
-                    info!("Smart scheduler (Automatic Warmup) is DISABLED.");
-                    info!("Smart scheduler started in headless mode.");
+                    // Start smart scheduler for 7-day weekly reset warmup
+                    modules::scheduler::start_scheduler(None, proxy_state.clone());
+                    info!("Smart scheduler (7-Day Weekly Reset Warmup) started in headless mode.");
                 }
                 Err(e) => {
                     error!("Failed to load config for headless mode: {}", e);
@@ -488,10 +487,10 @@ pub fn run() {
                 }
             });
 
-            // [DISABLED] Start smart scheduler (Automatic warmup disabled as per user request)
-            // let scheduler_state = app.handle().state::<commands::proxy::ProxyServiceState>();
-            // modules::scheduler::start_scheduler(Some(app.handle().clone()), scheduler_state.inner().clone());
-            info!("Smart scheduler (Automatic Warmup) is DISABLED.");
+            // Start smart scheduler for 7-day weekly reset warmup
+            let scheduler_state = app.handle().state::<commands::proxy::ProxyServiceState>();
+            modules::scheduler::start_scheduler(Some(app.handle().clone()), scheduler_state.inner().clone());
+            info!("Smart scheduler (7-Day Weekly Reset Warmup) initialized.");
 
             // [PHASE 1] 已整合至 Axum 端口 (8045)，不再单独启动 19527 端口
             info!("Management API integrated into main proxy server (port 8045)");

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -2057,11 +2057,10 @@ pub async fn refresh_all_quotas_logic() -> Result<RefreshStats, String> {
         elapsed.as_millis()
     ));
 
-    // After quota refresh, immediately check and trigger warmup for recovered models
-    // [Disabled] Automatic warmup is temporarily disabled
-    // tokio::spawn(async {
-    //     check_and_trigger_warmup_for_recovered_models().await;
-    // });
+    // After quota refresh, immediately check and trigger warmup for weekly recovered models
+    tokio::spawn(async {
+        check_and_trigger_warmup_for_recovered_models().await;
+    });
 
     Ok(RefreshStats {
         total,

--- a/src-tauri/src/modules/scheduler.rs
+++ b/src-tauri/src/modules/scheduler.rs
@@ -1,13 +1,13 @@
 use crate::models::Account;
 use crate::modules::{account, config, logger, quota};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use tokio::time::{self, Duration};
 
-// Warmup history: key = "email:model_name:100", value = warmup timestamp
+// Warmup history: key = "email:bucket_or_model:weekly:cycle_id", value = warmup timestamp
 static WARMUP_HISTORY: Lazy<Mutex<HashMap<String, i64>>> =
     Lazy::new(|| Mutex::new(load_warmup_history()));
 
@@ -50,15 +50,30 @@ pub fn check_cooldown(key: &str, cooldown_seconds: i64) -> bool {
     }
 }
 
+/// Helper to parse ISO8601 / RFC3339 string to timestamp
+fn parse_reset_time_ts(s: &str) -> Option<i64> {
+    if s.is_empty() {
+        return None;
+    }
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.timestamp());
+    }
+    if let Ok(dt) = DateTime::parse_from_str(s, "%Y/%m/%d %H:%M:%S") {
+        return Some(dt.timestamp());
+    }
+    None
+}
+
+/// Start smart weekly scheduler
 pub fn start_scheduler(
     app_handle: Option<tauri::AppHandle>,
     proxy_state: crate::commands::proxy::ProxyServiceState,
 ) {
     tauri::async_runtime::spawn(async move {
-        logger::log_info("Smart Warmup Scheduler started. Monitoring quota at 100%...");
+        logger::log_info("[Scheduler] Weekly Reset Warmup Scheduler started. Monitoring 7-day quota windows...");
 
-        // Scan every 10 minutes
-        let mut interval = time::interval(Duration::from_secs(600));
+        // Scan every 5 minutes (300s) to check for accounts reaching weekly reset time
+        let mut interval = time::interval(Duration::from_secs(300));
 
         loop {
             interval.tick().await;
@@ -68,11 +83,11 @@ pub fn start_scheduler(
                 continue;
             };
 
-            if !app_config.auto_refresh {
+            // Must be enabled by user in Settings
+            if !app_config.scheduled_warmup.enabled {
                 continue;
             }
 
-            // Get all accounts (no longer filtering by level)
             let Ok(accounts) = account::list_accounts() else {
                 continue;
             };
@@ -81,186 +96,152 @@ pub fn start_scheduler(
                 continue;
             }
 
-            logger::log_info(&format!(
-                "[Scheduler] Scanning {} accounts for 100% quota models...",
-                accounts.len()
-            ));
+            let now_ts = Utc::now().timestamp();
+            let mut tasks_to_run = Vec::new();
 
-            let mut warmup_tasks = Vec::new();
-            let mut skipped_cooldown = 0;
+            for acc in &accounts {
+                if acc.disabled || acc.proxy_disabled {
+                    continue;
+                }
 
-            // Scan each model for each account
-            for account in &accounts {
-                // Get valid token
-                let Ok((token, pid)) = quota::get_valid_token_for_warmup(account).await else {
+                let Ok((token, pid)) = quota::get_valid_token_for_warmup(acc).await else {
                     continue;
                 };
 
-                // Get fresh quota
                 let Ok((fresh_quota, _)) = quota::fetch_quota_with_cache(
                     &token,
-                    &account.email,
+                    &acc.email,
                     Some(&pid),
-                    Some(&account.id),
+                    Some(&acc.id),
                 )
                 .await
                 else {
                     continue;
                 };
 
-                // [FIX] 预热阶段检测到 403 时，使用统一禁用逻辑，确保账号文件和索引同时更新
                 if fresh_quota.is_forbidden {
-                    logger::log_warn(&format!(
-                        "[Scheduler] Account {} returned 403 Forbidden during quota fetch, marking as forbidden",
-                        account.email
-                    ));
-                    let _ = account::mark_account_forbidden(
-                        &account.id,
-                        "Scheduler: 403 Forbidden - quota fetch denied",
-                    );
                     continue;
                 }
 
-                let now_ts = Utc::now().timestamp();
+                // Check quota_groups for WEEKLY buckets
+                if let Some(groups) = &fresh_quota.quota_groups {
+                    for group in groups {
+                        for bucket in &group.buckets {
+                            let is_weekly = bucket.window.to_lowercase().contains("week")
+                                || bucket.bucket_id.to_lowercase().contains("week");
+                            if !is_weekly {
+                                continue;
+                            }
 
-                for model in fresh_quota.models {
-                    // Core logic: detect 100% quota
-                    if model.percentage == 100 {
-                        let model_to_ping = model.name.clone();
+                            // If fraction is 1.0 (100% full)
+                            if bucket.remaining_fraction >= 0.999 {
+                                if let Some(reset_ts) = parse_reset_time_ts(&bucket.reset_time) {
+                                    // Check if current time has passed reset_time (with 1 minute buffer)
+                                    if now_ts >= reset_ts - 60 {
+                                        let history_key = format!(
+                                            "{}:{}:weekly:{}",
+                                            acc.email, bucket.bucket_id, reset_ts
+                                        );
+                                        // 6-day cooldown for the same weekly cycle
+                                        if !check_cooldown(&history_key, 6 * 86400) {
+                                            // Pick representative model for this group
+                                            let model_to_ping = if bucket
+                                                .bucket_id
+                                                .contains("3p")
+                                                || group.display_name.contains("Claude")
+                                            {
+                                                "claude-sonnet-4-6".to_string()
+                                            } else {
+                                                "gemini-3-flash".to_string()
+                                            };
 
-                        // Only warmup models configured by user (allowlist)
-                        if !app_config
-                            .scheduled_warmup
-                            .monitored_models
-                            .contains(&model_to_ping)
-                        {
-                            continue;
-                        }
-
-                        // Use mapped name as key
-                        let history_key = format!("{}:{}:100", account.email, model_to_ping);
-
-                        // Check cooldown: do not repeat warmup within 4 hours
-                        {
-                            let history = WARMUP_HISTORY.lock().unwrap();
-                            if let Some(&last_warmup_ts) = history.get(&history_key) {
-                                let cooldown_seconds = 14400;
-                                if now_ts - last_warmup_ts < cooldown_seconds {
-                                    skipped_cooldown += 1;
-                                    continue;
+                                            tasks_to_run.push((
+                                                acc.id.clone(),
+                                                acc.email.clone(),
+                                                model_to_ping,
+                                                token.clone(),
+                                                pid.clone(),
+                                                history_key,
+                                            ));
+                                        }
+                                    }
                                 }
                             }
                         }
-
-                        warmup_tasks.push((
-                            account.id.clone(),
-                            account.email.clone(),
-                            model_to_ping.clone(),
-                            token.clone(),
-                            pid.clone(),
-                            model.percentage,
-                            history_key.clone(),
-                        ));
-
-                        logger::log_info(&format!(
-                            "[Scheduler] ✓ Scheduled warmup: {} @ {} (quota at 100%)",
-                            model_to_ping, account.email
-                        ));
-                    } else if model.percentage < 100 {
-                        // Quota not full, clear history, need to map name first
-                        let model_to_ping = model.name.clone();
-                        let history_key = format!("{}:{}:100", account.email, model_to_ping);
-
-                        let mut history = WARMUP_HISTORY.lock().unwrap();
-                        if history.remove(&history_key).is_some() {
-                            save_warmup_history(&history);
-                            logger::log_info(&format!(
-                                "[Scheduler] Cleared history for {} @ {} (quota: {}%)",
-                                model_to_ping, account.email, model.percentage
-                            ));
+                    }
+                } else {
+                    // Fallback to models if quota_groups is not populated
+                    for model in &fresh_quota.models {
+                        if model.percentage == 100 {
+                            if !app_config
+                                .scheduled_warmup
+                                .monitored_models
+                                .contains(&model.name)
+                            {
+                                continue;
+                            }
+                            if let Some(reset_ts) = parse_reset_time_ts(&model.reset_time) {
+                                if now_ts >= reset_ts - 60 {
+                                    let history_key = format!(
+                                        "{}:{}:weekly:{}",
+                                        acc.email, model.name, reset_ts
+                                    );
+                                    if !check_cooldown(&history_key, 6 * 86400) {
+                                        tasks_to_run.push((
+                                            acc.id.clone(),
+                                            acc.email.clone(),
+                                            model.name.clone(),
+                                            token.clone(),
+                                            pid.clone(),
+                                            history_key,
+                                        ));
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
 
-            // Execute warmup tasks
-            if !warmup_tasks.is_empty() {
-                let total = warmup_tasks.len();
-                if skipped_cooldown > 0 {
-                    logger::log_info(&format!(
-                        "[Scheduler] Skipped {} models in cooldown, will warmup {}",
-                        skipped_cooldown, total
-                    ));
-                }
+            // Execute weekly warmup tasks
+            if !tasks_to_run.is_empty() {
                 logger::log_info(&format!(
-                    "[Scheduler] 🔥 Triggering {} warmup tasks...",
-                    total
+                    "[Scheduler] 🎯 Reached weekly reset for {} account targets. Triggering warmup...",
+                    tasks_to_run.len()
                 ));
 
                 let handle_for_warmup = app_handle.clone();
                 let state_for_warmup = proxy_state.clone();
 
                 tokio::spawn(async move {
-                    let mut success = 0;
-                    let batch_size = 3;
-                    let now_ts = chrono::Utc::now().timestamp();
+                    for (acc_id, email, model, token, pid, history_key) in tasks_to_run {
+                        logger::log_info(&format!(
+                            "[WeeklyWarmup] 🚀 Triggering weekly warmup for {} @ {}",
+                            model, email
+                        ));
 
-                    for (batch_idx, batch) in warmup_tasks.chunks(batch_size).enumerate() {
-                        let mut handles = Vec::new();
+                        let success = quota::warmup_model_directly(
+                            &token,
+                            &model,
+                            &pid,
+                            &email,
+                            100,
+                            Some(&acc_id),
+                        )
+                        .await;
 
-                        for (task_idx, (id, email, model, token, pid, pct, history_key)) in
-                            batch.iter().enumerate()
-                        {
-                            let global_idx = batch_idx * batch_size + task_idx + 1;
-                            let id = id.clone();
-                            let email = email.clone();
-                            let model = model.clone();
-                            let token = token.clone();
-                            let pid = pid.clone();
-                            let pct = *pct;
-                            let history_key = history_key.clone();
-
+                        if success {
+                            let now = Utc::now().timestamp();
+                            record_warmup_history(&history_key, now);
                             logger::log_info(&format!(
-                                "[Warmup {}/{}] {} @ {} ({}%)",
-                                global_idx, total, model, email, pct
+                                "[WeeklyWarmup] ✅ Successfully started weekly timer for {} @ {}",
+                                model, email
                             ));
-
-                            let handle = tokio::spawn(async move {
-                                let result = quota::warmup_model_directly(
-                                    &token,
-                                    &model,
-                                    &pid,
-                                    &email,
-                                    pct,
-                                    Some(&id),
-                                )
-                                .await;
-                                (result, history_key)
-                            });
-                            handles.push(handle);
                         }
-
-                        for handle in handles {
-                            match handle.await {
-                                Ok((true, history_key)) => {
-                                    success += 1;
-                                    record_warmup_history(&history_key, now_ts);
-                                }
-                                _ => {}
-                            }
-                        }
-
-                        if batch_idx < (warmup_tasks.len() + batch_size - 1) / batch_size - 1 {
-                            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                        }
+                        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                     }
 
-                    logger::log_info(&format!(
-                        "[Scheduler] ✅ Warmup completed: {}/{} successful",
-                        success, total
-                    ));
-
-                    // Refresh quota
+                    // Refresh UI
                     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                     let _ = crate::commands::refresh_all_quotas_internal(
                         &state_for_warmup,
@@ -268,145 +249,86 @@ pub fn start_scheduler(
                     )
                     .await;
                 });
-            } else if skipped_cooldown > 0 {
-                logger::log_info(&format!(
-                    "[Scheduler] Scan completed, all 100% models are in cooldown, skipped {}",
-                    skipped_cooldown
-                ));
-            } else {
-                logger::log_info(
-                    "[Scheduler] Scan completed, no models with 100% quota need warmup",
-                );
             }
 
-            // Sync to frontend if handle exists
-            if let Some(handle) = app_handle.as_ref() {
-                let handle_inner = handle.clone();
-                let state_inner = proxy_state.clone();
-                tokio::spawn(async move {
-                    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-                    let _ = crate::commands::refresh_all_quotas_internal(
-                        &state_inner,
-                        Some(handle_inner),
-                    )
-                    .await;
-                    logger::log_info("[Scheduler] Quota data synced to frontend");
-                });
-            }
-
-            // Regularly clean up history (keep last 24 hours)
+            // Regularly clean up history (keep last 30 days)
             {
                 let now_ts = Utc::now().timestamp();
                 let mut history = WARMUP_HISTORY.lock().unwrap();
-                let cutoff = now_ts - 86400; // 24 hours ago
+                let cutoff = now_ts - 30 * 86400;
                 history.retain(|_, &mut ts| ts > cutoff);
             }
         }
     });
 }
 
-/// Trigger immediate smart warmup check for a single account
+/// Trigger immediate smart warmup check for a single account (e.g. on manual trigger / recovered event)
 pub async fn trigger_warmup_for_account(account: &Account) {
-    // Get valid token
     let Ok((token, pid)) = quota::get_valid_token_for_warmup(account).await else {
         return;
     };
 
-    // Get quota info (prefer cache as refresh command likely just updated disk/cache)
     let Ok((fresh_quota, _)) =
         quota::fetch_quota_with_cache(&token, &account.email, Some(&pid), Some(&account.id)).await
     else {
         return;
     };
 
-    // [FIX] 预热阶段检测到 403 时，使用统一禁用逻辑，确保账号文件和索引同时更新
     if fresh_quota.is_forbidden {
-        logger::log_warn(&format!(
-            "[Scheduler] Account {} returned 403 Forbidden during quota fetch, marking as forbidden",
-            account.email
-        ));
-        let _ = account::mark_account_forbidden(
-            &account.id,
-            "Scheduler: 403 Forbidden - quota fetch denied",
-        );
         return;
     }
 
-    // Load config once at the beginning
     let Ok(app_config) = config::load_app_config() else {
-        logger::log_warn("[Scheduler] Failed to load app config, skipping warmup check");
         return;
     };
 
-    let now_ts = Utc::now().timestamp();
-    let mut tasks_to_run = Vec::new();
-
-    for model in fresh_quota.models {
-        let model_name = model.name.clone();
-        let history_key = format!("{}:{}:100", account.email, model_name);
-
-        if model.percentage == 100 {
-            // First check if model is in user's monitored list
-            if !app_config
-                .scheduled_warmup
-                .monitored_models
-                .contains(&model_name)
-            {
-                continue;
-            }
-
-            // Then check cooldown history
-            {
-                let history = WARMUP_HISTORY.lock().unwrap();
-
-                // 4 hour cooldown (Pro account resets every 5h, 1h margin)
-                if let Some(&last_warmup_ts) = history.get(&history_key) {
-                    let cooldown_seconds = 14400;
-                    if now_ts - last_warmup_ts < cooldown_seconds {
-                        // Still in cooldown, skip
-                        continue;
-                    }
-                }
-            }
-            // Note: Don't write history here - only write after successful warmup
-
-            tasks_to_run.push((model_name, model.percentage, history_key));
-        } else if model.percentage < 100 {
-            // Quota not full, clear history, allow warmup next time it's 100%
-            let mut history = WARMUP_HISTORY.lock().unwrap();
-            if history.remove(&history_key).is_some() {
-                save_warmup_history(&history);
-            }
-        }
+    if !app_config.scheduled_warmup.enabled {
+        return;
     }
 
-    // Execute warmup and record history only on success
-    if !tasks_to_run.is_empty() {
-        logger::log_info(&format!(
-            "[Scheduler] Found {} models ready for warmup on {}",
-            tasks_to_run.len(),
-            account.email
-        ));
+    let now_ts = Utc::now().timestamp();
+    if let Some(groups) = fresh_quota.quota_groups {
+        for group in groups {
+            for bucket in group.buckets {
+                let is_weekly = bucket.window.to_lowercase().contains("week")
+                    || bucket.bucket_id.to_lowercase().contains("week");
+                if !is_weekly {
+                    continue;
+                }
 
-        for (model, pct, history_key) in tasks_to_run {
-            logger::log_info(&format!(
-                "[Scheduler] 🔥 Triggering individual warmup: {} @ {} (Sync)",
-                model, account.email
-            ));
+                if bucket.remaining_fraction >= 0.999 {
+                    if let Some(reset_ts) = parse_reset_time_ts(&bucket.reset_time) {
+                        if now_ts >= reset_ts - 60 {
+                            let history_key = format!(
+                                "{}:{}:weekly:{}",
+                                account.email, bucket.bucket_id, reset_ts
+                            );
+                            if !check_cooldown(&history_key, 6 * 86400) {
+                                let model_to_ping = if bucket.bucket_id.contains("3p")
+                                    || group.display_name.contains("Claude")
+                                {
+                                    "claude-sonnet-4-6".to_string()
+                                } else {
+                                    "gemini-3-flash".to_string()
+                                };
 
-            let success = quota::warmup_model_directly(
-                &token,
-                &model,
-                &pid,
-                &account.email,
-                pct,
-                Some(&account.id),
-            )
-            .await;
+                                let success = quota::warmup_model_directly(
+                                    &token,
+                                    &model_to_ping,
+                                    &pid,
+                                    &account.email,
+                                    100,
+                                    Some(&account.id),
+                                )
+                                .await;
 
-            // Only record history if warmup was successful
-            if success {
-                record_warmup_history(&history_key, now_ts);
+                                if success {
+                                    record_warmup_history(&history_key, now_ts);
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/src-tauri/src/proxy/handlers/warmup.rs
+++ b/src-tauri/src/proxy/handlers/warmup.rs
@@ -47,27 +47,6 @@ pub async fn handle_warmup(
 ) -> Response {
     let start_time = std::time::Instant::now();
 
-    // ===== 前置检查：跳过 gemini-2.5-* 家族模型 =====
-    let model_lower = req.model.to_lowercase();
-    if model_lower.contains("2.5-") || model_lower.contains("2-5-") {
-        info!(
-            "[Warmup-API] SKIP: gemini-2.5-* model not supported for warmup: {} / {}",
-            req.email, req.model
-        );
-        return (
-            StatusCode::OK,
-            Json(WarmupResponse {
-                success: true,
-                message: format!(
-                    "Skipped warmup for {} (2.5 models not supported)",
-                    req.model
-                ),
-                error: None,
-            }),
-        )
-            .into_response();
-    }
-
     info!(
         "[Warmup-API] ========== START: email={}, model={} ==========",
         req.email, req.model

--- a/src-tauri/src/proxy/middleware/service_status.rs
+++ b/src-tauri/src/proxy/middleware/service_status.rs
@@ -13,8 +13,8 @@ pub async fn service_status_middleware(
 ) -> Response {
     let path = request.uri().path();
 
-    // Always allow Admin API and Auth callback
-    if path.starts_with("/api/") || path == "/auth/callback" || path == "/health" {
+    // Always allow Admin API, internal endpoints and Auth callback
+    if path.starts_with("/api/") || path.starts_with("/internal/") || path == "/auth/callback" || path == "/health" {
         return next.run(request).await;
     }
 

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -26,6 +26,7 @@ interface AccountCardProps {
     onWarmup?: () => void;
     onUpdateLabel?: (label: string) => void;
     onViewError: () => void;
+    quotaWindow?: '5h' | 'weekly';
 }
 
 // 使用统一的模型配置
@@ -36,7 +37,7 @@ const DEFAULT_MODELS = Object.entries(MODEL_CONFIG).map(([id, config]) => ({
     Icon: config.Icon
 }));
 
-function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, isRefreshing, isSwitching = false, onSwitch, onRefresh, onViewDetails, onExport, onDelete, onToggleProxy, onViewDevice, onWarmup, onUpdateLabel, onViewError }: AccountCardProps) {
+function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, isRefreshing, isSwitching = false, onSwitch, onRefresh, onViewDetails, onExport, onDelete, onToggleProxy, onViewDevice, onWarmup, onUpdateLabel, onViewError, quotaWindow }: AccountCardProps) {
     const { t } = useTranslation();
     const { config, showAllQuotas } = useConfigStore();
     const isDisabled = Boolean(account.disabled);
@@ -128,6 +129,27 @@ function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, is
         // 应用排序并过滤过期模型
         return sortModels(models).filter(m => m.id !== 'claude-sonnet-4-6-thinking' && m.id !== 'claude-sonnet-4-5-thinking' && m.id !== 'claude-opus-4-5-thinking');
     }, [config, account, showAllQuotas]);
+
+    // 解析周配额项 (当处于 weekly 视图时)
+    const weeklyItems = useMemo(() => {
+        if (quotaWindow !== 'weekly') return [];
+        return (account.quota?.quota_groups || []).flatMap(group => {
+            return group.buckets
+                .filter(b => b.window.toLowerCase().includes('week') || b.bucket_id.toLowerCase().includes('week'))
+                .map(b => {
+                    const shortGroupName = group.display_name
+                        .replace(/ models?$/i, '')
+                        .replace(/Claude and GPT/i, 'Claude/GPT');
+                    return {
+                        id: `${group.display_name}-${b.bucket_id}`,
+                        label: b.display_name ? `${shortGroupName} (${b.display_name})` : `${shortGroupName} (周)`,
+                        percentage: Math.round((b.remaining_fraction || 0) * 100),
+                        resetTime: b.reset_time,
+                        Icon: shortGroupName.toLowerCase().includes('claude') ? Sparkles : Bot,
+                    };
+                });
+        });
+    }, [quotaWindow, account.quota?.quota_groups]);
 
     const isModelProtected = (key?: string) => {
         if (!key) return false;
@@ -262,17 +284,29 @@ function AccountCard({ account, selected, onSelect, isCurrent: propIsCurrent, is
                     </div>
                 ) : (
                     <div className="grid grid-cols-1 gap-2 content-start">
-                        {displayModels.map((model) => (
-                            <QuotaItem
-                                key={model.id}
-                                label={model.label}
-                                percentage={model.data?.percentage || 0}
-                                resetTime={model.data?.reset_time}
-                                isProtected={isModelProtected(model.protectedKey)}
-                                liveLimit={getLiveLimitForModel(account, model.id, model.protectedKey)}
-                                Icon={model.Icon}
-                            />
-                        ))}
+                        {quotaWindow === 'weekly' && weeklyItems.length > 0 ? (
+                            weeklyItems.map((item) => (
+                                <QuotaItem
+                                    key={item.id}
+                                    label={item.label}
+                                    percentage={item.percentage}
+                                    resetTime={item.resetTime}
+                                    Icon={item.Icon}
+                                />
+                            ))
+                        ) : (
+                            displayModels.map((model) => (
+                                <QuotaItem
+                                    key={model.id}
+                                    label={model.label}
+                                    percentage={model.data?.percentage || 0}
+                                    resetTime={model.data?.reset_time}
+                                    isProtected={isModelProtected(model.protectedKey)}
+                                    liveLimit={getLiveLimitForModel(account, model.id, model.protectedKey)}
+                                    Icon={model.Icon}
+                                />
+                            ))
+                        )}
                     </div>
                 )}
             </div>

--- a/src/components/accounts/AccountGrid.tsx
+++ b/src/components/accounts/AccountGrid.tsx
@@ -19,10 +19,11 @@ interface AccountGridProps {
     onWarmup?: (accountId: string) => void;
     onUpdateLabel?: (accountId: string, label: string) => void;
     onViewError: (accountId: string) => void;
+    quotaWindow?: '5h' | 'weekly';
 }
 
 
-function AccountGrid({ accounts, selectedIds, refreshingIds, onToggleSelect, currentAccountId, switchingAccountId, onSwitch, onRefresh, onViewDetails, onExport, onDelete, onToggleProxy, onViewDevice, onWarmup, onUpdateLabel, onViewError }: AccountGridProps) {
+function AccountGrid({ accounts, selectedIds, refreshingIds, onToggleSelect, currentAccountId, switchingAccountId, onSwitch, onRefresh, onViewDetails, onExport, onDelete, onToggleProxy, onViewDevice, onWarmup, onUpdateLabel, onViewError, quotaWindow }: AccountGridProps) {
     const { t } = useTranslation();
     if (accounts.length === 0) {
         return (
@@ -54,6 +55,7 @@ function AccountGrid({ accounts, selectedIds, refreshingIds, onToggleSelect, cur
                     onWarmup={onWarmup ? () => onWarmup(account.id) : undefined}
                     onUpdateLabel={onUpdateLabel ? (label: string) => onUpdateLabel(account.id, label) : undefined}
                     onViewError={() => onViewError(account.id)}
+                    quotaWindow={quotaWindow}
                 />
             ))}
         </div>

--- a/src/components/accounts/AccountTable.tsx
+++ b/src/components/accounts/AccountTable.tsx
@@ -81,6 +81,7 @@ interface AccountTableProps {
     /** 拖拽排序回调，当用户完成拖拽时触发 */
     onReorder?: (accountIds: string[]) => void;
     onViewError: (accountId: string) => void;
+    quotaWindow?: '5h' | 'weekly';
 }
 
 interface SortableRowProps {
@@ -101,6 +102,7 @@ interface SortableRowProps {
     onWarmup?: () => void;
     onUpdateLabel?: (label: string) => void;
     onViewError: () => void;
+    quotaWindow?: '5h' | 'weekly';
 }
 
 interface AccountRowContentProps {
@@ -119,6 +121,7 @@ interface AccountRowContentProps {
     onWarmup?: () => void;
     onUpdateLabel?: (label: string) => void;
     onViewError: () => void;
+    quotaWindow?: '5h' | 'weekly';
 }
 
 // ============================================================================
@@ -177,6 +180,7 @@ function SortableAccountRow({
     onWarmup,
     onUpdateLabel,
     onViewError,
+    quotaWindow,
 }: SortableRowProps) {
     const { t } = useTranslation();
     const {
@@ -221,10 +225,10 @@ function SortableAccountRow({
             <td className="px-2 py-1 w-10 align-middle">
                 <input
                     type="checkbox"
-                    className="checkbox checkbox-xs rounded border-2 border-gray-400 dark:border-gray-500 checked:border-blue-600 checked:bg-blue-600 [--chkbg:theme(colors.blue.600)] [--chkfg:white]"
+                    className="checkbox checkbox-sm rounded border-2 border-gray-400 dark:border-gray-500 checked:border-blue-600 checked:bg-blue-600 [--chkbg:theme(colors.blue.600)] [--chkfg:white]"
                     checked={selected}
                     onChange={onSelect}
-                    onClick={(e) => e.stopPropagation()}
+                    disabled={isRefreshing}
                 />
             </td>
             <AccountRowContent
@@ -243,6 +247,7 @@ function SortableAccountRow({
                 onWarmup={onWarmup}
                 onUpdateLabel={onUpdateLabel}
                 onViewError={onViewError}
+                quotaWindow={quotaWindow}
             />
         </tr>
     );
@@ -268,6 +273,7 @@ function AccountRowContent({
     onWarmup,
     onUpdateLabel,
     onViewError,
+    quotaWindow,
 }: AccountRowContentProps) {
     const { t } = useTranslation();
     const { config, showAllQuotas } = useConfigStore();
@@ -297,7 +303,26 @@ function AccountRowContent({
         }
     };
 
-    // 使用统一的模型配置
+    // 解析周配额项 (当处于 weekly 视图时)
+    const weeklyItems = useMemo(() => {
+        if (quotaWindow !== 'weekly') return [];
+        return (account.quota?.quota_groups || []).flatMap(group => {
+            return group.buckets
+                .filter(b => b.window.toLowerCase().includes('week') || b.bucket_id.toLowerCase().includes('week'))
+                .map(b => {
+                    const shortGroupName = group.display_name
+                        .replace(/ models?$/i, '')
+                        .replace(/Claude and GPT/i, 'Claude/GPT');
+                    return {
+                        id: `${group.display_name}-${b.bucket_id}`,
+                        label: b.display_name ? `${shortGroupName} (${b.display_name})` : `${shortGroupName} (周)`,
+                        percentage: Math.round((b.remaining_fraction || 0) * 100),
+                        resetTime: b.reset_time,
+                        Icon: shortGroupName.toLowerCase().includes('claude') ? Sparkles : Bot,
+                    };
+                });
+        });
+    }, [quotaWindow, account.quota?.quota_groups]);
 
     // 获取要显示的模型列表
     const pinnedModels = ensurePinnedImageSelector(
@@ -509,23 +534,37 @@ function AccountRowContent({
                 ) : (
                     <div className={cn(
                         "grid gap-x-2 gap-y-1 py-0",
-                        displayModels.length === 1 ? "grid-cols-1" : "grid-cols-2"
+                        (quotaWindow === 'weekly' && weeklyItems.length > 0)
+                            ? (weeklyItems.length === 1 ? "grid-cols-1" : "grid-cols-2")
+                            : (displayModels.length === 1 ? "grid-cols-1" : "grid-cols-2")
                     )}>
-                        {displayModels.map((model) => {
-                            const modelData = model.data;
-
-                            return (
+                        {quotaWindow === 'weekly' && weeklyItems.length > 0 ? (
+                            weeklyItems.map((item) => (
                                 <QuotaItem
-                                    key={model.id}
-                                    label={model.label}
-                                    percentage={modelData?.percentage || 0}
-                                    resetTime={modelData?.reset_time}
-                                    isProtected={isModelProtected(account.protected_models, model.protectedKey)}
-                                    liveLimit={getLiveLimitForModel(account, model.id, model.protectedKey)}
-                                    Icon={MODEL_CONFIG[model.id]?.Icon || Bot}
+                                    key={item.id}
+                                    label={item.label}
+                                    percentage={item.percentage}
+                                    resetTime={item.resetTime}
+                                    Icon={item.Icon}
                                 />
-                            );
-                        })}
+                            ))
+                        ) : (
+                            displayModels.map((model) => {
+                                const modelData = model.data;
+
+                                return (
+                                    <QuotaItem
+                                        key={model.id}
+                                        label={model.label}
+                                        percentage={modelData?.percentage || 0}
+                                        resetTime={modelData?.reset_time}
+                                        isProtected={isModelProtected(account.protected_models, model.protectedKey)}
+                                        liveLimit={getLiveLimitForModel(account, model.id, model.protectedKey)}
+                                        Icon={MODEL_CONFIG[model.id]?.Icon || Bot}
+                                    />
+                                );
+                            })
+                        )}
                     </div>
                 )}
             </td>
@@ -686,6 +725,7 @@ function AccountTable({
     onWarmup,
     onUpdateLabel,
     onViewError,
+    quotaWindow,
 }: AccountTableProps) {
     const { t } = useTranslation();
 
@@ -756,7 +796,7 @@ function AccountTable({
                             </th>
                             <th className="px-2 py-1 text-left rtl:text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[300px] whitespace-nowrap">{t('accounts.table.email')}</th>
                             <th className="px-2 py-1 text-left rtl:text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider min-w-[340px] whitespace-nowrap">
-                                {t('accounts.table.quota')}
+                                {quotaWindow === 'weekly' ? t('accounts.table.weekly_quota', '周配额') : t('accounts.table.quota')}
                             </th>
                             <th className="px-2 py-1 text-left rtl:text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-[90px] whitespace-nowrap">{t('accounts.table.last_used')}</th>
                             <th className="px-2 py-1 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider whitespace-nowrap sticky right-0 w-[220px] bg-gray-50 dark:bg-base-200 z-20 shadow-[-12px_0_12px_-12px_rgba(0,0,0,0.1)] dark:shadow-[-12px_0_12px_-12px_rgba(255,255,255,0.05)] text-center">{t('accounts.table.actions')}</th>
@@ -784,6 +824,7 @@ function AccountTable({
                                     onWarmup={onWarmup ? () => onWarmup(account.id) : undefined}
                                     onUpdateLabel={onUpdateLabel ? (label: string) => onUpdateLabel(account.id, label) : undefined}
                                     onViewError={() => onViewError(account.id)}
+                                    quotaWindow={quotaWindow}
                                 />
                             ))}
                         </tbody>
@@ -825,6 +866,7 @@ function AccountTable({
                                         onToggleProxy={() => { }}
                                         isDisabled={Boolean(activeAccount.disabled)}
                                         onViewError={() => { }}
+                                        quotaWindow={quotaWindow}
                                     />
                                 </tr>
                             </tbody>

--- a/src/components/settings/SmartWarmup.tsx
+++ b/src/components/settings/SmartWarmup.tsx
@@ -62,10 +62,10 @@ const SmartWarmup: React.FC<SmartWarmupProps> = ({ config, onChange }) => {
                     </div>
                     <div>
                         <div className="font-bold text-gray-900 dark:text-gray-100">
-                            {t('settings.warmup.title', '智能预热')}
+                            {t('settings.warmup.title', '7天周配额智能预热')}
                         </div>
                         <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                            {t('settings.warmup.desc')}
+                            {t('settings.warmup.desc', '在各账号的 7 天周配额到达重置时间后自动唤醒 1 次，启动当周计时器，零多余消耗。')}
                         </p>
                     </div>
                 </div>
@@ -85,7 +85,7 @@ const SmartWarmup: React.FC<SmartWarmupProps> = ({ config, onChange }) => {
                     <div className="space-y-3">
                         <div>
                             <label className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-widest block mb-2">
-                                {t('settings.quota_protection.monitored_models_label', '监控模型')}
+                                {t('settings.warmup.monitored_models_label', '预热模型范围')}
                             </label>
                             <div className="grid grid-cols-4 gap-2">
                                 {warmupModelsOptions.map((model) => {
@@ -115,7 +115,7 @@ const SmartWarmup: React.FC<SmartWarmupProps> = ({ config, onChange }) => {
                                 })}
                             </div>
                             <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-2 leading-relaxed">
-                                {t('settings.quota_protection.monitored_models_desc', '勾选需要监控的模型。当选中的任一模型利用率跌破阈值时，将触发保护')}
+                                {t('settings.warmup.monitored_models_desc', '勾选需要预热的模型。在周配额到达重置时间后将自动唤醒 1 次启动新周期。')}
                             </p>
                         </div>
                     </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -240,6 +240,9 @@
     "warmup_this": "Warmup this account",
     "warmup_now": "Warmup Now",
     "warmup_batch_triggered": "Warmup tasks triggered for {{count}} accounts",
+    "quota_window_5h": "5-Hour Rolling Quota",
+    "quota_window_weekly": "7-Day Weekly Quota",
+    "quota_window_weekly_short": "Weekly",
     "quota_protected": "Protected",
     "details": {
       "title": "Quota Details",
@@ -379,8 +382,8 @@
       "sync_interval": "Sync Interval (minutes)"
     },
     "warmup": {
-      "title": "Smart Warmup",
-      "desc": "Automatically monitors all models and triggers warmup immediately when quota reaches 100%, keeping models warm"
+      "title": "7-Day Weekly Reset Warmup",
+      "desc": "Automatically sends a minimal ping once when the 7-day weekly quota resets, starting the countdown with zero extra token waste."
     },
     "quota_protection": {
       "title": "Quota Protection",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -206,7 +206,10 @@
     "warmup_selected": "預熱 ({{count}})",
     "warmup_this": "預熱該帳號",
     "warmup_now": "立即預熱",
-    "warmup_batch_triggered": "已成功為 {{count}} 個帳號觸發預熱任務",
+    "warmup_batch_triggered": "已成功為 {{count}} 個帳號觸發預热任務",
+    "quota_window_5h": "5小時滑動配額",
+    "quota_window_weekly": "7天周配額",
+    "quota_window_weekly_short": "周配額",
     "quota_protected": "受保護",
     "details": {
       "title": "配額詳情",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -239,6 +239,9 @@
     "warmup_this": "预热该账号",
     "warmup_now": "立即预热",
     "warmup_batch_triggered": "已成功为 {{count}} 个账号触发预热任务",
+    "quota_window_5h": "5小时滑动配额",
+    "quota_window_weekly": "7天周配额",
+    "quota_window_weekly_short": "周配额",
     "quota_protected": "受保护",
     "details": {
       "title": "配额详情",
@@ -378,8 +381,8 @@
       "sync_interval": "同步间隔（分钟）"
     },
     "warmup": {
-      "title": "智能预热",
-      "desc": "自动监控所有模型，当额度恢复到 100% 时立即触发预热，保持模型热状态"
+      "title": "7天周配额智能预热",
+      "desc": "在各账号的 7 天周配额到达重置时间后自动唤醒 1 次，启动当周计时器，零多余消耗。"
     },
     "quota_protection": {
       "title": "配额保护",

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -1,6 +1,8 @@
 
 
 import {
+  Calendar,
+  Clock,
   Download,
   LayoutGrid,
   List,
@@ -33,6 +35,7 @@ import { useTranslation } from "react-i18next";
 
 type FilterType = "all" | "pro" | "ultra" | "free";
 type ViewMode = "list" | "grid";
+export type QuotaWindow = "5h" | "weekly";
 
 
 function Accounts() {
@@ -64,10 +67,20 @@ function Accounts() {
     return (saved === 'list' || saved === 'grid') ? saved : 'list';
   });
 
+  const [quotaWindow, setQuotaWindow] = useState<QuotaWindow>(() => {
+    const saved = localStorage.getItem('accounts_quota_window');
+    return (saved === '5h' || saved === 'weekly') ? saved : '5h';
+  });
+
   // Save view mode preference
   useEffect(() => {
     localStorage.setItem('accounts_view_mode', viewMode);
   }, [viewMode]);
+
+  // Save quota window preference
+  useEffect(() => {
+    localStorage.setItem('accounts_quota_window', quotaWindow);
+  }, [quotaWindow]);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [deviceAccount, setDeviceAccount] = useState<Account | null>(null);
   const [detailsAccount, setDetailsAccount] = useState<Account | null>(null);
@@ -791,6 +804,36 @@ function Accounts() {
           )}
         </div>
 
+        {/* 配额周期切换 (5H / 7天周配额) */}
+        <div className="flex gap-1 bg-gray-100 dark:bg-base-200 p-1 rounded-lg shrink-0 items-center">
+          <button
+            className={cn(
+              "px-2 py-1 text-xs font-semibold rounded-md transition-all flex items-center gap-1",
+              quotaWindow === "5h"
+                ? "bg-white dark:bg-base-100 text-blue-600 dark:text-blue-400 shadow-sm"
+                : "text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-base-content",
+            )}
+            onClick={() => setQuotaWindow("5h")}
+            title={t("accounts.quota_window_5h", "5小时滑动配额")}
+          >
+            <Clock className="w-3.5 h-3.5" />
+            <span>5H</span>
+          </button>
+          <button
+            className={cn(
+              "px-2 py-1 text-xs font-semibold rounded-md transition-all flex items-center gap-1",
+              quotaWindow === "weekly"
+                ? "bg-white dark:bg-base-100 text-blue-600 dark:text-blue-400 shadow-sm"
+                : "text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-base-content",
+            )}
+            onClick={() => setQuotaWindow("weekly")}
+            title={t("accounts.quota_window_weekly", "7天周配额")}
+          >
+            <Calendar className="w-3.5 h-3.5" />
+            <span>{t("accounts.quota_window_weekly_short", "周配额")}</span>
+          </button>
+        </div>
+
         {/* 视图切换按钮组 */}
         <div className="flex gap-1 bg-gray-100 dark:bg-base-200 p-1 rounded-lg shrink-0">
           <button
@@ -1077,6 +1120,7 @@ function Accounts() {
                 onWarmup={handleWarmup}
                 onUpdateLabel={handleUpdateLabel}
                 onViewError={(id: string) => setErrorAccountId(id)}
+                quotaWindow={quotaWindow}
               />
             </div>
           </div>
@@ -1104,6 +1148,7 @@ function Accounts() {
               onWarmup={handleWarmup}
               onUpdateLabel={handleUpdateLabel}
               onViewError={(id: string) => setErrorAccountId(id)}
+              quotaWindow={quotaWindow}
             />
           </div>
         )}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,7 +7,7 @@ import { AppConfig } from '../types/config';
 import ModalDialog from '../components/common/ModalDialog';
 import { showToast } from '../components/common/ToastContainer';
 import QuotaProtection from '../components/settings/QuotaProtection';
-// import SmartWarmup from '../components/settings/SmartWarmup';
+import SmartWarmup from '../components/settings/SmartWarmup';
 import PinnedQuotaModels from '../components/settings/PinnedQuotaModels';
 import { useDebugConsole } from '../stores/useDebugConsole';
 
@@ -800,8 +800,8 @@ function Settings() {
                                 )}
                             </div>
 
-                            {/* 智能预热 (Smart Warmup) - [DISABLED] Backend scheduler commented out as per user request */}
-                            {/* <div className="group bg-white dark:bg-base-100 rounded-xl p-5 border border-gray-100 dark:border-base-200 hover:border-orange-200 transition-all duration-300 shadow-sm">
+                            {/* 7天周配额智能预热 (Smart Warmup) */}
+                            <div className="group bg-white dark:bg-base-100 rounded-xl p-5 border border-gray-100 dark:border-base-200 hover:border-orange-200 transition-all duration-300 shadow-sm">
                                 <SmartWarmup
                                     config={formData.scheduled_warmup}
                                     onChange={async (newConfig) => {
@@ -818,7 +818,7 @@ function Settings() {
                                         }
                                     }}
                                 />
-                            </div> */}
+                            </div>
 
                             {/* 配额保护 (Quota Protection) */}
                             <div className="group bg-white dark:bg-base-100 rounded-xl p-5 border border-gray-100 dark:border-base-200 hover:border-rose-200 transition-all duration-300 shadow-sm">


### PR DESCRIPTION
## Summary

This PR addresses two long-standing community needs regarding weekly quota management and automated model warmup:

1. **5-Hour vs Weekly Quota View Switcher**: Adds a segmented toggle on the Accounts page to switch between real-time 5-hour rolling quotas and grouped 7-day weekly quota buckets (`quota_groups`).
2. **7-Day Weekly Reset-Aware Smart Warmup**: Refactors the background warmup scheduler to trigger strictly once per 7-day reset cycle based on official `reset_time` timestamps, eliminating high-frequency polling and token waste.
3. **Internal Middleware Whitelist**: Fixes 503 Service Unavailable errors for `/internal/warmup` when the external proxy switch is disabled.

## Background & Motivation

- **Weekly Quota Visibility**: Currently, to view the 7-day weekly limits introduced in #3185 / v4.2.4, users must open the account details modal for each account individually. There was previously no way to view all accounts' weekly remaining quotas and countdowns in the primary table or grid views.
- **Warmup Token Overhead**: The previous smart warmup implementation performed blind polling across all models every 10 minutes. For users with multiple accounts, this risked burning routine 5-hour quota. Furthermore, warmup loopback requests were blocked with HTTP 503 if the proxy service master toggle was turned off.

## Changes

| Component / File | Changes |
|---|---|
| `src/pages/Accounts.tsx` | Add `quotaWindow` state (`'5h'` / `'weekly'`) with `localStorage` persistence; add toolbar segmented control |
| `src/components/accounts/AccountTable.tsx` | Support rendering `QuotaGroup` weekly buckets with reset countdowns when in weekly mode |
| `src/components/accounts/AccountCard.tsx` | Support weekly quota rendering in grid view |
| `src/components/accounts/AccountGrid.tsx` | Pass `quotaWindow` prop down to account cards |
| `src-tauri/src/proxy/middleware/service_status.rs` | Whitelist `path.starts_with("/internal/")` to permit internal warmup pings even when the proxy is stopped |
| `src-tauri/src/modules/scheduler.rs` | Refactor scheduler to detect `window == "WEEK"` and compare `reset_time` timestamp; implement 6-day cooldown lock (`email:bucket_id:reset_ts`) |
| `src-tauri/src/proxy/handlers/warmup.rs` | Remove hardcoded `gemini-2.5-*` skip |
| `src-tauri/src/lib.rs` & `src-tauri/src/modules/account.rs` | Re-enable scheduler startup and post-refresh warmup checks |
| `src/pages/Settings.tsx` & `SmartWarmup.tsx` | Re-enable Smart Warmup settings card (default: opt-in `false`) with clear 7-day cycle descriptions |
| `src/locales/*.json` | Add and update i18n keys for Chinese, English, and Traditional Chinese |

## Design Details

- **Zero Token Waste**: Only targets buckets with `window == "WEEK"`. A single minimal ping is sent only after the weekly reset timestamp arrives, initiating the official countdown.
- **Cycle Cooldown Lock**: Successfully triggered weekly warmups are recorded as `<email>:<bucket_id>:weekly:<reset_ts>` in `warmup_history.json`, ensuring at most one execution per 7-day window.
- **Backward Compatible & Non-Intrusive**: Default quota view remains `5h`. Smart Warmup remains disabled by default (`enabled: false`).

## Verification

- Verified `5h` and `weekly` view switching in both list (table) and grid card modes.
- Verified that weekly reset countdowns format correctly (e.g., `5d 12h`).
- Verified that loopback `/internal/warmup` calls succeed when the proxy service is disabled.
- Verified that the scheduler correctly calculates weekly reset offsets and writes history locks.