### PR TITLE
fix(proxy): make restart failures diagnosable and drop a fake server handle

### DIFF
--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -36,8 +36,6 @@ pub struct ProxyServiceInstance {
     pub config: ProxyConfig,
     pub token_manager: Arc<TokenManager>,
     pub axum_server: crate::proxy::AxumServer,
-    #[allow(dead_code)] // 保留句柄以便未来支持显式停服/诊断
-    pub server_handle: tokio::task::JoinHandle<()>,
 }
 
 impl ProxyServiceState {
@@ -182,14 +180,18 @@ pub async fn internal_start_proxy_service(
 
     let mut instance_lock = state.instance.write().await;
     let admin_lock = state.admin_server.read().await;
-    let axum_server = admin_lock.as_ref().unwrap().axum_server.clone();
+    let axum_server = admin_lock
+        .as_ref()
+        .expect("admin server must exist after ensure_admin_server")
+        .axum_server
+        .clone();
 
-    // 创建服务实例（逻辑启动）
+    // 创建服务实例（逻辑启动）。不再保存假的 server_handle：
+    // 监听任务的真实句柄已由 AdminServerInstance 持有（见 ensure_admin_server）。
     let instance = ProxyServiceInstance {
         config: config.clone(),
         token_manager: token_manager.clone(),
         axum_server: axum_server.clone(),
-        server_handle: tokio::spawn(async {}), // 逻辑上的 handle
     };
 
     // [FIX] Ensure the server is logically running

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -484,6 +484,12 @@ pub fn run() {
                             info!("Proxy service auto-started successfully");
                         }
                     }
+                } else {
+                    // 配置加载失败不能再被静默吞掉：否则重启后“服务没起来”时无任何痕迹可查。
+                    error!(
+                        "Failed to load app config at startup; admin server and proxy service were NOT started. \
+                         Fix or reset the config file and restart the app."
+                    );
                 }
             });
 


### PR DESCRIPTION
## 背景（要修复的真实故障）

排查「反代端点不生效」时定位到两个**确定的问题**，都会在重启后表现为「界面显示运行中，但端点连不上」，且日志无痕迹：

1. **启动阶段配置加载失败被静默吞掉**（`src-tauri/src/lib.rs`）：
   ```rust
   if let Ok(config) = modules::config::load_app_config() {
       // ... 启动 admin server + auto-start proxy
   }
   // ← Err 分支不存在，配置反序列化失败时整条启动链路静默跳过，无任何日志
   ```

2. **假 server handle**（`src-tauri/src/commands/proxy.rs`）：
   ```rust
   server_handle: tokio::spawn(async {}), // 逻辑上的 handle
   ```
   用空任务冒充监听任务句柄，且该字段标记 `#[allow(dead_code)]`、从未被读取。真实句柄
   已由 `AdminServerInstance::server_handle` 持有，这里再存一个假的毫无意义。

## 改动

- **lib.rs**：`load_app_config()` 失败时新增 `else` 分支打 `error!` 日志，明确「admin server 与反代服务均未启动」，把静默失败变成可排查。
- **commands/proxy.rs**：删除 `ProxyServiceInstance` 中无用的 `server_handle` 字段，去掉 `tokio::spawn(async {})` 假句柄。监听任务的真实句柄保留在 `AdminServerInstance`。

已在本地通过 `cargo check`（`antigravity-tools` lib 编译通过，仅既有的 warning，无 error）。

## 未包含、建议后续处理（更大改动）

1. **端口修改不热生效**：改 `port` 只写盘，运行中的 `AxumServer` 用 `TcpListener::bind` 一次性绑定，无重建逻辑；改完端口必须彻底退出重启才生效（`server.rs:820-823`）。
2. **UI「运行中」与运行时端口脱钩**：`admin_get_proxy_status` 的 `running` 是逻辑标志位，`base_url`/`port` 取的是监听实例绑定端口；托盘驻留 + 单实例会让旧窗口继续显示。
3. **`is_running` 语义混淆**：`admin_start/stop_proxy_service` 仅置标志 + 持久化 `auto_start`，不触碰监听，建议区分「监听存活」与「转发启用」两层状态。
