### PR TITLE
fix(proxy): omit quota-project headers from content requests

### DIFF
--- a/src-tauri/src/proxy/upstream/client.rs
+++ b/src-tauri/src/proxy/upstream/client.rs
@@ -376,12 +376,14 @@ impl UpstreamClient {
         // This header belongs to the IDE's JS layer, not the official client's egress.
         // Sending it creates a contradictory "Electron + Node.js" fingerprint.
 
-        // [NEW] 深度解析 body 中的 project_id 并注入 Header
-        // 只有当 Body 包含 project 字段且非测试项目时，注入 x-goog-user-project
-        if let Some(proj) = body.get("project").and_then(|v| v.as_str()) {
-            if !proj.is_empty() && proj != "test-project" && proj != "project-id" {
-                if let Ok(hv) = header::HeaderValue::from_str(proj) {
-                    headers.insert("x-goog-user-project", hv);
+        // Keep body.project for content requests, but omit the quota-project header.
+        let is_content_request = matches!(method, "generateContent" | "streamGenerateContent");
+        if !is_content_request {
+            if let Some(proj) = body.get("project").and_then(|v| v.as_str()) {
+                if !proj.is_empty() && proj != "test-project" && proj != "project-id" {
+                    if let Ok(hv) = header::HeaderValue::from_str(proj) {
+                        headers.insert("x-goog-user-project", hv);
+                    }
                 }
             }
         }
@@ -393,6 +395,9 @@ impl UpstreamClient {
                     headers.insert(hk, hv);
                 }
             }
+        }
+        if is_content_request {
+            headers.remove("x-goog-user-project");
         }
 
         // [DEBUG] Log headers for verification


### PR DESCRIPTION
## Summary

Prevent content-generation requests from sending `x-goog-user-project` while preserving the project value in the request body.

The Cloud Code PA service is access-controlled and is not a normal API that arbitrary caller projects can enable. A manually verified control request returned `403 PERMISSION_DENIED / SERVICE_DISABLED` when the header was present and succeeded with HTTP 200 after removing only that header.

Closes #3350.

## Changes

- Do not derive `x-goog-user-project` from `body.project` for `generateContent` or `streamGenerateContent`.
- Remove the header from content requests even when supplied through extra headers.
- Preserve `body.project` unchanged.
- Preserve existing header behavior for non-content methods.

## Validation

- `cargo check --manifest-path src-tauri/Cargo.toml --offline --lib`
- Manually verified the header's independent 403/200 effect with the same authenticated service request.
- A direct `generateContent` integration comparison is not claimed; the code path is verified from request construction and fallback logic.

## Compatibility

- No public request schema changes.
- Non-content request behavior remains unchanged.
- The exact Google allowlist mechanism is undocumented and is not assumed by this change.
