### PR TITLE
fix(proxy): preserve thought signature validity when compressing thinking blocks

### DIFF
--- a/src-tauri/src/proxy/mappers/context_manager.rs
+++ b/src-tauri/src/proxy/mappers/context_manager.rs
@@ -433,16 +433,19 @@ impl ContextManager {
                             ..
                         } = block
                         {
-                            // Key logic: Only compress if signature exists
-                            // This ensures we don't lose unsigned thinking blocks
-                            if signature.is_some() && thinking.len() > 10 {
+                            // [FIX] When compressing thinking, clear signature to avoid Invalid signature errors
+                            // Signature is computed over original thinking content; keeping it with "..." causes
+                            // 400 INVALID_ARGUMENT: Invalid thought signature (Gemini) / Invalid signature (Claude).
+                            if thinking.len() > 10 {
                                 let original_len = thinking.len();
                                 *thinking = "...".to_string();
+                                // Clear signature when content is compressed
+                                *signature = None;
                                 compressed_count += 1;
                                 total_chars_saved += original_len - 3;
 
                                 debug!(
-                                    "[ContextManager] [Layer-2] Compressed thinking: {} → 3 chars (signature preserved)",
+                                    "[ContextManager] [Layer-2] Compressed thinking: {} → 3 chars (signature cleared)",
                                     original_len
                                 );
                             }
@@ -1165,6 +1168,10 @@ impl ContextManager {
                                         {
                                             if text.len() > 10 {
                                                 obj.insert("text".to_string(), json!("..."));
+                                                // [FIX] Remove thoughtSignature when compressing thought text
+                                                // Signature is computed over original thought content; keeping it with "..." causes
+                                                // Google API to return 400 INVALID_ARGUMENT: Invalid thought signature.
+                                                obj.remove("thoughtSignature");
                                                 compressed_count += 1;
                                             }
                                         }


### PR DESCRIPTION
## Description
Fixes 400 INVALID_ARGUMENT: Invalid thought signature that occurs with Gemini 3.x (gemini-3.7-flash, gemini-3.5-flash) when thinking is enabled with high effort and the conversation history is long (6+ turns with tools, e.g. opencode).

### Root Cause
ContextManager compressed thinking text to "..." but kept the original thoughtSignature. Google's Gemini API validates the signature over the original thought content - keeping the old signature with "..." makes it invalid, causing the next request to fail with 400 Invalid thought signature.

This happened in two layers:
- compress_thinking_preserve_signature (Claude) - kept signature while setting thinking = "..."
- compress_gemini_thinking_preserve_signature (Gemini) - kept thoughtSignature while setting text = "..."

### Fix
When compressing thinking content, clear the signature as well. This preserves the signature chain correctly - no stale signature is sent with modified content.

### Validation
- No longer triggers Invalid thought signature on long opencode sessions with gemini-3.7-flash + thinking budget 16000 + effort high + tools
- Preserves existing behavior for non-compressed paths (protected_last_n, purify_history still strips correctly)
- Zero impact on non-thinking models (e.g. gemini-3.1-flash-lite)
