### PR TITLE
fix(claude): normalize Agent SDK identity for CC GUI

### DIFF
--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -8,6 +8,24 @@ use crate::proxy::session_manager::SessionManager;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
+const CLAUDE_AGENT_SDK_IDENTITY: &str =
+    "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
+const CLAUDE_CODE_CLI_IDENTITY: &str = "You are Claude Code, Anthropic's official CLI for Claude.";
+
+/// Normalize the standalone identity block injected by Claude Agent SDK clients.
+///
+/// Antigravity's upstream currently classifies this SDK identity differently from
+/// Claude Code's CLI identity and can reject an otherwise identical request with
+/// RESOURCE_EXHAUSTED. Keep the match exact so user-authored text that merely
+/// mentions the SDK identity is not rewritten.
+fn normalize_claude_client_identity(text: &str) -> &str {
+    if text == CLAUDE_AGENT_SDK_IDENTITY {
+        CLAUDE_CODE_CLI_IDENTITY
+    } else {
+        text
+    }
+}
+
 // ===== Safety Settings Configuration =====
 
 /// Safety threshold levels for Gemini API
@@ -933,13 +951,15 @@ fn build_system_instruction(
             SystemPrompt::String(text) => {
                 // [MODIFIED] No longer filter "You are an interactive CLI tool"
                 // We pass everything through to ensure Flash/Lite models get full instructions
-                parts.push(json!({"text": text}));
+                parts.push(json!({"text": normalize_claude_client_identity(text)}));
             }
             SystemPrompt::Array(blocks) => {
                 for block in blocks {
                     if block.block_type == "text" {
                         // [MODIFIED] No longer filter "You are an interactive CLI tool"
-                        parts.push(json!({"text": block.text}));
+                        parts.push(json!({
+                            "text": normalize_claude_client_identity(&block.text)
+                        }));
                     }
                 }
             }
@@ -2208,6 +2228,51 @@ mod tests {
     use super::*;
     use crate::proxy::common::json_schema::clean_json_schema;
     use crate::proxy::config::{update_thinking_budget_config, ThinkingBudgetConfig};
+
+    #[test]
+    fn test_agent_sdk_identity_is_normalized_for_antigravity() {
+        let req: ClaudeRequest = serde_json::from_value(json!({
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Reply with ok"}],
+            "system": [
+                {
+                    "type": "text",
+                    "text": "x-anthropic-billing-header: cc_entrypoint=sdk-cli;"
+                },
+                {
+                    "type": "text",
+                    "text": CLAUDE_AGENT_SDK_IDENTITY,
+                    "cache_control": {"type": "ephemeral"}
+                }
+            ]
+        }))
+        .expect("Agent SDK request should deserialize");
+
+        let body =
+            transform_claude_request_in(&req, "test-project", false, None, "test-session", None)
+                .expect("Agent SDK request should transform");
+        let system_parts = body["request"]["systemInstruction"]["parts"]
+            .as_array()
+            .expect("system instruction should contain parts");
+        let system_texts = system_parts
+            .iter()
+            .filter_map(|part| part["text"].as_str())
+            .collect::<Vec<_>>();
+
+        assert!(system_texts.contains(&CLAUDE_CODE_CLI_IDENTITY));
+        assert!(!system_texts.contains(&CLAUDE_AGENT_SDK_IDENTITY));
+        assert!(system_texts.contains(&"x-anthropic-billing-header: cc_entrypoint=sdk-cli;"));
+    }
+
+    #[test]
+    fn test_agent_sdk_identity_mention_is_not_rewritten() {
+        let quoted_identity = format!("Compatibility note: {CLAUDE_AGENT_SDK_IDENTITY}");
+
+        assert_eq!(
+            normalize_claude_client_identity(&quoted_identity),
+            quoted_identity
+        );
+    }
 
     #[test]
     fn test_ephemeral_injection_debug() {


### PR DESCRIPTION
## Summary
- Normalize the exact identity block injected by Claude Agent SDK clients to the Claude Code CLI identity before forwarding upstream.
- Preserve all other user-provided system prompt text unchanged.
- Avoid the upstream rejection that surfaces as a 503 error in CC GUI.

## Tests
- `cargo test test_agent_sdk_identity --lib`
