### PR TITLE
fix(windows): suppress console window flashing on process execution

### DIFF
--- a/src-tauri/src/modules/cloudflared.rs
+++ b/src-tauri/src/modules/cloudflared.rs
@@ -13,8 +13,6 @@ use std::os::windows::process::CommandExt;
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 #[cfg(target_os = "windows")]
-const DETACHED_PROCESS: u32 = 0x00000008;
-#[cfg(target_os = "windows")]
 const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
 
 /// Cloudflared隧道模式
@@ -181,14 +179,18 @@ impl CloudflaredManager {
             std::fs::write(&archive_path, &bytes)
                 .map_err(|e| format!("Failed to write archive: {}", e))?;
 
-            let status = Command::new("tar")
-                .arg("-xzf")
-                .arg(&archive_path)
-                .arg("-C")
-                .arg(bin_dir)
-                .status()
-                .await
-                .map_err(|e| format!("Failed to extract archive: {}", e))?;
+            let status = {
+                let mut tar_cmd = Command::new("tar");
+                tar_cmd
+                    .arg("-xzf")
+                    .arg(&archive_path)
+                    .arg("-C")
+                    .arg(bin_dir);
+                #[cfg(target_os = "windows")]
+                tar_cmd.creation_flags(CREATE_NO_WINDOW);
+                tar_cmd.status().await
+            }
+            .map_err(|e| format!("Failed to extract archive: {}", e))?;
 
             if !status.success() {
                 return Err("Failed to extract cloudflared archive".to_string());
@@ -293,9 +295,9 @@ impl CloudflaredManager {
         // 恢复管道
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-        // 使用 DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP 隐藏窗口
+        // CREATE_NO_WINDOW supresses console window on Windows
         #[cfg(target_os = "windows")]
-        cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+        cmd.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
 
         let mut child = cmd.spawn().map_err(|e| format!("Failed to spawn: {}", e))?;
 

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -830,6 +830,9 @@ pub fn start_antigravity(target_ide: Option<&str>) -> Result<(), String> {
                     }
                 }
 
+                #[cfg(target_os = "windows")]
+                cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+
                 cmd.spawn().map_err(|e| format!("Startup failed: {}", e))?;
             }
 

--- a/src-tauri/src/utils/command.rs
+++ b/src-tauri/src/utils/command.rs
@@ -4,17 +4,19 @@ use tokio::process::Command as TokioCommand;
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
 
-const CREATE_NO_WINDOW: u32 = 0x08000000;
+// CREATE_NO_WINDOW (0x08000000) prevents console window creation on Windows
+#[cfg(target_os = "windows")]
+const WINDOWS_NO_WINDOW_FLAGS: u32 = 0x08000000;
 
 pub trait CommandExtWrapper {
-    /// 在 Windows 下为命令添加 CREATE_NO_WINDOW 标志，隐藏黑框
+    /// Add creation flags on Windows to suppress console window flashing
     fn creation_flags_windows(&mut self) -> &mut Self;
 }
 
 impl CommandExtWrapper for StdCommand {
     fn creation_flags_windows(&mut self) -> &mut Self {
         #[cfg(target_os = "windows")]
-        self.creation_flags(CREATE_NO_WINDOW);
+        self.creation_flags(WINDOWS_NO_WINDOW_FLAGS);
 
         self
     }
@@ -23,7 +25,7 @@ impl CommandExtWrapper for StdCommand {
 impl CommandExtWrapper for TokioCommand {
     fn creation_flags_windows(&mut self) -> &mut Self {
         #[cfg(target_os = "windows")]
-        self.creation_flags(CREATE_NO_WINDOW);
+        self.creation_flags(WINDOWS_NO_WINDOW_FLAGS);
 
         self
     }


### PR DESCRIPTION
## Description
This PR eliminates console window flashing (black terminal popups) on Windows when running background tasks or external binary checks.

### Summary of Changes:
- **Cloudflared:** Replaced \DETACHED_PROCESS\ with \CREATE_NO_WINDOW\ (the combination of \DETACHED_PROCESS\ was creating temporary detached console sessions that flashed on startup). Added \CREATE_NO_WINDOW\ flag to the \	ar\ extraction command.
- **Process Launcher:** Added \CREATE_NO_WINDOW\ (0x08000000) creation flags to manual executable startup on Windows.
- **Command Wrapper:** Standardized \WINDOWS_NO_WINDOW_FLAGS\ in \command.rs\ across both synchronous (\std::process::Command\) and asynchronous (\	okio::process::Command\) extensions.

### Validation:
- Verified clean compilation with \cargo check\ and tested zero-console popups on Windows.