### PR TITLE
feat(openai): support response_format.json_schema for structured outputs

### DIFF
--- a/src-tauri/src/proxy/common/json_schema.rs
+++ b/src-tauri/src/proxy/common/json_schema.rs
@@ -41,6 +41,11 @@ const MAX_RECURSION_DEPTH: usize = 10;
 /// 4. [NEW] 处理 anyOf 联合类型: anyOf: [{"type": "string"}, {"type": "null"}] -> "type": "string"
 /// 5. 将 type 字段的值转换为小写 (Gemini v1internal 要求)
 /// 6. 移除数字校验字段: multipleOf, exclusiveMinimum, exclusiveMaximum 等
+/// 清洗用于 responseSchema 的 JSON Schema
+pub fn clean_response_schema(value: &mut Value) {
+    clean_json_schema(value);
+}
+
 pub fn clean_json_schema(value: &mut Value) {
     // 0. 预处理：展开 $ref (Schema Flattening)
     // [FIX #952] 递归收集所有层级的 $defs/definitions，而非仅从根层级提取

--- a/src-tauri/src/proxy/mappers/openai/models.rs
+++ b/src-tauri/src/proxy/mappers/openai/models.rs
@@ -62,8 +62,22 @@ pub struct ThinkingConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseFormatJSONSchema {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResponseFormat {
     pub r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_schema: Option<ResponseFormatJSONSchema>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src-tauri/src/proxy/mappers/openai/request.rs
+++ b/src-tauri/src/proxy/mappers/openai/request.rs
@@ -919,6 +919,14 @@ pub fn transform_openai_request(
     if let Some(fmt) = &request.response_format {
         if fmt.r#type == "json_object" {
             gen_config["responseMimeType"] = json!("application/json");
+        } else if fmt.r#type == "json_schema" {
+            gen_config["responseMimeType"] = json!("application/json");
+            if let Some(js) = &fmt.json_schema {
+                if let Some(mut schema) = js.schema.clone() {
+                    crate::proxy::common::json_schema::clean_response_schema(&mut schema);
+                    gen_config["responseSchema"] = schema;
+                }
+            }
         }
     }
 
@@ -1845,5 +1853,52 @@ mod tests {
             !has_google_search,
             "v1internal should avoid mixed Google Search when functionDeclarations present"
         );
+    }
+
+    #[test]
+    fn test_response_format_json_schema_mapping() {
+        let raw_json = json!({
+            "model": "gemini-2.5-flash",
+            "messages": [
+                {"role": "user", "content": "test"}
+            ],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "test_schema",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "summary": {
+                                "type": "object",
+                                "properties": {
+                                    "text": { "type": "string" },
+                                    "sourceId": { "type": "string" },
+                                    "quote": { "type": "string" }
+                                },
+                                "required": ["text", "sourceId", "quote"],
+                                "additionalProperties": false
+                            },
+                            "topics": {
+                                "type": "array",
+                                "items": { "type": "string" }
+                            }
+                        },
+                        "required": ["summary", "topics"],
+                        "additionalProperties": false
+                    },
+                    "strict": true
+                }
+            }
+        });
+
+        let request: OpenAIRequest = serde_json::from_value(raw_json).unwrap();
+        let (res_val, _sid, _msg_count, _) = transform_openai_request(&request, "test-v", "gemini-2.5-flash", None);
+        let gen_config = &res_val["request"]["generationConfig"];
+        assert_eq!(gen_config["responseMimeType"], "application/json");
+        assert!(gen_config.get("responseSchema").is_some());
+        let resp_schema = &gen_config["responseSchema"];
+        assert_eq!(resp_schema["type"], "object");
+        assert_eq!(resp_schema["properties"]["summary"]["type"], "object");
     }
 }


### PR DESCRIPTION
### Summary
This PR adds support for OpenAI-compatible `response_format: { type: "json_schema", json_schema: { schema: ... } }` in the OpenAI endpoint mapper.

### Problem
Previously, the mapper only handled `response_format.type == "json_object"`, silently dropping `json_schema` payloads. Consequently, Gemini did not receive `generationConfig.responseSchema`, causing client-side structured output schema validations (e.g. LangChain / Zod) to fail with invalid type errors.

### Changes
1. **`models.rs`**:
   - Added `ResponseFormatJSONSchema` struct with `name`, `description`, `schema`, and `strict` fields.
   - Updated `ResponseFormat` to deserialize `json_schema`.
2. **`request.rs`**:
   - Implemented mapping from OpenAI `response_format.type == "json_schema"` to Gemini `generationConfig.responseSchema` (cleaned via `clean_response_schema`) and `responseMimeType: "application/json"`.
   - Added unit tests for `json_schema` mapping.
3. **`json_schema.rs`**:
   - Exposed `clean_response_schema` helper for response schemas.

### Verification
- Added and passed unit tests: `cargo test --lib proxy::mappers::openai::request::tests::test_response_format_json_schema_mapping`.
- Verified live requests against Gemini backend returning strict schema compliant JSON.