### PR TITLE
fix(proxy): preserve image rate-limit lifecycle

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -245,12 +245,9 @@ pub async fn fetch_account_quota(
     // 5. 同步到运行中的反代服务（如果已启动）
     let instance_lock = proxy_state.instance.read().await;
     if let Some(instance) = instance_lock.as_ref() {
-        // Safe check: If quota has recovered (> 0%), clear in-memory rate limit lock
-        let has_available_quota = quota.models.iter().any(|m| m.percentage > 0);
-        if has_available_quota {
-            instance.token_manager.clear_rate_limit(&account_id);
+        if quota.models.iter().any(|model| model.percentage > 0) {
+            instance.token_manager.clear_rate_limit_memory(&account_id);
         }
-
         let _ = instance.token_manager.reload_account(&account_id).await;
 
         // Blend TokenManager lockout state only for models that are still 0%

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -449,10 +449,86 @@ mod tests {
         let regular_parse: Result<Account, _> = serde_json::from_str(&healed_raw);
         assert!(regular_parse.is_ok(), "Healed file should be standard valid JSON");
     }
+
+    #[test]
+    fn task_quota_refresh_keeps_unexpired_live_limit() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let dir = TestDataDir::new();
+        let account_id = "live-limit-account";
+        create_account_file(dir.path(), account_id, "live-limit@example.com");
+        std::env::set_var("ABV_DATA_DIR", dir.path());
+
+        let now = chrono::Utc::now().timestamp();
+        let mut account = load_account(account_id).unwrap();
+        account.live_limited_models.insert(
+            "gemini-3-pro-image".to_string(),
+            crate::models::account::LiveLimitStatus {
+                model: "gemini-3-pro-image".to_string(),
+                status: 429,
+                reason: "QuotaExhausted".to_string(),
+                until: now + 7200,
+                detected_at: now,
+                message: Some(
+                    r#"{"error":{"details":[{"reason":"QUOTA_EXHAUSTED","metadata":{"quotaResetDelay":"2h"}}]}}"#
+                        .to_string(),
+                ),
+            },
+        );
+        account.live_limited_models.insert(
+            "gemini-3.1-flash-image".to_string(),
+            crate::models::account::LiveLimitStatus {
+                model: "gemini-3.1-flash-image".to_string(),
+                status: 429,
+                reason: "QuotaExhausted".to_string(),
+                until: now + 7200,
+                detected_at: now,
+                message: Some("QUOTA_EXHAUSTED".to_string()),
+            },
+        );
+        account.live_limited_models.insert(
+            "gemini-2.5-pro".to_string(),
+            crate::models::account::LiveLimitStatus {
+                model: "gemini-2.5-pro".to_string(),
+                status: 429,
+                reason: "QuotaExhausted".to_string(),
+                until: now + 7200,
+                detected_at: now,
+                message: Some("QUOTA_EXHAUSTED; reset after 2h".to_string()),
+            },
+        );
+        save_account(&account).unwrap();
+
+        let quota: QuotaData = serde_json::from_value(serde_json::json!({
+            "models": [
+                {"name": "gemini-3-pro-image", "percentage": 99, "reset_time": ""},
+                {"name": "gemini-3.1-flash-image", "percentage": 99, "reset_time": ""},
+                {"name": "gemini-2.5-pro", "percentage": 99, "reset_time": ""}
+            ],
+            "last_updated": now
+        }))
+        .unwrap();
+        update_account_quota(account_id, quota).unwrap();
+
+        let updated = load_account(account_id).unwrap();
+        assert!(updated
+            .live_limited_models
+            .contains_key("gemini-3-pro-image"));
+        assert!(!updated
+            .live_limited_models
+            .contains_key("gemini-3.1-flash-image"));
+        assert!(!updated.live_limited_models.contains_key("gemini-2.5-pro"));
+        std::env::remove_var("ABV_DATA_DIR");
+    }
 }
 
 /// Global account write lock to prevent corruption during concurrent operations
 static ACCOUNT_INDEX_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+pub(crate) fn lock_account_file_updates() -> Result<std::sync::MutexGuard<'static, ()>, String> {
+    ACCOUNT_INDEX_LOCK
+        .lock()
+        .map_err(|e| format!("failed_to_acquire_lock: {}", e))
+}
 
 // ... existing constants ...
 const DATA_DIR: &str = ".antigravity_tools";
@@ -1557,6 +1633,7 @@ pub fn set_current_account_id_with_target(
 
 /// Update account quota
 pub fn update_account_quota(account_id: &str, quota: QuotaData) -> Result<(), String> {
+    let _account_write = lock_account_file_updates()?;
     let mut account = load_account(account_id)?;
     account.update_quota(quota);
 
@@ -1621,14 +1698,21 @@ pub fn update_account_quota(account_id: &str, quota: QuotaData) -> Result<(), St
     }
     // --- Quota protection logic end ---
 
-    // Clean up stale live_limited_models entries for models that have recovered quota (> 0%)
+    // Quota snapshots may recover before an explicit long image lock expires. Other live
+    // records retain the baseline percentage-based cleanup behavior.
     if let Some(ref q) = account.quota {
-        account.live_limited_models.retain(|model_key, _| {
-            let recovered = q.models.iter().any(|m| {
-                let is_matching = m.name == *model_key || 
-                    crate::proxy::common::model_mapping::normalize_to_standard_id(&m.name)
-                        .map_or(false, |std| std == *model_key);
-                is_matching && m.percentage > 0
+        let now = chrono::Utc::now().timestamp();
+        account.live_limited_models.retain(|model_key, status| {
+            if crate::proxy::rate_limit::is_active_persisted_long_image_limit(
+                model_key, status, now,
+            ) {
+                return true;
+            }
+            let recovered = q.models.iter().any(|model| {
+                let is_matching = model.name == *model_key
+                    || crate::proxy::common::model_mapping::normalize_to_standard_id(&model.name)
+                        .is_some_and(|standard| standard == *model_key);
+                is_matching && model.percentage > 0
             });
             !recovered
         });
@@ -1639,9 +1723,6 @@ pub fn update_account_quota(account_id: &str, quota: QuotaData) -> Result<(), St
 
     // [FIX] 同时更新索引文件中的摘要信息，确保列表页图标即时刷新
     {
-        let _lock = ACCOUNT_INDEX_LOCK
-            .lock()
-            .map_err(|e| format!("failed_to_acquire_lock: {}", e))?;
         if let Ok(mut index) = load_account_index() {
             if let Some(summary) = index.accounts.iter_mut().find(|a| a.id == account_id) {
                 summary.protected_models = account.protected_models.clone();

--- a/src-tauri/src/proxy/handlers/claude.rs
+++ b/src-tauri/src/proxy/handlers/claude.rs
@@ -795,7 +795,7 @@ pub async fn handle_messages(
     let max_attempts = MAX_RETRY_ATTEMPTS.min(pool_size.saturating_add(1)).max(2);
 
     let mut last_error = String::new();
-    let retried_without_thinking = false;
+    let mut retried_without_thinking = false;
     let mut last_email: Option<String> = None;
     let mut last_mapped_model: Option<String> = None;
     let mut last_status = StatusCode::SERVICE_UNAVAILABLE; // Default to 503 if no response reached
@@ -1612,7 +1612,7 @@ pub async fn handle_messages(
             || status_code == 404
         {
             token_manager
-                .mark_rate_limited_async(
+                .mark_rate_limited_async_baseline(
                     &email,
                     status_code,
                     retry_after.as_deref(),
@@ -1645,7 +1645,8 @@ pub async fn handle_messages(
                 || lower_err.contains("must be `thinking`")
                 || lower_err.contains("must be 'thinking'"))
         {
-            // Existing logic for thinking signature...\n            retried_without_thinking = true;
+            // Existing logic for thinking signature.
+            retried_without_thinking = true;
 
             // 使用 WARN 级别,因为这不应该经常发生(已经主动过滤过)
             tracing::warn!(

--- a/src-tauri/src/proxy/handlers/common.rs
+++ b/src-tauri/src/proxy/handlers/common.rs
@@ -6,6 +6,7 @@ use axum::{
     Json,
 };
 use serde_json::{json, Value};
+use std::collections::HashSet;
 use tokio::time::{sleep, Duration};
 use tracing::{debug, info};
 
@@ -26,14 +27,117 @@ pub enum RetryStrategy {
     GraceRetry(Duration),
 }
 
+#[derive(Debug, Default)]
+pub struct RequestRetryState {
+    grace_retried_accounts: HashSet<String>,
+}
+
+impl RequestRetryState {
+    pub fn determine_strategy(
+        &mut self,
+        account_id: &str,
+        status_code: u16,
+        error_text: &str,
+        retry_after: Option<&str>,
+        retried_without_thinking: bool,
+    ) -> RetryStrategy {
+        let allow_grace_retry = !self.grace_retried_accounts.contains(account_id);
+        let strategy = determine_retry_strategy_inner(
+            status_code,
+            error_text,
+            retry_after,
+            retried_without_thinking,
+            allow_grace_retry,
+        );
+        if matches!(strategy, RetryStrategy::GraceRetry(_)) {
+            self.grace_retried_accounts.insert(account_id.to_string());
+        }
+        strategy
+    }
+}
+
+pub fn next_rotation_attempt(
+    used_attempts: &mut usize,
+    max_attempts: usize,
+    retry_same_account: bool,
+) -> Option<usize> {
+    if retry_same_account {
+        return used_attempts.checked_sub(1);
+    }
+    if *used_attempts >= max_attempts {
+        return None;
+    }
+
+    let attempt = *used_attempts;
+    *used_attempts += 1;
+    Some(attempt)
+}
+
+#[derive(Debug, Default)]
+pub struct FailureStatusTracker {
+    saw_failure: bool,
+    last_non_rate_limit: Option<StatusCode>,
+}
+
+impl FailureStatusTracker {
+    pub fn record(&mut self, status: StatusCode) {
+        self.saw_failure = true;
+        if status != StatusCode::TOO_MANY_REQUESTS {
+            self.last_non_rate_limit = Some(status);
+        }
+    }
+
+    pub fn final_status(&self) -> StatusCode {
+        self.last_non_rate_limit.unwrap_or_else(|| {
+            if self.saw_failure {
+                StatusCode::TOO_MANY_REQUESTS
+            } else {
+                StatusCode::BAD_GATEWAY
+            }
+        })
+    }
+}
+
 /// 根据错误状态码和错误信息确定重试策略
 pub fn determine_retry_strategy(
     status_code: u16,
     error_text: &str,
     retried_without_thinking: bool,
 ) -> RetryStrategy {
-    // [FIX] 400 signature errors must be case-insensitive and cover all Google variants:
-    // "Invalid thought signature", "thoughtSignature", "thought_signature", "Invalid signature"
+    if status_code == 429 {
+        return match crate::proxy::upstream::retry::parse_legacy_retry_delay(error_text) {
+            Some(delay_ms) if delay_ms > 0 && delay_ms <= 2000 => {
+                let actual_delay = delay_ms.saturating_add(100);
+                tracing::info!(
+                    "Grace Retry Triggered: Delay {}ms is within window, using same account",
+                    actual_delay
+                );
+                RetryStrategy::GraceRetry(Duration::from_millis(actual_delay))
+            }
+            Some(delay_ms) => RetryStrategy::FixedDelay(Duration::from_millis(
+                delay_ms.saturating_add(200).min(30_000),
+            )),
+            None => RetryStrategy::LinearBackoff { base_ms: 5000 },
+        };
+    }
+
+    determine_retry_strategy_inner(
+        status_code,
+        error_text,
+        None,
+        retried_without_thinking,
+        true,
+    )
+}
+
+fn determine_retry_strategy_inner(
+    status_code: u16,
+    error_text: &str,
+    retry_after: Option<&str>,
+    retried_without_thinking: bool,
+    allow_grace_retry: bool,
+) -> RetryStrategy {
+    // 400 signature errors must be case-insensitive and cover all Google variants.
     let lower = error_text.to_lowercase();
     match status_code {
         // 400 错误：仅在特定 Thinking 签名失败时重试一次
@@ -53,17 +157,25 @@ pub fn determine_retry_strategy(
         // 429 限流错误
         429 => {
             // 优先使用服务端返回的 Retry-After / quotaResetDelay
-            if let Some(delay_ms) = crate::proxy::upstream::retry::parse_retry_delay(error_text) {
-                // [NEW] 如果延迟在 2s 内，执行 Grace Retry (原地重试)
+            if let Some(parsed_delay) = crate::proxy::upstream::retry::parse_retry_delay_with_source(
+                error_text,
+                retry_after,
+            ) {
+                let delay_ms = parsed_delay.raw_ms;
+                // 短期原账号重试已使用时，立即回到现有换号逻辑
                 if crate::proxy::upstream::retry::should_grace_retry(delay_ms) {
-                    let actual_delay = delay_ms.saturating_add(100); // 增加 100ms 安全缓冲
-                    tracing::info!(
-                        "Grace Retry Triggered: Delay {}ms is within window, using same account",
-                        actual_delay
-                    );
-                    RetryStrategy::GraceRetry(Duration::from_millis(actual_delay))
+                    if allow_grace_retry {
+                        let actual_delay = parsed_delay.actual_wait_ms();
+                        tracing::info!(
+                            "Grace Retry Triggered: Delay {}ms is within window, using same account",
+                            actual_delay
+                        );
+                        RetryStrategy::GraceRetry(Duration::from_millis(actual_delay))
+                    } else {
+                        RetryStrategy::FixedDelay(Duration::ZERO)
+                    }
                 } else {
-                    let actual_delay = delay_ms.saturating_add(200).min(30_000);
+                    let actual_delay = parsed_delay.actual_wait_ms().min(30_000);
                     RetryStrategy::FixedDelay(Duration::from_millis(actual_delay))
                 }
             } else {
@@ -96,6 +208,61 @@ pub fn determine_retry_strategy(
 
         // 其他错误：不重试
         _ => RetryStrategy::NoRetry,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_short_429_preserves_rotation_budget_and_structured_status() {
+        let body = r#"{"error":{"details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"1s"}]}}"#;
+
+        let drive_failures = |account_count| {
+            let mut state = RequestRetryState::default();
+            let mut used_attempts = 0;
+            let mut retry_same_account = false;
+            let mut sends = Vec::new();
+
+            while let Some(attempt) = next_rotation_attempt(
+                &mut used_attempts,
+                account_count,
+                retry_same_account,
+            ) {
+                retry_same_account = false;
+                sends.push(attempt);
+                let account_id = format!("account-{}", attempt);
+                let strategy =
+                    state.determine_strategy(&account_id, 429, body, None, false);
+                if matches!(strategy, RetryStrategy::GraceRetry(_)) {
+                    assert!(!should_rotate_account(429, Some(&strategy)));
+                    retry_same_account = true;
+                } else {
+                    assert!(should_rotate_account(429, Some(&strategy)));
+                }
+            }
+            sends
+        };
+
+        assert_eq!(drive_failures(1), vec![0, 0]);
+        assert_eq!(drive_failures(2), vec![0, 0, 1, 1]);
+
+        let mut all_429 = FailureStatusTracker::default();
+        all_429.record(StatusCode::TOO_MANY_REQUESTS);
+        all_429.record(StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(all_429.final_status(), StatusCode::TOO_MANY_REQUESTS);
+
+        for non_429 in [StatusCode::FORBIDDEN, StatusCode::SERVICE_UNAVAILABLE] {
+            let mut mixed = FailureStatusTracker::default();
+            mixed.record(non_429);
+            mixed.record(StatusCode::TOO_MANY_REQUESTS);
+            assert_eq!(mixed.final_status(), non_429);
+        }
+
+        let mut all_503 = FailureStatusTracker::default();
+        all_503.record(StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(all_503.final_status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }
 

--- a/src-tauri/src/proxy/handlers/gemini.rs
+++ b/src-tauri/src/proxy/handlers/gemini.rs
@@ -11,7 +11,8 @@ use tracing::{debug, error, info};
 use crate::proxy::common::client_adapter::CLIENT_ADAPTERS;
 use crate::proxy::debug_logger;
 use crate::proxy::handlers::common::{
-    apply_retry_strategy, determine_retry_strategy, should_rotate_account,
+    apply_retry_strategy, next_rotation_attempt, should_rotate_account, FailureStatusTracker,
+    RequestRetryState, RetryStrategy,
 };
 use crate::proxy::mappers::gemini::{unwrap_response, wrap_request, wrap_request_v2};
 use crate::proxy::server::AppState;
@@ -20,6 +21,48 @@ use crate::proxy::upstream::client::mask_email;
 use axum::http::HeaderMap;
 
 const MAX_RETRY_ATTEMPTS: usize = 3;
+
+fn response_has_inline_image_data(value: &Value) -> bool {
+    let response = value.get("response").unwrap_or(value);
+    response
+        .get("candidates")
+        .and_then(Value::as_array)
+        .is_some_and(|candidates| {
+            candidates.iter().any(|candidate| {
+                candidate
+                    .get("content")
+                    .and_then(|content| content.get("parts"))
+                    .and_then(Value::as_array)
+                    .is_some_and(|parts| {
+                        parts.iter().any(|part| {
+                            part.get("inlineData")
+                                .or_else(|| part.get("inline_data"))
+                                .and_then(|image| image.get("data"))
+                                .and_then(Value::as_str)
+                                .is_some_and(|data| !data.is_empty())
+                        })
+                    })
+            })
+        })
+}
+
+#[cfg(test)]
+mod image_success_tests {
+    use super::response_has_inline_image_data;
+    use serde_json::json;
+
+    #[test]
+    fn task_gemini_image_success_requires_nonempty_payload() {
+        let empty = json!({
+            "response": {"candidates": [{"content": {"parts": [{"inlineData": {"data": ""}}]}}]}
+        });
+        let image = json!({
+            "response": {"candidates": [{"content": {"parts": [{"inlineData": {"data": "AQ=="}}]}}]}
+        });
+        assert!(!response_has_inline_image_data(&empty));
+        assert!(response_has_inline_image_data(&image));
+    }
+}
 
 /// 处理 generateContent 和 streamGenerateContent
 /// 路径参数: model_name, method (e.g. "gemini-pro", "generateContent")
@@ -99,8 +142,16 @@ pub async fn handle_generate(
     let mut last_error = String::new();
     let mut last_email: Option<String> = None;
     let mut force_rotate = false;
+    let mut retry_state = RequestRetryState::default();
+    let mut retry_credentials: Option<(String, String, String, String, u64)> = None;
+    let mut failure_statuses = FailureStatusTracker::default();
+    let mut used_attempts = 0;
 
-    for attempt in 0..max_attempts {
+    while let Some(attempt) = next_rotation_attempt(
+        &mut used_attempts,
+        max_attempts,
+        retry_credentials.is_some(),
+    ) {
         // 3. 模型路由解析
         let mapped_model = crate::proxy::common::model_mapping::resolve_model_route(
             &model_name,
@@ -138,23 +189,28 @@ pub async fn handle_generate(
         let session_id = SessionManager::extract_gemini_session_id(&body, &model_name);
 
         // 关键：根据 force_rotate 标志决定是否轮换账号（支持 Grace Retry 原地重试）
-        let (access_token, project_id, email, account_id, _wait_ms) = match token_manager
-            .get_token(
-                &config.request_type,
-                force_rotate,
-                Some(&session_id),
-                &config.final_model,
-            )
-            .await
-        {
-            Ok(t) => t,
-            Err(e) => {
-                return Err((
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    format!("Token error: {}", e),
-                ));
-            }
-        };
+        let (access_token, project_id, email, account_id, _wait_ms) =
+            if let Some(credentials) = retry_credentials.take() {
+                credentials
+            } else {
+                match token_manager
+                    .get_token(
+                        &config.request_type,
+                        force_rotate,
+                        Some(&session_id),
+                        &config.final_model,
+                    )
+                    .await
+                {
+                    Ok(t) => t,
+                    Err(e) => {
+                        return Err((
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            format!("Token error: {}", e),
+                        ));
+                    }
+                }
+            };
 
         let mapped_model = token_manager
             .resolve_dynamic_model_for_account(&account_id, &mapped_model)
@@ -229,6 +285,7 @@ pub async fn handle_generate(
             Ok(r) => r,
             Err(e) => {
                 last_error = e.clone();
+                failure_statuses.record(StatusCode::BAD_GATEWAY);
                 debug!(
                     "Gemini Request failed on attempt {}/{}: {}",
                     attempt + 1,
@@ -349,14 +406,20 @@ pub async fn handle_generate(
                 }
 
                 if retry_gemini {
+                    failure_statuses.record(StatusCode::BAD_GATEWAY);
                     continue;
                 }
-
                 let s_id_for_stream = s_id.clone();
                 let model_name_for_stream = mapped_model.clone();
+                let track_image_success = config.request_type == "image_gen";
+                let image_success_manager = token_manager.clone();
+                let image_success_account = account_id.clone();
+                let image_success_model = mapped_model.clone();
                 let stream = async_stream::stream! {
                     let mut first_data = first_chunk;
                     let mut meta_sent = false;
+                    let mut saw_image_data = false;
+                    let mut stream_failed = false;
 
                     loop {
                         // [NEW] 阶段 6.2: 补全 __cloudCodeMeta 响应元数据透传
@@ -381,6 +444,7 @@ pub async fn handle_generate(
                                 Ok(next_item) => next_item,
                                 Err(_) => {
                                     error!("[Gemini-SSE] Idle timeout after 300s, terminating stream");
+                                    stream_failed = true;
                                     None
                                 }
                             }
@@ -390,6 +454,7 @@ pub async fn handle_generate(
                             Some(Ok(b)) => b,
                             Some(Err(e)) => {
                                 error!("[Gemini-SSE] Stream error: {}", e);
+                                stream_failed = true;
                                 let error_json = serde_json::json!({
                                     "id": &s_id_for_stream,
                                     "object": "chat.completion.chunk",
@@ -428,6 +493,9 @@ pub async fn handle_generate(
 
                                     match serde_json::from_str::<Value>(json_part) {
                                         Ok(mut json) => {
+                                            if track_image_success && response_has_inline_image_data(&json) {
+                                                saw_image_data = true;
+                                            }
                                             // [FIX #765] Extract thoughtSignature from stream
                                             let inner_val = if json.get("response").is_some() {
                                                 json.get("response")
@@ -464,6 +532,7 @@ pub async fn handle_generate(
                                         }
                                         Err(e) => {
                                             debug!("[Gemini-SSE] JSON parse error: {}, passing raw line", e);
+                                            stream_failed = true;
                                             yield Ok::<Bytes, String>(Bytes::from(format!("{}\n\n", line)));
                                         }
                                     }
@@ -477,6 +546,15 @@ pub async fn handle_generate(
                                 yield Ok::<Bytes, String>(line_raw.freeze());
                             }
                         }
+                    }
+
+                    if track_image_success && saw_image_data && !stream_failed {
+                        image_success_manager.mark_account_success(&image_success_account);
+                        image_success_manager
+                            .clear_persisted_live_limit(
+                                &image_success_account,
+                                Some(&image_success_model),
+                            );
                     }
                 };
 
@@ -580,7 +658,13 @@ pub async fn handle_generate(
         }
 
         // 处理错误并重试
+        failure_statuses.record(status);
         let status_code = status.as_u16();
+        let retry_after = response
+            .headers()
+            .get("Retry-After")
+            .and_then(|header| header.to_str().ok())
+            .map(str::to_string);
         let error_text = response
             .text()
             .await
@@ -640,7 +724,31 @@ pub async fn handle_generate(
         }
 
         // 确定重试策略
-        let strategy = determine_retry_strategy(status_code, &error_text, false);
+        let strategy = retry_state.determine_strategy(
+            &account_id,
+            status_code,
+            &error_text,
+            retry_after.as_deref(),
+            false,
+        );
+        let needs_quota_refresh = if config.request_type == "image_gen" && status_code == 429 {
+            token_manager
+                .mark_rate_limited_fast(
+                    &email,
+                    status_code,
+                    retry_after.as_deref(),
+                    &error_text,
+                    Some(&mapped_model),
+                )
+                .await
+        } else {
+            false
+        };
+        if needs_quota_refresh {
+            token_manager
+                .refresh_quota_lock_after_fast_mark(&email, Some(&mapped_model))
+                .await;
+        }
         let trace_id = format!("gemini_{}", session_id);
 
         // 执行退避
@@ -653,6 +761,15 @@ pub async fn handle_generate(
         )
         .await
         {
+            if matches!(strategy, RetryStrategy::GraceRetry(_)) {
+                retry_credentials = Some((
+                    access_token.clone(),
+                    project_id.clone(),
+                    email.clone(),
+                    account_id.clone(),
+                    0,
+                ));
+            }
             // [NEW] Apply Client Adapter "let_it_crash" strategy
             if let Some(adapter) = &client_adapter {
                 if adapter.let_it_crash() && attempt > 0 {
@@ -730,14 +847,8 @@ pub async fn handle_generate(
             .into_response());
     }
 
-    // 所有尝试均失败：根据最后的错误类型决定状态码
-    let final_status = if last_error.contains("403") || last_error.contains("PERMISSION_DENIED") || last_error.contains("VALIDATION_REQUIRED") {
-        StatusCode::FORBIDDEN
-    } else if last_error.contains("401") || last_error.contains("UNAUTHENTICATED") {
-        StatusCode::UNAUTHORIZED
-    } else {
-        StatusCode::TOO_MANY_REQUESTS
-    };
+    // 所有尝试均失败：仅当全部结构化失败状态均为 429 时返回 429
+    let final_status = failure_statuses.final_status();
 
     if let Some(email) = last_email {
         Ok((

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -17,6 +17,9 @@ use crate::proxy::server::AppState;
 use crate::proxy::upstream::client::mask_email;
 
 const MAX_RETRY_ATTEMPTS: usize = 3;
+const MAX_INPUT_IMAGES: usize = 16;
+const MAX_INPUT_IMAGE_BYTES: usize = 20 * 1024 * 1024;
+const MAX_TOTAL_INPUT_IMAGE_BYTES: usize = 32 * 1024 * 1024;
 const CODEX_VISIBLE_THOUGHT_MESSAGE_PREFIX: &str = "msg_thought_";
 use super::common::{
     apply_retry_strategy, determine_retry_strategy, should_rotate_account, RetryStrategy,
@@ -27,6 +30,226 @@ use crate::proxy::session_manager::SessionManager;
 use axum::http::HeaderMap;
 use std::collections::VecDeque;
 use tokio::time::Duration;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct NormalizedInputImage {
+    mime_type: String,
+    base64_data: String,
+    decoded_len: usize,
+}
+
+fn validate_input_image_limits(
+    image_count: usize,
+    image_bytes: usize,
+    total_bytes: usize,
+) -> Result<(), String> {
+    if image_count > MAX_INPUT_IMAGES {
+        return Err(format!(
+            "Too many input images: maximum is {}",
+            MAX_INPUT_IMAGES
+        ));
+    }
+    if image_bytes > MAX_INPUT_IMAGE_BYTES {
+        return Err(format!(
+            "Input image is too large: maximum decoded size is {} bytes",
+            MAX_INPUT_IMAGE_BYTES
+        ));
+    }
+    if total_bytes > MAX_TOTAL_INPUT_IMAGE_BYTES {
+        return Err(format!(
+            "Total input image data is too large: maximum decoded size is {} bytes",
+            MAX_TOTAL_INPUT_IMAGE_BYTES
+        ));
+    }
+    Ok(())
+}
+
+fn normalized_image_from_bytes(
+    bytes: &[u8],
+    mime_type: &str,
+    image_count: usize,
+    total_bytes: usize,
+) -> Result<NormalizedInputImage, String> {
+    let next_total = total_bytes.saturating_add(bytes.len());
+    validate_input_image_limits(image_count, bytes.len(), next_total)?;
+    Ok(NormalizedInputImage {
+        mime_type: mime_type.to_string(),
+        base64_data: base64::engine::general_purpose::STANDARD.encode(bytes),
+        decoded_len: bytes.len(),
+    })
+}
+
+fn parse_image_data_url(
+    data_url: &str,
+    image_count: usize,
+    total_bytes: usize,
+) -> Result<NormalizedInputImage, String> {
+    let (metadata, encoded) = data_url
+        .strip_prefix("data:")
+        .and_then(|value| value.split_once(','))
+        .ok_or_else(|| "Input image must be a base64 data:image URL".to_string())?;
+    let mut metadata_parts = metadata.split(';');
+    let mime_type = metadata_parts.next().unwrap_or_default();
+    if !mime_type.starts_with("image/") || mime_type.len() <= "image/".len() {
+        return Err("Input image data URL must use an image MIME type".to_string());
+    }
+    if !metadata_parts.any(|part| part.eq_ignore_ascii_case("base64")) {
+        return Err("Input image data URL must be base64 encoded".to_string());
+    }
+    if encoded.is_empty() {
+        return Err("Input image data URL is empty".to_string());
+    }
+
+    let max_encoded_len = MAX_INPUT_IMAGE_BYTES.div_ceil(3).saturating_mul(4);
+    if encoded.len() > max_encoded_len {
+        return Err(format!(
+            "Input image is too large: maximum decoded size is {} bytes",
+            MAX_INPUT_IMAGE_BYTES
+        ));
+    }
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|_| "Input image contains invalid base64 data".to_string())?;
+    normalized_image_from_bytes(&decoded, mime_type, image_count, total_bytes)
+}
+
+fn parse_generation_input_images(image: Option<&Value>) -> Result<Vec<NormalizedInputImage>, String> {
+    let Some(image) = image else {
+        return Ok(Vec::new());
+    };
+
+    let urls: Vec<&str> = match image {
+        Value::String(url) => vec![url.as_str()],
+        Value::Array(urls) if urls.is_empty() => {
+            return Err("Input image array must not be empty".to_string())
+        }
+        Value::Array(urls) => urls
+            .iter()
+            .map(|url| {
+                url.as_str()
+                    .ok_or_else(|| "Every input image must be a base64 data:image URL".to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        _ => return Err("Input image must be a string or an array of strings".to_string()),
+    };
+
+    validate_input_image_limits(urls.len(), 0, 0)?;
+    let mut images = Vec::with_capacity(urls.len());
+    let mut total_bytes = 0;
+    for url in urls {
+        let image = parse_image_data_url(url, images.len() + 1, total_bytes)?;
+        total_bytes = total_bytes.saturating_add(image.decoded_len);
+        images.push(image);
+    }
+    Ok(images)
+}
+
+fn generation_image_size_param(body: &Value) -> Result<Option<&str>, String> {
+    for key in ["image_size", "imageSize"] {
+        let Some(value) = body.get(key) else {
+            continue;
+        };
+        if value.is_null() {
+            continue;
+        }
+        return value.as_str().map(Some).ok_or_else(|| {
+            "Invalid image_size: expected one of 1K, 2K, 4K, or auto".to_string()
+        });
+    }
+    Ok(None)
+}
+
+fn is_edit_image_field(name: &str) -> bool {
+    name == "image"
+        || name == "image[]"
+        || name
+            .strip_prefix("image")
+            .is_some_and(|suffix| !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+fn edit_size_input<'a>(aspect_ratio: Option<&'a str>, size: Option<&'a str>) -> Option<&'a str> {
+    aspect_ratio
+        .filter(|value| {
+            crate::proxy::mappers::common_utils::image_aspect_ratio_from_size(value).is_some()
+        })
+        .or_else(|| {
+            size.filter(|value| {
+                crate::proxy::mappers::common_utils::image_aspect_ratio_from_size(value).is_some()
+            })
+        })
+}
+
+fn image_account_selection_target(model_to_use: &str) -> &str {
+    model_to_use
+}
+
+fn image_inline_part(image: &NormalizedInputImage) -> Value {
+    json!({
+        "inlineData": {
+            "mimeType": image.mime_type,
+            "data": image.base64_data
+        }
+    })
+}
+
+fn build_image_contents(
+    prompt: String,
+    input_images: &[NormalizedInputImage],
+    mask: Option<&NormalizedInputImage>,
+) -> Vec<Value> {
+    let mut parts = Vec::with_capacity(1 + input_images.len() + usize::from(mask.is_some()));
+    parts.push(json!({ "text": prompt }));
+    for (index, image) in input_images.iter().enumerate() {
+        parts.push(image_inline_part(image));
+        if index == 0 {
+            if let Some(mask) = mask {
+                parts.push(image_inline_part(mask));
+            }
+        }
+    }
+    if input_images.is_empty() {
+        if let Some(mask) = mask {
+            parts.push(image_inline_part(mask));
+        }
+    }
+    parts
+}
+
+fn build_image_edit_body(
+    project_id: String,
+    resolved_model: &str,
+    contents_parts: Vec<Value>,
+    image_config: Value,
+) -> Value {
+    json!({
+        "project": project_id,
+        "requestId": format!("img-edit-{}", uuid::Uuid::new_v4()),
+        "model": resolved_model,
+        "userAgent": "antigravity",
+        "requestType": "image_gen",
+        "request": {
+            "contents": [{
+                "role": "user",
+                "parts": contents_parts
+            }],
+            "generationConfig": {
+                "candidateCount": 1,
+                "imageConfig": image_config,
+                "maxOutputTokens": 8192,
+                "stopSequences": [],
+                "temperature": 1.0,
+                "topP": 0.95,
+                "topK": 40
+            },
+            "safetySettings": [
+                { "category": "HARM_CATEGORY_HARASSMENT", "threshold": "OFF" },
+                { "category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "OFF" },
+                { "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "OFF" },
+                { "category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "OFF" },
+            ]
+        }
+    })
+}
 
 /// Return true only when a streamed chunk contains an actual error event.
 ///
@@ -301,15 +524,24 @@ fn is_codex_transcript_only_assistant_message(item: &Value, text: &str) -> bool 
 
 #[cfg(test)]
 mod stream_peek_tests {
+    use super::build_image_contents;
+    use super::build_image_edit_body;
     use super::convert_chat_response_to_responses;
     use super::convert_codex_to_openai_request;
     use super::drop_leading_orphan_tool_history;
+    use super::edit_size_input;
+    use super::generation_image_size_param;
+    use super::image_account_selection_target;
     use super::is_codex_transcript_only_assistant_message;
+    use super::is_edit_image_field;
+    use super::parse_generation_input_images;
     use super::responses_input_item_type;
     use super::responses_message_parts;
     use super::rewrite_terminal_assistant_prefill;
     use super::stream_chunk_has_error_event;
-    use serde_json::json;
+    use super::validate_input_image_limits;
+    use super::{MAX_INPUT_IMAGES, MAX_INPUT_IMAGE_BYTES, MAX_TOTAL_INPUT_IMAGE_BYTES};
+    use serde_json::{json, Value};
 
     #[test]
     fn responses_created_with_null_error_is_not_an_error_event() {
@@ -589,6 +821,142 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
             &clean_final,
             "done"
         ));
+    }
+
+    #[test]
+    fn generation_image_extension_adds_single_and_array_images_in_order() {
+        let single = json!("data:image/png;base64,AQ==");
+        let single_images = parse_generation_input_images(Some(&single)).expect("single data URL");
+        let single_parts = build_image_contents("prompt".to_string(), &single_images, None);
+        assert_eq!(single_parts.len(), 2);
+        assert_eq!(single_parts[1]["inlineData"]["data"], "AQ==");
+
+        let multiple = json!([
+            "data:image/png;base64,AQ==",
+            "data:image/jpeg;base64,Ag=="
+        ]);
+        let multiple_images =
+            parse_generation_input_images(Some(&multiple)).expect("ordered data URL array");
+        let multiple_parts = build_image_contents("prompt".to_string(), &multiple_images, None);
+        assert_eq!(multiple_parts.len(), 3);
+        assert_eq!(multiple_parts[1]["inlineData"]["data"], "AQ==");
+        assert_eq!(multiple_parts[2]["inlineData"]["data"], "Ag==");
+    }
+
+    #[test]
+    fn generation_without_image_remains_text_only() {
+        let images = parse_generation_input_images(None).expect("absent image is standard text-to-image");
+        let parts = build_image_contents("prompt".to_string(), &images, None);
+        assert_eq!(parts, vec![json!({"text": "prompt"})]);
+    }
+
+    #[test]
+    fn generation_image_extension_rejects_invalid_or_remote_inputs() {
+        let invalid_inputs = [
+            json!("https://example.invalid/image.png"),
+            json!("data:text/plain;base64,AQ=="),
+            json!("data:image/png;base64,not-base64"),
+            json!([]),
+            json!(["data:image/png;base64,AQ==", 2]),
+        ];
+        for input in invalid_inputs {
+            assert!(parse_generation_input_images(Some(&input)).is_err());
+        }
+
+        let too_many = Value::Array(
+            (0..=MAX_INPUT_IMAGES)
+                .map(|_| json!("data:image/png;base64,AQ=="))
+                .collect(),
+        );
+        assert!(parse_generation_input_images(Some(&too_many)).is_err());
+        assert!(validate_input_image_limits(1, MAX_INPUT_IMAGE_BYTES + 1, 0).is_err());
+        assert!(
+            validate_input_image_limits(1, 1, MAX_TOTAL_INPUT_IMAGE_BYTES + 1).is_err()
+        );
+
+        assert!(generation_image_size_param(&json!({"imageSize": 4})).is_err());
+    }
+
+    #[test]
+    fn edit_image_fields_preserve_all_supported_forms_in_arrival_order() {
+        let field_names = [
+            "image",
+            "image",
+            "image[]",
+            "image[]",
+            "image1",
+            "image2",
+            "imageSize",
+            "image_size",
+            "imageReference",
+        ];
+        let accepted: Vec<(usize, &str)> = field_names
+            .iter()
+            .enumerate()
+            .filter(|(_, name)| is_edit_image_field(name))
+            .map(|(index, name)| (index, *name))
+            .collect();
+        assert_eq!(
+            accepted,
+            vec![
+                (0, "image"),
+                (1, "image"),
+                (2, "image[]"),
+                (3, "image[]"),
+                (4, "image1"),
+                (5, "image2"),
+            ]
+        );
+    }
+
+    #[test]
+    fn edit_aspect_ratio_priority_preserves_suffix_without_explicit_size() {
+        use crate::proxy::mappers::common_utils::try_parse_image_config_with_params;
+
+        let suffix_input = edit_size_input(None, None);
+        let (suffix_config, _) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image-16x9",
+            suffix_input,
+            None,
+            None,
+        )
+        .expect("model suffix config");
+        assert_eq!(suffix_config["aspectRatio"], "16:9");
+
+        let explicit_input = edit_size_input(Some("4:3"), Some("1280x720"));
+        let (explicit_config, _) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image-16x9",
+            explicit_input,
+            None,
+            None,
+        )
+        .expect("explicit aspect ratio config");
+        assert_eq!(explicit_config["aspectRatio"], "4:3");
+    }
+
+    #[test]
+    fn edit_flash_model_is_used_for_account_selection_and_resolved_upstream_body() {
+        use crate::proxy::mappers::common_utils::try_parse_image_config_with_params;
+
+        let (image_config, model_to_use) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image",
+            None,
+            None,
+            None,
+        )
+        .expect("flash edit model config");
+        assert_eq!(
+            image_account_selection_target(&model_to_use),
+            "gemini-3.1-flash-image"
+        );
+
+        let body = build_image_edit_body(
+            "project".to_string(),
+            "account-resolved-image-model",
+            json!([{"text": "prompt"}]).as_array().cloned().expect("parts"),
+            image_config,
+        );
+        assert_eq!(body["model"], "account-resolved-image-model");
     }
 }
 
@@ -3430,31 +3798,36 @@ pub async fn handle_images_generations_internal(
 
     let quality = body.get("quality").and_then(|v| v.as_str());
 
-    let image_size = body
-        .get("image_size")
-        .or(body.get("imageSize"))
-        .and_then(|v| v.as_str());
+    let image_size = generation_image_size_param(&body)
+        .map_err(|message| (StatusCode::BAD_REQUEST, message, None))?;
 
     let style = body
         .get("style")
         .and_then(|v| v.as_str())
         .unwrap_or("vivid");
 
+    // Canvas compatibility extension: OpenAI's standard generations endpoint does not define
+    // this top-level field. Accept only inline data:image URLs and never fetch remote URLs.
+    let input_images = parse_generation_input_images(body.get("image")).map_err(|message| {
+        (StatusCode::BAD_REQUEST, message, None)
+    })?;
+
     info!(
-        "[Images] Received request: model={}, prompt={:.50}..., n={}, size={}, quality={}, style={}",
-        model,
-        prompt,
-        n,
-        size.unwrap_or("auto"),
-        quality.unwrap_or("auto"),
-        style
+        model = model,
+        image_count = input_images.len(),
+        n = n,
+        size = size.unwrap_or("auto"),
+        quality = quality.unwrap_or("auto"),
+        style = style,
+        "[Images] Received generation request"
     );
 
     // 2. 使用 common_utils 解析图片配置（统一逻辑，支持动态计算宽高比和 quality 映射）
     let (image_config, clean_model_name) =
-        crate::proxy::mappers::common_utils::parse_image_config_with_params(
+        crate::proxy::mappers::common_utils::try_parse_image_config_with_params(
             model, size, quality, image_size,
-        );
+        )
+        .map_err(|message| (StatusCode::BAD_REQUEST, message, None))?;
 
     // 3. Prompt Enhancement（保留原有逻辑）
     let mut final_prompt = prompt.to_string();
@@ -3466,6 +3839,7 @@ pub async fn handle_images_generations_internal(
         "natural" => final_prompt.push_str(", (natural lighting, realistic, photorealistic)"),
         _ => {}
     }
+    let contents_parts = build_image_contents(final_prompt, &input_images, None);
 
     // 4. 并发发送请求
     // 注意：不再在外部获取 Token，而是移入 Task 内部并在重试时获取
@@ -3485,7 +3859,7 @@ pub async fn handle_images_generations_internal(
     for _ in 0..n {
         let upstream = upstream.clone();
         let token_manager = token_manager.clone();
-        let final_prompt = final_prompt.clone();
+        let contents_parts = contents_parts.clone();
         let image_config = image_config.clone(); // 使用解析后的完整配置
         let _response_format = response_format.to_string();
 
@@ -3532,7 +3906,7 @@ pub async fn handle_images_generations_internal(
                     "request": {
                         "contents": [{
                             "role": "user",
-                            "parts": [{"text": final_prompt}]
+                            "parts": contents_parts
                         }],
                         "generationConfig": {
                             "candidateCount": 1, // 强制单张
@@ -3742,16 +4116,17 @@ pub async fn handle_images_edits(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     tracing::info!("[Images] Received edit request");
 
-    let mut image_data: Option<(String, String)> = None;
-    let mut mask_data: Option<(String, String)> = None;
-    let mut reference_images: Vec<(String, String)> = Vec::new(); // Store (base64 data, mime type) reference images
+    let mut input_images: Vec<NormalizedInputImage> = Vec::new();
+    let mut mask_data: Option<NormalizedInputImage> = None;
+    let mut total_input_image_bytes = 0;
     let mut prompt = String::new();
     let mut n = 1;
-    let mut size = "1024x1024".to_string();
+    let mut size: Option<String> = None;
     let mut response_format = "b64_json".to_string();
     let mut model = "gemini-3.1-flash-image".to_string();
     let mut aspect_ratio: Option<String> = None;
     let mut image_size_param: Option<String> = None;
+    let mut quality: Option<String> = None;
     let mut style: Option<String> = None;
 
     while let Some(field) = multipart
@@ -3761,7 +4136,7 @@ pub async fn handle_images_edits(
     {
         let name = field.name().unwrap_or("").to_string();
 
-        if name == "image" {
+        if is_edit_image_field(&name) {
             let mime_type = field
                 .content_type()
                 .map(|content_type| content_type.to_string())
@@ -3770,10 +4145,15 @@ pub async fn handle_images_edits(
                 .bytes()
                 .await
                 .map_err(|e| (StatusCode::BAD_REQUEST, format!("Image read error: {}", e)))?;
-            image_data = Some((
-                base64::engine::general_purpose::STANDARD.encode(data),
-                mime_type,
-            ));
+            let image = normalized_image_from_bytes(
+                &data,
+                &mime_type,
+                input_images.len() + 1,
+                total_input_image_bytes,
+            )
+            .map_err(|message| (StatusCode::BAD_REQUEST, message))?;
+            total_input_image_bytes = total_input_image_bytes.saturating_add(image.decoded_len);
+            input_images.push(image);
         } else if name == "mask" {
             let mime_type = field
                 .content_type()
@@ -3783,26 +4163,15 @@ pub async fn handle_images_edits(
                 .bytes()
                 .await
                 .map_err(|e| (StatusCode::BAD_REQUEST, format!("Mask read error: {}", e)))?;
-            mask_data = Some((
-                base64::engine::general_purpose::STANDARD.encode(data),
-                mime_type,
-            ));
-        } else if name.starts_with("image") && name != "image_size" {
-            // Support image1, image2, etc.
-            let mime_type = field
-                .content_type()
-                .map(|content_type| content_type.to_string())
-                .unwrap_or_else(|| "image/jpeg".to_string());
-            let data = field.bytes().await.map_err(|e| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("Reference image read error: {}", e),
-                )
-            })?;
-            reference_images.push((
-                base64::engine::general_purpose::STANDARD.encode(data),
-                mime_type,
-            ));
+            let mask = normalized_image_from_bytes(
+                &data,
+                &mime_type,
+                input_images.len(),
+                total_input_image_bytes,
+            )
+            .map_err(|message| (StatusCode::BAD_REQUEST, message))?;
+            total_input_image_bytes = total_input_image_bytes.saturating_add(mask.decoded_len);
+            mask_data = Some(mask);
         } else if name == "prompt" {
             prompt = field
                 .text()
@@ -3813,12 +4182,18 @@ pub async fn handle_images_edits(
                 n = val.parse().unwrap_or(1);
             }
         } else if name == "size" {
-            if let Ok(val) = field.text().await {
-                size = val;
-            }
-        } else if name == "image_size" {
+            let val = field
+                .text()
+                .await
+                .map_err(|e| (StatusCode::BAD_REQUEST, format!("Size read error: {}", e)))?;
+            size = Some(val);
+        } else if name == "image_size" || name == "imageSize" {
             if let Ok(val) = field.text().await {
                 image_size_param = Some(val);
+            }
+        } else if name == "quality" {
+            if let Ok(val) = field.text().await {
+                quality = Some(val);
             }
         } else if name == "aspect_ratio" {
             if let Ok(val) = field.text().await {
@@ -3848,16 +4223,16 @@ pub async fn handle_images_edits(
     }
 
     tracing::info!(
-        "[Images] Edit/Ref Request: model={}, prompt={}, n={}, size={}, aspect_ratio={:?}, image_size={:?}, style={:?}, refs={}, has_main_image={}",
-        model,
-        prompt,
-        n,
-        size,
-        aspect_ratio,
-        image_size_param,
-        style,
-        reference_images.len(),
-        image_data.is_some()
+        model = model,
+        n = n,
+        size = size.as_deref().unwrap_or("auto"),
+        aspect_ratio = aspect_ratio.as_deref().unwrap_or("auto"),
+        image_size = image_size_param.as_deref().unwrap_or("auto"),
+        quality = quality.as_deref().unwrap_or("auto"),
+        style = style.as_deref().unwrap_or("auto"),
+        image_count = input_images.len(),
+        has_mask = mask_data.is_some(),
+        "[Images] Received edit request metadata"
     );
 
     // 2. Prepare Config (Aspect Ratio / Size)
@@ -3865,65 +4240,23 @@ pub async fn handle_images_edits(
     // Priority: image_size param > quality param (derived from model suffix or default)
 
     // We reuse parse_image_config_with_params but need to adapt the inputs
-    let size_input = aspect_ratio.as_deref().or(Some(&size)); // If aspect_ratio is "16:9", it works. If it's just "1:1", it also works.
-
-    // Map 'image_size' (2K) to 'quality' semantics if needed, or pass directly if logic supports
-    // common_utils logic: 'hd' -> 4K, 'medium' -> 2K.
-    let quality_input = match image_size_param.as_deref() {
-        Some("4K") => Some("hd"),
-        Some("2K") => Some("medium"),
-        _ => None, // Fallback to standard
-    };
+    let size_input = edit_size_input(aspect_ratio.as_deref(), size.as_deref());
 
     let (image_config, clean_model_name) =
-        crate::proxy::mappers::common_utils::parse_image_config_with_params(
+        crate::proxy::mappers::common_utils::try_parse_image_config_with_params(
             &model,
             size_input,
-            quality_input,
-            image_size_param.as_deref(), // [NEW] Pass direct image_size param
-        );
+            quality.as_deref(),
+            image_size_param.as_deref(),
+        )
+        .map_err(|message| (StatusCode::BAD_REQUEST, message))?;
 
     // 3. Construct Contents
-    let mut contents_parts = Vec::new();
-
-    // Add Prompt
     let mut final_prompt = prompt.clone();
     if let Some(s) = style {
         final_prompt.push_str(&format!(", style: {}", s));
     }
-    contents_parts.push(json!({
-        "text": final_prompt
-    }));
-
-    // Add Main Image (if standard edit)
-    if let Some((data, mime_type)) = image_data {
-        contents_parts.push(json!({
-            "inlineData": {
-                "mimeType": mime_type,
-                "data": data
-            }
-        }));
-    }
-
-    // Add Mask (if standard edit)
-    if let Some((data, mime_type)) = mask_data {
-        contents_parts.push(json!({
-            "inlineData": {
-                "mimeType": mime_type,
-                "data": data
-            }
-        }));
-    }
-
-    // Add Reference Images (Image-to-Image)
-    for (ref_data, mime_type) in reference_images {
-        contents_parts.push(json!({
-            "inlineData": {
-                "mimeType": mime_type,
-                "data": ref_data
-            }
-        }));
-    }
+    let contents_parts = build_image_contents(final_prompt, &input_images, mask_data.as_ref());
 
     // 4. 并发发送请求
     // 注意：不再在外部获取 Token，而是移入 Task 内部
@@ -3951,7 +4284,12 @@ pub async fn handle_images_edits(
             for attempt in 0..max_attempts {
                 // 4.1 获取 Token
                 let (access_token, project_id, email, account_id, _wait_ms) = match token_manager
-                    .get_token("image_gen", force_rotate, None, "gemini-3-pro-image")
+                    .get_token(
+                        "image_gen",
+                        force_rotate,
+                        None,
+                        image_account_selection_target(&model_to_use),
+                    )
                     .await
                 {
                     Ok(t) => t,
@@ -3965,35 +4303,17 @@ pub async fn handle_images_edits(
                     }
                 };
 
-                // 4.2 Construct Request Body (Need project_id)
-                let gemini_body = json!({
-                    "project": project_id,
-                    "requestId": format!("img-edit-{}", uuid::Uuid::new_v4()),
-                    "model": model_to_use,
-                    "userAgent": "antigravity",
-                    "requestType": "image_gen",
-                    "request": {
-                        "contents": [{
-                            "role": "user",
-                            "parts": contents_parts
-                        }],
-                        "generationConfig": {
-                            "candidateCount": 1,
-                            "imageConfig": image_config,
-                            "maxOutputTokens": 8192,
-                            "stopSequences": [],
-                            "temperature": 1.0,
-                            "topP": 0.95,
-                            "topK": 40
-                        },
-                        "safetySettings": [
-                            { "category": "HARM_CATEGORY_HARASSMENT", "threshold": "OFF" },
-                            { "category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "OFF" },
-                            { "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "OFF" },
-                            { "category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "OFF" },
-                        ]
-                    }
-                });
+                let resolved_model = token_manager
+                    .resolve_dynamic_model_for_account(&account_id, &model_to_use)
+                    .await;
+
+                // 4.2 Construct Request Body (Need project_id and account-resolved model)
+                let gemini_body = build_image_edit_body(
+                    project_id,
+                    &resolved_model,
+                    contents_parts.clone(),
+                    image_config.clone(),
+                );
 
                 match upstream
                     .call_v1_internal(

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -22,13 +22,15 @@ const MAX_INPUT_IMAGE_BYTES: usize = 20 * 1024 * 1024;
 const MAX_TOTAL_INPUT_IMAGE_BYTES: usize = 32 * 1024 * 1024;
 const CODEX_VISIBLE_THOUGHT_MESSAGE_PREFIX: &str = "msg_thought_";
 use super::common::{
-    apply_retry_strategy, determine_retry_strategy, should_rotate_account, RetryStrategy,
+    apply_retry_strategy, next_rotation_attempt, should_rotate_account, FailureStatusTracker,
+    RequestRetryState, RetryStrategy,
 };
 use crate::modules::account;
 use crate::proxy::common::client_adapter::CLIENT_ADAPTERS; // [NEW] Adapter Registry
 use crate::proxy::session_manager::SessionManager;
 use axum::http::HeaderMap;
 use std::collections::VecDeque;
+use tokio::task::JoinSet;
 use tokio::time::Duration;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -113,7 +115,9 @@ fn parse_image_data_url(
     normalized_image_from_bytes(&decoded, mime_type, image_count, total_bytes)
 }
 
-fn parse_generation_input_images(image: Option<&Value>) -> Result<Vec<NormalizedInputImage>, String> {
+fn parse_generation_input_images(
+    image: Option<&Value>,
+) -> Result<Vec<NormalizedInputImage>, String> {
     let Some(image) = image else {
         return Ok(Vec::new());
     };
@@ -152,9 +156,10 @@ fn generation_image_size_param(body: &Value) -> Result<Option<&str>, String> {
         if value.is_null() {
             continue;
         }
-        return value.as_str().map(Some).ok_or_else(|| {
-            "Invalid image_size: expected one of 1K, 2K, 4K, or auto".to_string()
-        });
+        return value
+            .as_str()
+            .map(Some)
+            .ok_or_else(|| "Invalid image_size: expected one of 1K, 2K, 4K, or auto".to_string());
     }
     Ok(None)
 }
@@ -162,9 +167,9 @@ fn generation_image_size_param(body: &Value) -> Result<Option<&str>, String> {
 fn is_edit_image_field(name: &str) -> bool {
     name == "image"
         || name == "image[]"
-        || name
-            .strip_prefix("image")
-            .is_some_and(|suffix| !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit()))
+        || name.strip_prefix("image").is_some_and(|suffix| {
+            !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit())
+        })
 }
 
 fn edit_size_input<'a>(aspect_ratio: Option<&'a str>, size: Option<&'a str>) -> Option<&'a str> {
@@ -269,6 +274,66 @@ fn stream_chunk_has_error_event(bytes: &[u8]) -> bool {
             payload.get("type").and_then(Value::as_str),
             Some("error" | "response.failed")
         ) || payload.get("error").is_some_and(|error| !error.is_null())
+    })
+}
+
+fn response_has_inline_image_data(value: &Value) -> bool {
+    let response = value.get("response").unwrap_or(value);
+    response
+        .get("candidates")
+        .and_then(Value::as_array)
+        .is_some_and(|candidates| {
+            candidates.iter().any(|candidate| {
+                candidate
+                    .get("content")
+                    .and_then(|content| content.get("parts"))
+                    .and_then(Value::as_array)
+                    .is_some_and(|parts| {
+                        parts.iter().any(|part| {
+                            part.get("inlineData")
+                                .or_else(|| part.get("inline_data"))
+                                .and_then(|image| image.get("data"))
+                                .and_then(Value::as_str)
+                                .is_some_and(|data| !data.is_empty())
+                        })
+                    })
+            })
+        })
+}
+
+fn text_has_nonempty_image_data_url(text: &str) -> bool {
+    let mut remaining = text;
+    while let Some(start) = remaining.find("data:image/") {
+        let candidate = &remaining[start..];
+        if let Some((_, encoded)) = candidate.split_once(";base64,") {
+            if encoded.chars().next().is_some_and(|first| {
+                !first.is_whitespace() && !matches!(first, '"' | '\\' | ')' | ']' | '}')
+            }) {
+                return true;
+            }
+        }
+        remaining = &candidate["data:image/".len()..];
+    }
+    false
+}
+
+fn value_has_nonempty_image_data_url(value: &Value) -> bool {
+    match value {
+        Value::String(text) => text_has_nonempty_image_data_url(text),
+        Value::Array(values) => values.iter().any(value_has_nonempty_image_data_url),
+        Value::Object(values) => values.values().any(value_has_nonempty_image_data_url),
+        _ => false,
+    }
+}
+
+fn stream_chunk_has_image_data(bytes: &[u8]) -> bool {
+    String::from_utf8_lossy(bytes).lines().any(|line| {
+        let Some(data) = line.trim_start().strip_prefix("data:") else {
+            return false;
+        };
+        serde_json::from_str::<Value>(data.trim())
+            .ok()
+            .is_some_and(|payload| value_has_nonempty_image_data_url(&payload))
     })
 }
 
@@ -535,10 +600,12 @@ mod stream_peek_tests {
     use super::is_codex_transcript_only_assistant_message;
     use super::is_edit_image_field;
     use super::parse_generation_input_images;
+    use super::response_has_inline_image_data;
     use super::responses_input_item_type;
     use super::responses_message_parts;
     use super::rewrite_terminal_assistant_prefill;
     use super::stream_chunk_has_error_event;
+    use super::stream_chunk_has_image_data;
     use super::validate_input_image_limits;
     use super::{MAX_INPUT_IMAGES, MAX_INPUT_IMAGE_BYTES, MAX_TOTAL_INPUT_IMAGE_BYTES};
     use serde_json::{json, Value};
@@ -575,6 +642,29 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
 
 "#;
         assert!(!stream_chunk_has_error_event(chunk));
+    }
+
+    #[test]
+    fn task_image_success_requires_nonempty_payload() {
+        let empty = json!({
+            "response": {"candidates": [{"content": {"parts": [{"inlineData": {"data": ""}}]}}]}
+        });
+        let image = json!({
+            "response": {"candidates": [{"content": {"parts": [{"inlineData": {"data": "AQ=="}}]}}]}
+        });
+        assert!(!response_has_inline_image_data(&empty));
+        assert!(response_has_inline_image_data(&image));
+
+        let empty_chunk =
+            br#"data: {"choices":[{"delta":{"content":"![image](data:image/png;base64,)"}}]}
+
+"#;
+        let image_chunk =
+            br#"data: {"choices":[{"delta":{"content":"![image](data:image/png;base64,AQ==)"}}]}
+
+"#;
+        assert!(!stream_chunk_has_image_data(empty_chunk));
+        assert!(stream_chunk_has_image_data(image_chunk));
     }
 
     #[test]
@@ -831,10 +921,7 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
         assert_eq!(single_parts.len(), 2);
         assert_eq!(single_parts[1]["inlineData"]["data"], "AQ==");
 
-        let multiple = json!([
-            "data:image/png;base64,AQ==",
-            "data:image/jpeg;base64,Ag=="
-        ]);
+        let multiple = json!(["data:image/png;base64,AQ==", "data:image/jpeg;base64,Ag=="]);
         let multiple_images =
             parse_generation_input_images(Some(&multiple)).expect("ordered data URL array");
         let multiple_parts = build_image_contents("prompt".to_string(), &multiple_images, None);
@@ -845,7 +932,8 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
 
     #[test]
     fn generation_without_image_remains_text_only() {
-        let images = parse_generation_input_images(None).expect("absent image is standard text-to-image");
+        let images =
+            parse_generation_input_images(None).expect("absent image is standard text-to-image");
         let parts = build_image_contents("prompt".to_string(), &images, None);
         assert_eq!(parts, vec![json!({"text": "prompt"})]);
     }
@@ -870,9 +958,7 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
         );
         assert!(parse_generation_input_images(Some(&too_many)).is_err());
         assert!(validate_input_image_limits(1, MAX_INPUT_IMAGE_BYTES + 1, 0).is_err());
-        assert!(
-            validate_input_image_limits(1, 1, MAX_TOTAL_INPUT_IMAGE_BYTES + 1).is_err()
-        );
+        assert!(validate_input_image_limits(1, 1, MAX_TOTAL_INPUT_IMAGE_BYTES + 1).is_err());
 
         assert!(generation_image_size_param(&json!({"imageSize": 4})).is_err());
     }
@@ -938,13 +1024,9 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
     fn edit_flash_model_is_used_for_account_selection_and_resolved_upstream_body() {
         use crate::proxy::mappers::common_utils::try_parse_image_config_with_params;
 
-        let (image_config, model_to_use) = try_parse_image_config_with_params(
-            "gemini-3.1-flash-image",
-            None,
-            None,
-            None,
-        )
-        .expect("flash edit model config");
+        let (image_config, model_to_use) =
+            try_parse_image_config_with_params("gemini-3.1-flash-image", None, None, None)
+                .expect("flash edit model config");
         assert_eq!(
             image_account_selection_target(&model_to_use),
             "gemini-3.1-flash-image"
@@ -953,7 +1035,10 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
         let body = build_image_edit_body(
             "project".to_string(),
             "account-resolved-image-model",
-            json!([{"text": "prompt"}]).as_array().cloned().expect("parts"),
+            json!([{"text": "prompt"}])
+                .as_array()
+                .cloned()
+                .expect("parts"),
             image_config,
         );
         assert_eq!(body["model"], "account-resolved-image-model");
@@ -1280,11 +1365,14 @@ pub async fn handle_chat_completions(
     let upstream = state.upstream.clone();
     let token_manager = state.token_manager;
     let pool_size = token_manager.len();
-    // [FIX] Ensure max_attempts is at least 2 to allow for internal retries
-    let max_attempts = MAX_RETRY_ATTEMPTS.min(pool_size.saturating_add(1)).max(2);
+    let max_attempts = MAX_RETRY_ATTEMPTS.min(pool_size).max(1);
 
     let mut last_error = String::new();
     let mut last_email: Option<String> = None;
+    let mut retry_state = RequestRetryState::default();
+    let mut retry_credentials: Option<(String, String, String, String, u64)> = None;
+    let mut failure_statuses = FailureStatusTracker::default();
+    let mut used_attempts = 0;
 
     // 2. 模型路由解析 (移到循环外以支持在所有路径返回 X-Mapped-Model)
     let mapped_model = crate::proxy::common::model_mapping::resolve_model_route(
@@ -1292,7 +1380,11 @@ pub async fn handle_chat_completions(
         &*state.custom_mapping.read().await,
     );
 
-    for attempt in 0..max_attempts {
+    while let Some(attempt) = next_rotation_attempt(
+        &mut used_attempts,
+        max_attempts,
+        retry_credentials.is_some(),
+    ) {
         // 将 OpenAI 工具转为 Value 数组以便探测联网
         let tools_val: Option<Vec<Value>> = openai_req
             .tools
@@ -1313,27 +1405,32 @@ pub async fn handle_chat_completions(
 
         // 4. 获取 Token (使用准确的 request_type)
         // 关键：在重试尝试时根据 force_rotate 决定是否轮换账号
-        let (access_token, project_id, email, account_id, _wait_ms) = match token_manager
-            .get_token(
-                &config.request_type,
-                force_rotate,
-                Some(&session_id),
-                &mapped_model,
-            )
-            .await
-        {
-            Ok(t) => t,
-            Err(e) => {
-                // [FIX] Attach headers to error response for logging visibility
-                let headers = [("X-Mapped-Model", mapped_model.as_str())];
-                return Ok((
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    headers,
-                    format!("Token error: {}", e),
-                )
-                    .into_response());
-            }
-        };
+        let (access_token, project_id, email, account_id, _wait_ms) =
+            if let Some(credentials) = retry_credentials.take() {
+                credentials
+            } else {
+                match token_manager
+                    .get_token(
+                        &config.request_type,
+                        force_rotate,
+                        Some(&session_id),
+                        &mapped_model,
+                    )
+                    .await
+                {
+                    Ok(t) => t,
+                    Err(e) => {
+                        // [FIX] Attach headers to error response for logging visibility
+                        let headers = [("X-Mapped-Model", mapped_model.as_str())];
+                        return Ok((
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            headers,
+                            format!("Token error: {}", e),
+                        )
+                            .into_response());
+                    }
+                }
+            };
 
         // [NEW v4.1.29] 获取完整 Token 对象用于动态规格查询
         let proxy_token = token_manager.get_token_by_id(&account_id);
@@ -1424,6 +1521,7 @@ pub async fn handle_chat_completions(
             Ok(r) => r,
             Err(e) => {
                 last_error = e.clone();
+                failure_statuses.record(StatusCode::BAD_GATEWAY);
                 debug!(
                     "OpenAI Request failed on attempt {}/{}: {}",
                     attempt + 1,
@@ -1565,9 +1663,9 @@ pub async fn handle_chat_completions(
                 }
 
                 if retry_this_account {
+                    failure_statuses.record(StatusCode::BAD_GATEWAY);
                     continue; // Rotate to next account
                 }
-
                 // Combine first chunk with remaining stream
                 let combined_stream =
                     futures::stream::once(
@@ -1576,19 +1674,48 @@ pub async fn handle_chat_completions(
                     .chain(openai_stream);
 
                 // [NEW] 针对 OpenAI 流增加 300 秒空闲超时保护
+                let track_image_success = config.request_type == "image_gen";
+                let image_success_manager = token_manager.clone();
+                let image_success_account = account_id.clone();
+                let image_success_model = mapped_model.clone();
                 let combined_stream = async_stream::stream! {
                     let mut s = Box::pin(combined_stream);
+                    let mut saw_image_data = false;
+                    let mut stream_failed = false;
 
                     loop {
                         match tokio::time::timeout(std::time::Duration::from_secs(300), s.next()).await {
-                            Ok(Some(item)) => yield item,
+                            Ok(Some(Ok(bytes))) => {
+                                if stream_chunk_has_error_event(&bytes) {
+                                    stream_failed = true;
+                                }
+                                if track_image_success && stream_chunk_has_image_data(&bytes) {
+                                    saw_image_data = true;
+                                }
+                                yield Ok::<Bytes, String>(bytes);
+                            }
+                            Ok(Some(Err(error))) => {
+                                stream_failed = true;
+                                yield Err::<Bytes, String>(error);
+                                break;
+                            }
                             Ok(None) => break,
                             Err(_) => {
                                 tracing::error!("[OpenAI-SSE] Idle timeout after 300s, terminating stream");
+                                stream_failed = true;
                                 yield Ok::<Bytes, String>(Bytes::from("data: [DONE]\n\n"));
                                 break;
                             }
                         }
+                    }
+
+                    if track_image_success && saw_image_data && !stream_failed {
+                        image_success_manager.mark_account_success(&image_success_account);
+                        image_success_manager
+                            .clear_persisted_live_limit(
+                                &image_success_account,
+                                Some(&image_success_model),
+                            );
                     }
                 };
                 let converted_meta = json!({
@@ -1770,8 +1897,9 @@ pub async fn handle_chat_completions(
         }
 
         // 处理特定错误并重试
+        failure_statuses.record(status);
         let status_code = status.as_u16();
-        let _retry_after = response
+        let retry_after = response
             .headers()
             .get("Retry-After")
             .and_then(|h| h.to_str().ok())
@@ -1812,16 +1940,42 @@ pub async fn handle_chat_completions(
         }
 
         // 确定重试策略
-        let strategy = determine_retry_strategy(status_code, &error_text, false);
+        let strategy = retry_state.determine_strategy(
+            &account_id,
+            status_code,
+            &error_text,
+            retry_after.as_deref(),
+            false,
+        );
+        let should_mark_limited =
+            status_code == 429 || status_code == 529 || status_code == 503 || status_code == 500;
+        let needs_quota_refresh = if config.request_type == "image_gen" && should_mark_limited {
+            token_manager
+                .mark_rate_limited_fast(
+                    &email,
+                    status_code,
+                    retry_after.as_deref(),
+                    &error_text,
+                    Some(&mapped_model),
+                )
+                .await
+        } else {
+            false
+        };
+        if needs_quota_refresh {
+            token_manager
+                .refresh_quota_lock_after_fast_mark(&email, Some(&mapped_model))
+                .await;
+        }
 
         // 3. 标记限流状态(用于 UI 显示)
-        if status_code == 429 || status_code == 529 || status_code == 503 || status_code == 500 {
+        if config.request_type != "image_gen" && should_mark_limited {
             // [FIX] Use async version with model parameter for fine-grained rate limiting
             token_manager
                 .mark_rate_limited_async(
                     &email,
                     status_code,
-                    _retry_after.as_deref(),
+                    retry_after.as_deref(),
                     &error_text,
                     Some(&mapped_model),
                 )
@@ -1868,6 +2022,15 @@ pub async fn handle_chat_completions(
         )
         .await
         {
+            if matches!(strategy, RetryStrategy::GraceRetry(_)) {
+                retry_credentials = Some((
+                    access_token.clone(),
+                    project_id.clone(),
+                    email.clone(),
+                    account_id.clone(),
+                    0,
+                ));
+            }
             // [NEW] Apply Client Adapter "let_it_crash" strategy
             if let Some(adapter) = &client_adapter {
                 if adapter.let_it_crash() && attempt > 0 {
@@ -1960,14 +2123,8 @@ pub async fn handle_chat_completions(
             .into_response());
     }
 
-    // 所有尝试均失败：根据最后的错误类型决定状态码
-    let final_status = if last_error.contains("403") || last_error.contains("PERMISSION_DENIED") || last_error.contains("VALIDATION_REQUIRED") {
-        StatusCode::FORBIDDEN
-    } else if last_error.contains("401") || last_error.contains("UNAUTHENTICATED") {
-        StatusCode::UNAUTHORIZED
-    } else {
-        StatusCode::TOO_MANY_REQUESTS
-    };
+    // 所有尝试均失败：仅当全部结构化失败状态均为 429 时返回 429
+    let final_status = failure_statuses.final_status();
 
     if let Some(email) = last_email {
         Ok((
@@ -2868,11 +3025,14 @@ pub async fn handle_completions(
 
     let upstream = state.upstream.clone();
     let pool_size = token_manager.len();
-    // [FIX] Ensure max_attempts is at least 2 to allow for internal retries
-    let max_attempts = MAX_RETRY_ATTEMPTS.min(pool_size.saturating_add(1)).max(2);
+    let max_attempts = MAX_RETRY_ATTEMPTS.min(pool_size).max(1);
 
     let mut last_error = String::new();
     let mut last_email: Option<String> = None;
+    let mut retry_state = RequestRetryState::default();
+    let mut retry_credentials: Option<(String, String, String, String, u64)> = None;
+    let mut failure_statuses = FailureStatusTracker::default();
+    let mut used_attempts = 0;
 
     if debug_logger::is_enabled(&debug_cfg) {
         let payload = json!({
@@ -2893,7 +3053,11 @@ pub async fn handle_completions(
 
     let mut force_rotate = false;
 
-    for attempt in 0..max_attempts {
+    while let Some(attempt) = next_rotation_attempt(
+        &mut used_attempts,
+        max_attempts,
+        retry_credentials.is_some(),
+    ) {
         // 3. 模型配置解析
         // 将 OpenAI 工具转为 Value 数组以便探测联网
         let tools_val: Option<Vec<Value>> = openai_req
@@ -2915,25 +3079,30 @@ pub async fn handle_completions(
         let session_id_str = SessionManager::extract_openai_session_id(&openai_req);
         let session_id = Some(session_id_str.as_str());
 
-        let (access_token, project_id, email, account_id, _wait_ms) = match token_manager
-            .get_token(
-                &config.request_type,
-                force_rotate,
-                session_id,
-                &mapped_model,
-            )
-            .await
-        {
-            Ok(t) => t,
-            Err(e) => {
-                return (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    [("X-Mapped-Model", mapped_model)],
-                    format!("Token error: {}", e),
-                )
-                    .into_response()
-            }
-        };
+        let (access_token, project_id, email, account_id, _wait_ms) =
+            if let Some(credentials) = retry_credentials.take() {
+                credentials
+            } else {
+                match token_manager
+                    .get_token(
+                        &config.request_type,
+                        force_rotate,
+                        session_id,
+                        &mapped_model,
+                    )
+                    .await
+                {
+                    Ok(t) => t,
+                    Err(e) => {
+                        return (
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            [("X-Mapped-Model", mapped_model)],
+                            format!("Token error: {}", e),
+                        )
+                            .into_response()
+                    }
+                }
+            };
 
         let mapped_model = token_manager
             .resolve_dynamic_model_for_account(&account_id, &mapped_model)
@@ -3029,6 +3198,7 @@ pub async fn handle_completions(
             Ok(r) => r,
             Err(e) => {
                 last_error = e.clone();
+                failure_statuses.record(StatusCode::BAD_GATEWAY);
                 debug!(
                     "Codex Request failed on attempt {}/{}: {}",
                     attempt + 1,
@@ -3143,6 +3313,7 @@ pub async fn handle_completions(
                     }
 
                     if retry_this_account {
+                        failure_statuses.record(StatusCode::BAD_GATEWAY);
                         continue;
                     }
 
@@ -3257,6 +3428,7 @@ pub async fn handle_completions(
                         }
                     }
                     if retry_this_account {
+                        failure_statuses.record(StatusCode::BAD_GATEWAY);
                         continue;
                     }
 
@@ -3504,6 +3676,7 @@ pub async fn handle_completions(
         }
 
         // Handle errors and retry
+        failure_statuses.record(status);
         let status_code = status.as_u16();
         let retry_after = response
             .headers()
@@ -3535,9 +3708,13 @@ pub async fn handle_completions(
                 .await;
         }
 
-        // 确定重试策略
-        // 确定重试策略 (对齐官方 1.5s Grace Window)
-        let strategy = determine_retry_strategy(status_code, &error_text, false);
+        let strategy = retry_state.determine_strategy(
+            &account_id,
+            status_code,
+            &error_text,
+            retry_after.as_deref(),
+            false,
+        );
 
         // 执行退备
         if apply_retry_strategy(
@@ -3549,7 +3726,16 @@ pub async fn handle_completions(
         )
         .await
         {
-            // 继续重试 (loop 会增加 attempt, 导致 force_rotate=true)
+            if matches!(strategy, RetryStrategy::GraceRetry(_)) {
+                retry_credentials = Some((
+                    access_token.clone(),
+                    project_id.clone(),
+                    email.clone(),
+                    account_id.clone(),
+                    0,
+                ));
+            }
+            force_rotate = should_rotate_account(status_code, Some(&strategy));
             continue;
         } else {
             // 不可重试
@@ -3566,16 +3752,17 @@ pub async fn handle_completions(
     }
 
     // 所有尝试均失败
+    let final_status = failure_statuses.final_status();
     if let Some(email) = last_email {
         (
-            StatusCode::TOO_MANY_REQUESTS,
+            final_status,
             [("X-Account-Email", email), ("X-Mapped-Model", mapped_model)],
             format!("All accounts exhausted. Last error: {}", last_error),
         )
             .into_response()
     } else {
         (
-            StatusCode::TOO_MANY_REQUESTS,
+            final_status,
             [("X-Mapped-Model", mapped_model)],
             format!("All accounts exhausted. Last error: {}", last_error),
         )
@@ -3808,9 +3995,8 @@ pub async fn handle_images_generations_internal(
 
     // Canvas compatibility extension: OpenAI's standard generations endpoint does not define
     // this top-level field. Accept only inline data:image URLs and never fetch remote URLs.
-    let input_images = parse_generation_input_images(body.get("image")).map_err(|message| {
-        (StatusCode::BAD_REQUEST, message, None)
-    })?;
+    let input_images = parse_generation_input_images(body.get("image"))
+        .map_err(|message| (StatusCode::BAD_REQUEST, message, None))?;
 
     info!(
         model = model,
@@ -3846,11 +4032,9 @@ pub async fn handle_images_generations_internal(
     let upstream = state.upstream.clone();
     let token_manager = state.token_manager.clone();
     let max_pool_size = token_manager.len();
-    let max_attempts = MAX_RETRY_ATTEMPTS
-        .min(max_pool_size.saturating_add(1))
-        .max(2);
+    let max_attempts = MAX_RETRY_ATTEMPTS.min(max_pool_size).max(1);
 
-    let mut tasks = Vec::new();
+    let mut tasks = JoinSet::new();
 
     // Track the last account actually attempted, so error responses (502/503) can be
     // attributed to an account in the traffic log instead of showing "(none)".
@@ -3866,25 +4050,44 @@ pub async fn handle_images_generations_internal(
         let model_to_use = clean_model_name.clone();
         let attempted_account = attempted_account.clone();
 
-        tasks.push(tokio::spawn(async move {
+        tasks.spawn(async move {
             let mut last_error = String::new();
             let mut force_rotate = false;
+            let mut retry_state = RequestRetryState::default();
+            let mut retry_credentials: Option<(String, String, String, String, u64)> = None;
+            let mut failure_statuses = FailureStatusTracker::default();
+            let mut used_attempts = 0;
 
-            for attempt in 0..max_attempts {
-                let (access_token, project_id, email, account_id, _wait_ms) = match token_manager
-                    .get_token("image_gen", force_rotate, None, &model_to_use)
-                    .await
-                {
-                    Ok(t) => t,
-                    Err(e) => {
-                        last_error = format!("Token error: {}", e);
-                        if attempt < max_attempts - 1 {
-                            tokio::time::sleep(Duration::from_millis(500)).await;
-                            continue;
+            while let Some(attempt) = next_rotation_attempt(
+                &mut used_attempts,
+                max_attempts,
+                retry_credentials.is_some(),
+            ) {
+                let (access_token, project_id, email, account_id, _wait_ms) =
+                    if let Some(credentials) = retry_credentials.take() {
+                        credentials
+                    } else {
+                        match token_manager
+                            .get_token(
+                                "image_gen",
+                                force_rotate,
+                                None,
+                                &model_to_use,
+                            )
+                            .await
+                        {
+                            Ok(credentials) => credentials,
+                            Err(e) => {
+                                last_error = format!("Token error: {}", e);
+                                failure_statuses.record(StatusCode::SERVICE_UNAVAILABLE);
+                                if attempt < max_attempts - 1 {
+                                    tokio::time::sleep(Duration::from_millis(500)).await;
+                                    continue;
+                                }
+                                break;
+                            }
                         }
-                        break;
-                    }
-                };
+                    };
                 if let Ok(mut g) = attempted_account.lock() {
                     *g = Some(email.clone());
                 }
@@ -3935,26 +4138,80 @@ pub async fn handle_images_generations_internal(
                         let response = call_result.response;
                         let status = response.status();
                         if !status.is_success() {
+                            failure_statuses.record(status);
+                            let retry_after = response
+                                .headers()
+                                .get("Retry-After")
+                                .and_then(|header| header.to_str().ok())
+                                .map(str::to_string);
                             let err_text = response.text().await.unwrap_or_default();
                             let status_code = status.as_u16();
                             last_error = format!("Upstream error {}: {}", status, err_text);
-
-                            // 429/500/503: mark limited and rotate to another account
-                            if status_code == 429 || status_code == 503 || status_code == 500 {
+                            let strategy = (status_code == 429).then(|| {
+                                retry_state.determine_strategy(
+                                    &account_id,
+                                    status_code,
+                                    &err_text,
+                                    retry_after.as_deref(),
+                                    false,
+                                )
+                            });
+                            // 429/500/503: mark limited before retry/rotation
+                            let should_mark_limited =
+                                status_code == 429 || status_code == 503 || status_code == 500;
+                            let needs_quota_refresh = if should_mark_limited {
                                 tracing::warn!(
                                     "[Images] Account {} rate limited/error ({}), rotating...",
                                     email,
                                     status_code
                                 );
                                 token_manager
-                                    .mark_rate_limited_async(
+                                    .mark_rate_limited_fast(
                                         &email,
                                         status_code,
-                                        None,
+                                        retry_after.as_deref(),
                                         &err_text,
-                                        Some(model_to_use.as_str()),
+                                        Some(&resolved_model),
+                                    )
+                                    .await
+                            } else {
+                                false
+                            };
+                            if needs_quota_refresh {
+                                token_manager
+                                    .refresh_quota_lock_after_fast_mark(
+                                        &email,
+                                        Some(&resolved_model),
                                     )
                                     .await;
+                            }
+
+                            if let Some(strategy) = strategy {
+                                if apply_retry_strategy(
+                                    strategy.clone(),
+                                    attempt,
+                                    max_attempts,
+                                    status_code,
+                                    "image_generation",
+                                )
+                                .await
+                                {
+                                    if matches!(strategy, RetryStrategy::GraceRetry(_)) {
+                                        retry_credentials = Some((
+                                            access_token.clone(),
+                                            project_id.clone(),
+                                            email.clone(),
+                                            account_id.clone(),
+                                            0,
+                                        ));
+                                    }
+                                    force_rotate =
+                                        should_rotate_account(status_code, Some(&strategy));
+                                    continue;
+                                }
+                            }
+
+                            if status_code == 503 || status_code == 500 {
                                 force_rotate = true;
                                 continue; // Retry loop
                             }
@@ -3975,37 +4232,52 @@ pub async fn handle_images_generations_internal(
                             }
 
                             // Other errors: return
-                            return Err(last_error);
+                            return Err((failure_statuses.final_status(), last_error));
                         }
-                        token_manager.mark_account_success(&account_id);
-                        token_manager
-                            .clear_persisted_live_limit(&account_id, Some(&model_to_use))
-                            .await;
-
                         match response.json::<Value>().await {
-                            Ok(json) => return Ok((json, email)),
-                            Err(e) => return Err(format!("Parse error: {}", e)),
+                            Ok(json) => {
+                                if response_has_inline_image_data(&json) {
+                                    token_manager.mark_account_success(&account_id);
+                                    token_manager
+                                        .clear_persisted_live_limit(
+                                            &account_id,
+                                            Some(&model_to_use),
+                                        );
+                                }
+                                return Ok((json, email));
+                            }
+                            Err(e) => {
+                                return Err((
+                                    StatusCode::BAD_GATEWAY,
+                                    format!("Parse error: {}", e),
+                                ))
+                            }
                         }
                     }
                     Err(e) => {
                         last_error = format!("Network error: {}", e);
+                        failure_statuses.record(StatusCode::BAD_GATEWAY);
                         continue;
                     }
                 }
             }
 
             // All attempts failed
-            Err(format!("Max retries exhausted. Last error: {}", last_error))
-        }));
+            Err((
+                failure_statuses.final_status(),
+                format!("Max retries exhausted. Last error: {}", last_error),
+            ))
+        });
     }
 
     // 5. 收集结果
     let mut images: Vec<Value> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
     let mut used_email: Option<String> = None;
+    let mut failure_statuses = FailureStatusTracker::default();
 
-    for (idx, task) in tasks.into_iter().enumerate() {
-        match task.await {
+    while let Some(task) = tasks.join_next().await {
+        match task {
             Ok(result) => match result {
                 Ok((gemini_resp, email_used)) => {
                     // Capture the email from the first successful task for logging
@@ -4037,20 +4309,22 @@ pub async fn handle_images_generations_internal(
                                             "b64_json": data
                                         }));
                                     }
-                                    tracing::debug!("[Images] Task {} succeeded", idx);
+                                    tracing::debug!("[Images] Task succeeded");
                                 }
                             }
                         }
                     }
                 }
-                Err(e) => {
-                    tracing::error!("[Images] Task {} failed: {}", idx, e);
+                Err((status, e)) => {
+                    tracing::error!("[Images] Task failed: {}", e);
+                    failure_statuses.record(status);
                     errors.push(e);
                 }
             },
             Err(e) => {
                 let err_msg = format!("Task join error: {}", e);
-                tracing::error!("[Images] Task {} join error: {}", idx, e);
+                tracing::error!("[Images] Task join error: {}", e);
+                failure_statuses.record(StatusCode::BAD_GATEWAY);
                 errors.push(err_msg);
             }
         }
@@ -4064,14 +4338,7 @@ pub async fn handle_images_generations_internal(
         };
         tracing::error!("[Images] All {} requests failed. Errors: {}", n, error_msg);
 
-        // [FIX] Map upstream status codes correctly instead of forcing 502
-        let status = if error_msg.contains("429") || error_msg.contains("Quota exhausted") {
-            StatusCode::TOO_MANY_REQUESTS
-        } else if error_msg.contains("503") || error_msg.contains("Service Unavailable") {
-            StatusCode::SERVICE_UNAVAILABLE
-        } else {
-            StatusCode::BAD_GATEWAY
-        };
+        let status = failure_statuses.final_status();
 
         let attempted = used_email
             .clone()
@@ -4263,11 +4530,9 @@ pub async fn handle_images_edits(
     let upstream = state.upstream.clone();
     let token_manager = state.token_manager.clone();
     let max_pool_size = token_manager.len();
-    let max_attempts = MAX_RETRY_ATTEMPTS
-        .min(max_pool_size.saturating_add(1))
-        .max(2);
+    let max_attempts = MAX_RETRY_ATTEMPTS.min(max_pool_size).max(1);
 
-    let mut tasks = Vec::new();
+    let mut tasks = JoinSet::new();
     for _ in 0..n {
         let upstream = upstream.clone();
         let token_manager = token_manager.clone();
@@ -4276,32 +4541,45 @@ pub async fn handle_images_edits(
         let response_format = response_format.clone();
         let model_to_use = clean_model_name.clone();
 
-        tasks.push(tokio::spawn(async move {
+        tasks.spawn(async move {
             let mut last_error = String::new();
-
             let mut force_rotate = false;
+            let mut retry_state = RequestRetryState::default();
+            let mut retry_credentials: Option<(String, String, String, String, u64)> = None;
+            let mut failure_statuses = FailureStatusTracker::default();
+            let mut used_attempts = 0;
 
-            for attempt in 0..max_attempts {
+            while let Some(attempt) = next_rotation_attempt(
+                &mut used_attempts,
+                max_attempts,
+                retry_credentials.is_some(),
+            ) {
                 // 4.1 获取 Token
-                let (access_token, project_id, email, account_id, _wait_ms) = match token_manager
-                    .get_token(
-                        "image_gen",
-                        force_rotate,
-                        None,
-                        image_account_selection_target(&model_to_use),
-                    )
-                    .await
-                {
-                    Ok(t) => t,
-                    Err(e) => {
-                        last_error = format!("Token error: {}", e);
-                        if attempt < max_attempts - 1 {
-                            tokio::time::sleep(Duration::from_millis(500)).await;
-                            continue;
+                let (access_token, project_id, email, account_id, _wait_ms) =
+                    if let Some(credentials) = retry_credentials.take() {
+                        credentials
+                    } else {
+                        match token_manager
+                            .get_token(
+                                "image_gen",
+                                force_rotate,
+                                None,
+                                image_account_selection_target(&model_to_use),
+                            )
+                            .await
+                        {
+                            Ok(credentials) => credentials,
+                            Err(e) => {
+                                last_error = format!("Token error: {}", e);
+                                failure_statuses.record(StatusCode::SERVICE_UNAVAILABLE);
+                                if attempt < max_attempts - 1 {
+                                    tokio::time::sleep(Duration::from_millis(500)).await;
+                                    continue;
+                                }
+                                break;
+                            }
                         }
-                        break;
-                    }
-                };
+                    };
 
                 let resolved_model = token_manager
                     .resolve_dynamic_model_for_account(&account_id, &model_to_use)
@@ -4309,7 +4587,7 @@ pub async fn handle_images_edits(
 
                 // 4.2 Construct Request Body (Need project_id and account-resolved model)
                 let gemini_body = build_image_edit_body(
-                    project_id,
+                    project_id.clone(),
                     &resolved_model,
                     contents_parts.clone(),
                     image_config.clone(),
@@ -4329,57 +4607,125 @@ pub async fn handle_images_edits(
                         let response = call_result.response;
                         let status = response.status();
                         if !status.is_success() {
+                            failure_statuses.record(status);
+                            let retry_after = response
+                                .headers()
+                                .get("Retry-After")
+                                .and_then(|header| header.to_str().ok())
+                                .map(str::to_string);
                             let err_text = response.text().await.unwrap_or_default();
                             let status_code = status.as_u16();
                             last_error = format!("Upstream error {}: {}", status, err_text);
-
+                            let strategy = (status_code == 429).then(|| {
+                                retry_state.determine_strategy(
+                                    &account_id,
+                                    status_code,
+                                    &err_text,
+                                    retry_after.as_deref(),
+                                    false,
+                                )
+                            });
                             // 429/500/503 等错误进行标记和重试
-                            if status_code == 429 || status_code == 503 || status_code == 500 {
+                            let should_mark_limited =
+                                status_code == 429 || status_code == 503 || status_code == 500;
+                            let needs_quota_refresh = if should_mark_limited {
                                 tracing::warn!(
                                     "[Images] Account {} rate limited/error ({}), rotating...",
                                     email,
                                     status_code
                                 );
                                 token_manager
-                                    .mark_rate_limited_async(
+                                    .mark_rate_limited_fast(
                                         &email,
                                         status_code,
-                                        None,
+                                        retry_after.as_deref(),
                                         &err_text,
-                                        Some(&model_to_use),
+                                        Some(&resolved_model),
+                                    )
+                                    .await
+                            } else {
+                                false
+                            };
+                            if needs_quota_refresh {
+                                token_manager
+                                    .refresh_quota_lock_after_fast_mark(
+                                        &email,
+                                        Some(&resolved_model),
                                     )
                                     .await;
+                            }
+
+                            if let Some(strategy) = strategy {
+                                if apply_retry_strategy(
+                                    strategy.clone(),
+                                    attempt,
+                                    max_attempts,
+                                    status_code,
+                                    "image_edit",
+                                )
+                                .await
+                                {
+                                    if matches!(strategy, RetryStrategy::GraceRetry(_)) {
+                                        retry_credentials = Some((
+                                            access_token.clone(),
+                                            project_id.clone(),
+                                            email.clone(),
+                                            account_id.clone(),
+                                            0,
+                                        ));
+                                    }
+                                    force_rotate =
+                                        should_rotate_account(status_code, Some(&strategy));
+                                    continue;
+                                }
+                            }
+
+                            if status_code == 503 || status_code == 500 {
                                 continue; // Retry loop
                             }
-                            return Err(last_error);
+                            return Err((failure_statuses.final_status(), last_error));
                         }
-                        token_manager.mark_account_success(&account_id);
-                        token_manager
-                            .clear_persisted_live_limit(&account_id, Some(&model_to_use))
-                            .await;
-
                         match response.json::<Value>().await {
-                            Ok(json) => return Ok((json, response_format.clone(), email)),
-                            Err(e) => return Err(format!("Parse error: {}", e)),
+                            Ok(json) => {
+                                if response_has_inline_image_data(&json) {
+                                    token_manager.mark_account_success(&account_id);
+                                    token_manager.clear_persisted_live_limit(
+                                        &account_id,
+                                        Some(&model_to_use),
+                                    );
+                                }
+                                return Ok((json, response_format.clone(), email));
+                            }
+                            Err(e) => {
+                                return Err((
+                                    StatusCode::BAD_GATEWAY,
+                                    format!("Parse error: {}", e),
+                                ))
+                            }
                         }
                     }
                     Err(e) => {
                         last_error = format!("Network error: {}", e);
+                        failure_statuses.record(StatusCode::BAD_GATEWAY);
                         continue;
                     }
                 }
             }
-            Err(format!("Max retries exhausted. Last error: {}", last_error))
-        }));
+            Err((
+                failure_statuses.final_status(),
+                format!("Max retries exhausted. Last error: {}", last_error),
+            ))
+        });
     }
 
     // 5. Collect Results
     let mut images: Vec<Value> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
     let mut used_email: Option<String> = None;
+    let mut failure_statuses = FailureStatusTracker::default();
 
-    for (idx, task) in tasks.into_iter().enumerate() {
-        match task.await {
+    while let Some(task) = tasks.join_next().await {
+        match task {
             Ok(result) => match result {
                 Ok((gemini_resp, response_format, email_used)) => {
                     if used_email.is_none() {
@@ -4410,20 +4756,22 @@ pub async fn handle_images_edits(
                                             "b64_json": data
                                         }));
                                     }
-                                    tracing::debug!("[Images] Task {} succeeded", idx);
+                                    tracing::debug!("[Images] Task succeeded");
                                 }
                             }
                         }
                     }
                 }
-                Err(e) => {
-                    tracing::error!("[Images] Task {} failed: {}", idx, e);
+                Err((status, e)) => {
+                    tracing::error!("[Images] Task failed: {}", e);
+                    failure_statuses.record(status);
                     errors.push(e);
                 }
             },
             Err(e) => {
                 let err_msg = format!("Task join error: {}", e);
-                tracing::error!("[Images] Task {} join error: {}", idx, e);
+                tracing::error!("[Images] Task join error: {}", e);
+                failure_statuses.record(StatusCode::BAD_GATEWAY);
                 errors.push(err_msg);
             }
         }
@@ -4440,13 +4788,7 @@ pub async fn handle_images_edits(
             n,
             error_msg
         );
-        let status = if error_msg.contains("429") || error_msg.contains("Quota exhausted") {
-            StatusCode::TOO_MANY_REQUESTS
-        } else if error_msg.contains("503") || error_msg.contains("Service Unavailable") {
-            StatusCode::SERVICE_UNAVAILABLE
-        } else {
-            StatusCode::BAD_GATEWAY
-        };
+        let status = failure_statuses.final_status();
 
         return Err((status, error_msg));
     }

--- a/src-tauri/src/proxy/mappers/common_utils.rs
+++ b/src-tauri/src/proxy/mappers/common_utils.rs
@@ -159,6 +159,23 @@ pub fn parse_image_config(model_name: &str) -> (Value, String) {
     parse_image_config_with_params(model_name, None, None, None)
 }
 
+/// Parse image configuration while rejecting an explicit, unsupported `imageSize` value.
+/// API handlers should use this variant so invalid client input becomes a boundary error.
+pub fn try_parse_image_config_with_params(
+    model_name: &str,
+    size: Option<&str>,
+    quality: Option<&str>,
+    image_size: Option<&str>,
+) -> Result<(Value, String), String> {
+    let image_size = normalize_image_size(image_size)?;
+    Ok(parse_image_config_with_normalized_params(
+        model_name,
+        size,
+        quality,
+        image_size,
+    ))
+}
+
 /// Extended version that accepts OpenAI size and quality parameters
 ///
 /// This function supports parsing image configuration from:
@@ -180,11 +197,23 @@ pub fn parse_image_config_with_params(
     quality: Option<&str>,
     image_size: Option<&str>,
 ) -> (Value, String) {
+    // Legacy internal callers cannot return an HTTP boundary error. Invalid explicit values are
+    // ignored here; public API handlers use `try_parse_image_config_with_params` instead.
+    let image_size = normalize_image_size(image_size).ok().flatten();
+    parse_image_config_with_normalized_params(model_name, size, quality, image_size)
+}
+
+fn parse_image_config_with_normalized_params(
+    model_name: &str,
+    size: Option<&str>,
+    quality: Option<&str>,
+    image_size: Option<&'static str>,
+) -> (Value, String) {
     let mut aspect_ratio = "1:1";
 
     // 1. 优先从 size 参数解析宽高比
-    if let Some(s) = size {
-        aspect_ratio = calculate_aspect_ratio_from_size(s);
+    if let Some(parsed_ratio) = size.and_then(image_aspect_ratio_from_size) {
+        aspect_ratio = parsed_ratio;
     } else {
         // 2. 回退到模型后缀解析（保持向后兼容）
         if model_name.contains("-21x9") || model_name.contains("-21-9") {
@@ -214,32 +243,24 @@ pub fn parse_image_config_with_params(
     config.insert("aspectRatio".to_string(), json!(aspect_ratio));
 
     // [NEW] 0. 最高优先级：直接使用 image_size 参数
-    if let Some(is) = image_size {
-        config.insert("imageSize".to_string(), json!(is.to_uppercase()));
+    if let Some(image_size) = image_size {
+        config.insert("imageSize".to_string(), json!(image_size));
     } else {
         // 3. 优先从 quality 参数解析分辨率
-        if let Some(q) = quality {
-            match q.to_lowercase().as_str() {
-                "hd" | "4k" => {
-                    config.insert("imageSize".to_string(), json!("4K"));
-                }
-                "medium" | "2k" => {
-                    config.insert("imageSize".to_string(), json!("2K"));
-                }
-                "standard" | "1k" => {
-                    config.insert("imageSize".to_string(), json!("1K"));
-                }
-                _ => {} // 其他值不设置，使用默认
-            }
+        if let Some(image_size) = quality.and_then(image_size_from_quality) {
+            config.insert("imageSize".to_string(), json!(image_size));
         } else {
             // 4. 回退到模型后缀解析（保持向后兼容）
             let is_hd = model_name.contains("-4k") || model_name.contains("-hd");
             let is_2k = model_name.contains("-2k");
+            let is_1k = model_name.contains("-1k") || model_name.contains("-standard");
 
             if is_hd {
                 config.insert("imageSize".to_string(), json!("4K"));
             } else if is_2k {
                 config.insert("imageSize".to_string(), json!("2K"));
+            } else if is_1k {
+                config.insert("imageSize".to_string(), json!("1K"));
             }
         }
     }
@@ -247,6 +268,33 @@ pub fn parse_image_config_with_params(
     let clean_model_name = clean_image_model_name(model_name);
 
     (serde_json::Value::Object(config), clean_model_name)
+}
+
+fn normalize_image_size(image_size: Option<&str>) -> Result<Option<&'static str>, String> {
+    let Some(image_size) = image_size.map(str::trim) else {
+        return Ok(None);
+    };
+
+    if image_size.is_empty() || image_size.eq_ignore_ascii_case("auto") {
+        return Ok(None);
+    }
+
+    match image_size.to_ascii_lowercase().as_str() {
+        "1k" => Ok(Some("1K")),
+        "2k" => Ok(Some("2K")),
+        "4k" => Ok(Some("4K")),
+        _ => Err("Invalid image_size: expected one of 1K, 2K, 4K, or auto".to_string()),
+    }
+}
+
+fn image_size_from_quality(quality: &str) -> Option<&'static str> {
+    match quality.trim().to_ascii_lowercase().as_str() {
+        "low" | "standard" | "1k" => Some("1K"),
+        "medium" | "2k" => Some("2K"),
+        "high" | "hd" | "4k" => Some("4K"),
+        "auto" | "" => None,
+        _ => None,
+    }
 }
 
 /// Helper function to clean image model names by removing resolution/aspect-ratio suffixes.
@@ -309,19 +357,24 @@ fn clean_image_model_name(model_name: &str) -> String {
 ///
 /// # Returns
 /// 标准宽高比字符串 ("1:1", "16:9", "9:16", "4:3", "3:4", "21:9")
-fn calculate_aspect_ratio_from_size(size: &str) -> &'static str {
+pub fn image_aspect_ratio_from_size(size: &str) -> Option<&'static str> {
+    let size = size.trim();
+    if size.is_empty() || size.eq_ignore_ascii_case("auto") {
+        return None;
+    }
+
     // 0. Explicitly check known aspect ratios first
     match size {
-        "21:9" => return "21:9",
-        "16:9" => return "16:9",
-        "9:16" => return "9:16",
-        "4:3" => return "4:3",
-        "3:4" => return "3:4",
-        "3:2" => return "3:2",
-        "2:3" => return "2:3",
-        "5:4" => return "5:4",
-        "4:5" => return "4:5",
-        "1:1" => return "1:1",
+        "21:9" => return Some("21:9"),
+        "16:9" => return Some("16:9"),
+        "9:16" => return Some("9:16"),
+        "4:3" => return Some("4:3"),
+        "3:4" => return Some("3:4"),
+        "3:2" => return Some("3:2"),
+        "2:3" => return Some("2:3"),
+        "5:4" => return Some("5:4"),
+        "4:5" => return Some("4:5"),
+        "1:1" => return Some("1:1"),
         _ => {}
     }
 
@@ -332,40 +385,44 @@ fn calculate_aspect_ratio_from_size(size: &str) -> &'static str {
 
                 // 容差匹配常见比例（容差 0.05，避免 3:4 和 2:3 重叠）
                 if (ratio - 21.0 / 9.0).abs() < 0.05 {
-                    return "21:9";
+                    return Some("21:9");
                 }
                 if (ratio - 16.0 / 9.0).abs() < 0.05 {
-                    return "16:9";
+                    return Some("16:9");
                 }
                 if (ratio - 4.0 / 3.0).abs() < 0.05 {
-                    return "4:3";
+                    return Some("4:3");
                 }
                 if (ratio - 3.0 / 4.0).abs() < 0.05 {
-                    return "3:4";
+                    return Some("3:4");
                 }
                 if (ratio - 9.0 / 16.0).abs() < 0.05 {
-                    return "9:16";
+                    return Some("9:16");
                 }
                 if (ratio - 3.0 / 2.0).abs() < 0.05 {
-                    return "3:2";
+                    return Some("3:2");
                 }
                 if (ratio - 2.0 / 3.0).abs() < 0.05 {
-                    return "2:3";
+                    return Some("2:3");
                 }
                 if (ratio - 5.0 / 4.0).abs() < 0.05 {
-                    return "5:4";
+                    return Some("5:4");
                 }
                 if (ratio - 4.0 / 5.0).abs() < 0.05 {
-                    return "4:5";
+                    return Some("4:5");
                 }
                 if (ratio - 1.0).abs() < 0.05 {
-                    return "1:1";
+                    return Some("1:1");
                 }
             }
         }
     }
 
-    "1:1" // 默认回退
+    None
+}
+
+fn calculate_aspect_ratio_from_size(size: &str) -> &'static str {
+    image_aspect_ratio_from_size(size).unwrap_or("1:1")
 }
 
 /// Inject current googleSearch tool and ensure no duplicate legacy search tools
@@ -887,6 +944,79 @@ mod tests {
         );
         assert_eq!(config_3["imageSize"], "4K");
         assert_eq!(config_3["aspectRatio"], "16:9");
+    }
+
+    #[test]
+    fn image_quality_aliases_map_to_unified_image_sizes() {
+        let cases = [
+            ("low", "1K"),
+            ("standard", "1K"),
+            ("1k", "1K"),
+            ("medium", "2K"),
+            ("2k", "2K"),
+            ("high", "4K"),
+            ("hd", "4K"),
+            ("4k", "4K"),
+        ];
+        for (quality, expected) in cases {
+            let (config, _) = try_parse_image_config_with_params(
+                "gemini-3.1-flash-image",
+                None,
+                Some(quality),
+                None,
+            )
+            .expect("quality alias must parse");
+            assert_eq!(config["imageSize"], expected, "quality={quality}");
+        }
+    }
+
+    #[test]
+    fn image_size_priority_and_auto_fallback_are_enforced() {
+        let (explicit, _) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image-1k",
+            None,
+            Some("high"),
+            Some("2k"),
+        )
+        .expect("case-insensitive explicit image size");
+        assert_eq!(explicit["imageSize"], "2K");
+
+        let (quality, _) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image-1k",
+            None,
+            Some("medium"),
+            None,
+        )
+        .expect("quality overrides suffix");
+        assert_eq!(quality["imageSize"], "2K");
+
+        for quality in [Some("auto"), Some(""), None] {
+            let (fallback, _) = try_parse_image_config_with_params(
+                "gemini-3.1-flash-image-4k",
+                None,
+                quality,
+                Some("auto"),
+            )
+            .expect("auto values fall back to suffix");
+            assert_eq!(fallback["imageSize"], "4K");
+        }
+
+        let (upstream_default, _) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image",
+            None,
+            Some("auto"),
+            None,
+        )
+        .expect("auto without suffix uses upstream default");
+        assert!(upstream_default.get("imageSize").is_none());
+
+        assert!(try_parse_image_config_with_params(
+            "gemini-3.1-flash-image",
+            None,
+            None,
+            Some("8K"),
+        )
+        .is_err());
     }
 }
 

--- a/src-tauri/src/proxy/rate_limit.rs
+++ b/src-tauri/src/proxy/rate_limit.rs
@@ -2,6 +2,14 @@ use dashmap::DashMap;
 use regex::Regex;
 use std::time::{Duration, SystemTime};
 
+const MAX_LOCKOUT_SECONDS: u64 = 300;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RetryParserMode {
+    Current,
+    Baseline,
+}
+
 /// 限流原因类型
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RateLimitReason {
@@ -15,6 +23,35 @@ pub enum RateLimitReason {
     ServerError,
     /// 未知原因
     Unknown,
+}
+
+pub(crate) fn normalize_image_model_id(model: &str) -> Option<String> {
+    let normalized = crate::proxy::common::model_mapping::normalize_to_standard_id(model)?;
+    matches!(
+        normalized.as_str(),
+        "gemini-3.1-flash-image" | "gemini-3-pro-image"
+    )
+    .then_some(normalized)
+}
+
+pub(crate) fn has_explicit_quota_exhausted(body: &str) -> bool {
+    body.to_ascii_uppercase().contains("QUOTA_EXHAUSTED")
+}
+
+pub(crate) fn is_active_persisted_long_image_limit(
+    model_key: &str,
+    status: &crate::models::account::LiveLimitStatus,
+    now: i64,
+) -> bool {
+    status.status == 429
+        && status.reason == "QuotaExhausted"
+        && status.until > now
+        && status.until.saturating_sub(status.detected_at) > MAX_LOCKOUT_SECONDS as i64
+        && normalize_image_model_id(model_key).is_some()
+        && status.message.as_deref().is_some_and(|message| {
+            has_explicit_quota_exhausted(message)
+                && crate::proxy::upstream::retry::parse_retry_delay(message, None).is_some()
+        })
 }
 
 /// 限流信息
@@ -129,24 +166,23 @@ impl RateLimitTracker {
         model: Option<String>,
     ) {
         let now = SystemTime::now();
-        let mut retry_sec = reset_time
+        let (mut retry_sec, mut effective_reset_time) = reset_time
             .duration_since(now)
-            .map(|d| d.as_secs())
-            .unwrap_or(60); // 如果时间已过,使用默认 60 秒
+            .map(|duration| (duration.as_secs(), reset_time))
+            .unwrap_or((60, now + Duration::from_secs(60)));
 
-        if retry_sec > 300 {
+        if retry_sec > MAX_LOCKOUT_SECONDS {
             tracing::info!(
                 "Capping lockout time for {} from {}s to 300s (5 minutes)",
                 account_id,
                 retry_sec
             );
-            retry_sec = 300;
+            retry_sec = MAX_LOCKOUT_SECONDS;
+            effective_reset_time = now + Duration::from_secs(retry_sec);
         }
 
-        let reset_time = now + Duration::from_secs(retry_sec);
-
         let info = RateLimitInfo {
-            reset_time,
+            reset_time: effective_reset_time,
             retry_after_sec: retry_sec,
             detected_at: now,
             reason,
@@ -170,6 +206,39 @@ impl RateLimitTracker {
                 retry_sec
             );
         }
+    }
+
+    pub fn restore_persisted_long_image_limit(
+        &self,
+        account_id: &str,
+        reset_time: SystemTime,
+        detected_at: SystemTime,
+        model: &str,
+    ) -> bool {
+        let Some(normalized_model) = normalize_image_model_id(model) else {
+            return false;
+        };
+        let now = SystemTime::now();
+        let Ok(original_duration) = reset_time.duration_since(detected_at) else {
+            return false;
+        };
+        let Ok(remaining) = reset_time.duration_since(now) else {
+            return false;
+        };
+        if original_duration <= Duration::from_secs(MAX_LOCKOUT_SECONDS) {
+            return false;
+        }
+
+        let info = RateLimitInfo {
+            reset_time,
+            retry_after_sec: remaining.as_secs(),
+            detected_at,
+            reason: RateLimitReason::QuotaExhausted,
+            model: Some(normalized_model.clone()),
+        };
+        let key = self.get_limit_key(account_id, Some(&normalized_model));
+        self.limits.insert(key, info);
+        true
     }
 
     /// 使用 ISO 8601 时间字符串精确锁定账号
@@ -220,6 +289,47 @@ impl RateLimitTracker {
         model: Option<String>,
         backoff_steps: &[u64], // [NEW] 传入退避配置
     ) -> Option<RateLimitInfo> {
+        self.parse_from_error_with_mode(
+            account_id,
+            status,
+            retry_after_header,
+            body,
+            model,
+            backoff_steps,
+            RetryParserMode::Current,
+        )
+    }
+
+    pub fn parse_from_error_baseline(
+        &self,
+        account_id: &str,
+        status: u16,
+        retry_after_header: Option<&str>,
+        body: &str,
+        model: Option<String>,
+        backoff_steps: &[u64],
+    ) -> Option<RateLimitInfo> {
+        self.parse_from_error_with_mode(
+            account_id,
+            status,
+            retry_after_header,
+            body,
+            model,
+            backoff_steps,
+            RetryParserMode::Baseline,
+        )
+    }
+
+    fn parse_from_error_with_mode(
+        &self,
+        account_id: &str,
+        status: u16,
+        retry_after_header: Option<&str>,
+        body: &str,
+        model: Option<String>,
+        backoff_steps: &[u64],
+        parser_mode: RetryParserMode,
+    ) -> Option<RateLimitInfo> {
         // 支持 429 (限流) 以及 500/503/529 (后端故障软避让)
         if status != 429 && status != 500 && status != 503 && status != 529 && status != 404 {
             return None;
@@ -238,19 +348,25 @@ impl RateLimitTracker {
             RateLimitReason::ServerError
         };
 
-        let mut retry_after_sec = None;
-
-        // 2. 从 Retry-After header 提取
-        if let Some(retry_after) = retry_after_header {
-            if let Ok(seconds) = retry_after.parse::<u64>() {
-                retry_after_sec = Some(seconds);
+        let retry_after_sec = match parser_mode {
+            RetryParserMode::Current => {
+                crate::proxy::upstream::retry::parse_retry_delay(body, retry_after_header)
+                    .map(|delay_ms| delay_ms.saturating_add(999) / 1000)
             }
-        }
-
-        // 3. 从错误消息提取 (优先尝试 JSON 解析，再试正则)
-        if retry_after_sec.is_none() {
-            retry_after_sec = self.parse_retry_time_from_body(body);
-        }
+            RetryParserMode::Baseline => retry_after_header
+                .and_then(|value| value.parse::<u64>().ok())
+                .or_else(|| self.parse_retry_time_from_body_baseline(body)),
+        };
+        let has_explicit_retry_time = retry_after_sec.is_some();
+        let preserve_long_image_quota = parser_mode == RetryParserMode::Current
+            && status == 429
+            && reason == RateLimitReason::QuotaExhausted
+            && has_explicit_quota_exhausted(body)
+            && has_explicit_retry_time
+            && model
+                .as_deref()
+                .and_then(normalize_image_model_id)
+                .is_some();
 
         // 4. 处理默认值与软避让逻辑（根据限流类型设置不同默认值）
         let retry_sec = match retry_after_sec {
@@ -359,13 +475,13 @@ impl RateLimitTracker {
         };
 
         let mut retry_sec = retry_sec;
-        if retry_sec > 300 {
+        if retry_sec > MAX_LOCKOUT_SECONDS && !preserve_long_image_quota {
             tracing::info!(
                 "Capping retry lockout time for {} from {}s to 300s (5 minutes)",
                 account_id,
                 retry_sec
             );
-            retry_sec = 300;
+            retry_sec = MAX_LOCKOUT_SECONDS;
         }
 
         let info = RateLimitInfo {
@@ -461,161 +577,110 @@ impl RateLimitTracker {
         }
     }
 
-    /// 通用时间解析函数：支持 "2h1m1s" 等所有格式组合
-    fn parse_duration_string(&self, s: &str) -> Option<u64> {
-        tracing::debug!("[时间解析] 尝试解析: '{}'", s);
+    /// 从错误消息 body 中解析重置时间
+    fn parse_retry_time_from_body(&self, body: &str) -> Option<u64> {
+        crate::proxy::upstream::retry::parse_retry_delay(body, None)
+            .map(|delay_ms| delay_ms.saturating_add(999) / 1000)
+    }
 
-        // 使用正则表达式提取小时、分钟、秒、毫秒
-        // 支持格式："2h1m1s", "1h30m", "5m", "30s", "500ms", "510.790006ms" 等
-        // 🔧 [FIX] 修改 ms 部分支持小数: (\d+)ms -> (\d+(?:\.\d+)?)ms
+    fn parse_duration_string_baseline(&self, value: &str) -> Option<u64> {
         let re = Regex::new(r"(?:(\d+)h)?(?:(\d+)m)?(?:(\d+(?:\.\d+)?)s)?(?:(\d+(?:\.\d+)?)ms)?")
             .ok()?;
-        let caps = match re.captures(s) {
-            Some(c) => c,
-            None => {
-                tracing::warn!("[时间解析] 正则未匹配: '{}'", s);
-                return None;
-            }
-        };
-
-        let hours = caps
+        let captures = re.captures(value)?;
+        let hours = captures
             .get(1)
-            .and_then(|m| m.as_str().parse::<u64>().ok())
+            .and_then(|value| value.as_str().parse::<u64>().ok())
             .unwrap_or(0);
-        let minutes = caps
+        let minutes = captures
             .get(2)
-            .and_then(|m| m.as_str().parse::<u64>().ok())
+            .and_then(|value| value.as_str().parse::<u64>().ok())
             .unwrap_or(0);
-        let seconds = caps
+        let seconds = captures
             .get(3)
-            .and_then(|m| m.as_str().parse::<f64>().ok())
+            .and_then(|value| value.as_str().parse::<f64>().ok())
             .unwrap_or(0.0);
-        // 🔧 [FIX] 毫秒也支持小数解析
-        let milliseconds = caps
+        let milliseconds = captures
             .get(4)
-            .and_then(|m| m.as_str().parse::<f64>().ok())
+            .and_then(|value| value.as_str().parse::<f64>().ok())
             .unwrap_or(0.0);
-
-        tracing::debug!(
-            "[时间解析] 提取结果: {}h {}m {:.3}s {:.3}ms",
-            hours,
-            minutes,
-            seconds,
-            milliseconds
-        );
-
-        // 🔧 [FIX] 计算总秒数，毫秒部分向上取整
         let total_seconds = hours * 3600
             + minutes * 60
             + seconds.ceil() as u64
             + (milliseconds / 1000.0).ceil() as u64;
-
-        // 如果总秒数为 0，说明解析失败
-        if total_seconds == 0 {
-            tracing::warn!("[时间解析] 失败: '{}' (总秒数为0)", s);
-            None
-        } else {
-            tracing::info!(
-                "[时间解析] ✓ 成功: '{}' => {}秒 ({}h {}m {:.1}s {:.1}ms)",
-                s,
-                total_seconds,
-                hours,
-                minutes,
-                seconds,
-                milliseconds
-            );
-            Some(total_seconds)
-        }
+        (total_seconds > 0).then_some(total_seconds)
     }
 
-    /// 从错误消息 body 中解析重置时间
-    fn parse_retry_time_from_body(&self, body: &str) -> Option<u64> {
-        // A. 优先尝试 JSON 精准解析
+    fn parse_retry_time_from_body_baseline(&self, body: &str) -> Option<u64> {
         let trimmed = body.trim();
         if trimmed.starts_with('{') || trimmed.starts_with('[') {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed) {
-                // 1. Google 常见的 quotaResetDelay 格式 (支持所有格式："2h1m1s", "1h30m", "42s", "500ms" 等)
-                // 路径: error.details[0].metadata.quotaResetDelay
-                if let Some(delay_str) = json
+                if let Some(delay) = json
                     .get("error")
-                    .and_then(|e| e.get("details"))
-                    .and_then(|d| d.as_array())
-                    .and_then(|a| a.get(0))
-                    .and_then(|o| o.get("metadata")) // 添加 metadata 层级
-                    .and_then(|m| m.get("quotaResetDelay"))
-                    .and_then(|v| v.as_str())
+                    .and_then(|error| error.get("details"))
+                    .and_then(|details| details.as_array())
+                    .and_then(|details| details.first())
+                    .and_then(|detail| detail.get("metadata"))
+                    .and_then(|metadata| metadata.get("quotaResetDelay"))
+                    .and_then(|value| value.as_str())
+                    .and_then(|value| self.parse_duration_string_baseline(value))
                 {
-                    tracing::debug!("[JSON解析] 找到 quotaResetDelay: '{}'", delay_str);
-
-                    // 使用通用时间解析函数
-                    if let Some(seconds) = self.parse_duration_string(delay_str) {
-                        return Some(seconds);
-                    }
+                    return Some(delay);
                 }
-
-                // 2. OpenAI 常见的 retry_after 字段 (数字)
                 if let Some(retry) = json
                     .get("error")
-                    .and_then(|e| e.get("retry_after"))
-                    .and_then(|v| v.as_u64())
+                    .and_then(|error| error.get("retry_after"))
+                    .and_then(|value| value.as_u64())
                 {
                     return Some(retry);
                 }
             }
         }
 
-        // B. 正则匹配模式 (兜底)
-        // 模式 1: "Try again in 2m 30s"
-        if let Ok(re) = Regex::new(r"(?i)try again in (\d+)m\s*(\d+)s") {
-            if let Some(caps) = re.captures(body) {
-                if let (Ok(m), Ok(s)) = (caps[1].parse::<u64>(), caps[2].parse::<u64>()) {
-                    return Some(m * 60 + s);
-                }
+        for pattern in [
+            r"(?i)try again in (\d+)m\s*(\d+)s",
+            r"(?i)(?:try again in|backoff for|wait)\s*(\d+)s",
+            r"(?i)quota will reset in (\d+) second",
+            r"(?i)retry after (\d+) second",
+            r"\(wait (\d+)s\)",
+        ] {
+            let captures = Regex::new(pattern).ok()?.captures(body);
+            let Some(captures) = captures else {
+                continue;
+            };
+            if captures.len() == 3 {
+                let minutes = captures.get(1)?.as_str().parse::<u64>().ok()?;
+                let seconds = captures.get(2)?.as_str().parse::<u64>().ok()?;
+                return Some(minutes * 60 + seconds);
+            }
+            if let Some(seconds) = captures
+                .get(1)
+                .and_then(|value| value.as_str().parse::<u64>().ok())
+            {
+                return Some(seconds);
             }
         }
-
-        // 模式 2: "Try again in 30s" 或 "backoff for 42s"
-        if let Ok(re) = Regex::new(r"(?i)(?:try again in|backoff for|wait)\s*(\d+)s") {
-            if let Some(caps) = re.captures(body) {
-                if let Ok(s) = caps[1].parse::<u64>() {
-                    return Some(s);
-                }
-            }
-        }
-
-        // 模式 3: "quota will reset in X seconds"
-        if let Ok(re) = Regex::new(r"(?i)quota will reset in (\d+) second") {
-            if let Some(caps) = re.captures(body) {
-                if let Ok(s) = caps[1].parse::<u64>() {
-                    return Some(s);
-                }
-            }
-        }
-
-        // 模式 4: OpenAI 风格的 "Retry after (\d+) seconds"
-        if let Ok(re) = Regex::new(r"(?i)retry after (\d+) second") {
-            if let Some(caps) = re.captures(body) {
-                if let Ok(s) = caps[1].parse::<u64>() {
-                    return Some(s);
-                }
-            }
-        }
-
-        // 模式 5: 括号形式 "(wait (\d+)s)"
-        if let Ok(re) = Regex::new(r"\(wait (\d+)s\)") {
-            if let Some(caps) = re.captures(body) {
-                if let Ok(s) = caps[1].parse::<u64>() {
-                    return Some(s);
-                }
-            }
-        }
-
         None
     }
 
     /// 获取账号的限流信息
     pub fn get(&self, account_id: &str) -> Option<RateLimitInfo> {
         self.limits.get(account_id).map(|r| r.clone())
+    }
+
+    pub fn clear_model(&self, account_id: &str, model: &str) -> bool {
+        let normalized = crate::proxy::common::model_mapping::normalize_to_standard_id(model)
+            .unwrap_or_else(|| model.to_string());
+        let mut cleared = self
+            .limits
+            .remove(&self.get_limit_key(account_id, Some(&normalized)))
+            .is_some();
+        if normalized != model {
+            cleared |= self
+                .limits
+                .remove(&self.get_limit_key(account_id, Some(model)))
+                .is_some();
+        }
+        cleared
     }
 
     /// 检查账号是否仍在限流中
@@ -661,7 +726,29 @@ impl RateLimitTracker {
 
     /// 清除指定账号的限流记录
     pub fn clear(&self, account_id: &str) -> bool {
-        self.limits.remove(account_id).is_some()
+        let prefix = format!("{}:", account_id);
+        let before = self.limits.len();
+        self.limits
+            .retain(|key, _| key != account_id && !key.starts_with(&prefix));
+        self.failure_counts.remove(account_id);
+        self.limits.len() != before
+    }
+
+    pub fn clear_for_optimistic_reset(&self) {
+        let now = SystemTime::now();
+        self.limits.retain(|_, info| {
+            info.reason == RateLimitReason::QuotaExhausted
+                && info
+                    .model
+                    .as_deref()
+                    .and_then(normalize_image_model_id)
+                    .is_some()
+                && info
+                    .reset_time
+                    .duration_since(info.detected_at)
+                    .is_ok_and(|duration| duration > Duration::from_secs(MAX_LOCKOUT_SECONDS))
+                && info.reset_time.duration_since(now).is_ok()
+        });
     }
 
     /// 清除所有限流记录 (乐观重置策略)
@@ -738,6 +825,123 @@ mod tests {
         let wait = tracker.get_remaining_wait("acc1", None);
         // Due to time passing, it might be 1 or 2
         assert!(wait >= 1 && wait <= 2);
+    }
+
+    #[test]
+    fn task_preserves_explicit_long_image_quota_deadline() {
+        let tracker = RateLimitTracker::new();
+        let body = r#"{
+            "error": {
+                "details": [{
+                    "reason": "QUOTA_EXHAUSTED",
+                    "metadata": {"quotaResetDelay": "58h24m53s"}
+                }]
+            }
+        }"#;
+        let info = tracker
+            .parse_from_error(
+                "acc-long",
+                429,
+                None,
+                body,
+                Some("gemini-3-pro-image".to_string()),
+                &[60, 300],
+            )
+            .unwrap();
+        assert_eq!(info.retry_after_sec, 210_293);
+
+        tracker.clear_for_optimistic_reset();
+        assert!(tracker.is_rate_limited("acc-long", Some("gemini-3-pro-image")));
+
+        let now = SystemTime::now();
+        assert!(tracker.restore_persisted_long_image_limit(
+            "acc-expiring",
+            now + Duration::from_secs(30),
+            now - Duration::from_secs(301),
+            "gemini-3.1-flash-image",
+        ));
+        tracker.clear_for_optimistic_reset();
+        assert!(tracker.is_rate_limited("acc-expiring", Some("gemini-3.1-flash-image")));
+
+        let inferred = tracker
+            .parse_from_error(
+                "acc-inferred",
+                429,
+                None,
+                "Quota limit hit; reset after 72h",
+                Some("gemini-3-pro-image".to_string()),
+                &[60, 300],
+            )
+            .unwrap();
+        assert_eq!(inferred.retry_after_sec, 300);
+
+        let text_model = tracker
+            .parse_from_error(
+                "acc-text",
+                429,
+                Some("72h"),
+                r#"{"error":{"details":[{"reason":"QUOTA_EXHAUSTED"}]}}"#,
+                Some("gemini-2.5-pro".to_string()),
+                &[60, 300],
+            )
+            .unwrap();
+        assert_eq!(text_model.retry_after_sec, 300);
+
+        let broad_quota = tracker
+            .parse_from_error(
+                "acc-broad",
+                429,
+                None,
+                "Quota limit hit; reset after 72h",
+                Some("gemini-3.1-flash-image".to_string()),
+                &[60, 300],
+            )
+            .unwrap();
+        assert_eq!(broad_quota.retry_after_sec, 300);
+
+        let inferred_reset = SystemTime::now() + Duration::from_secs(72 * 3600);
+        tracker.set_lockout_until(
+            "acc-inferred-reset",
+            inferred_reset,
+            RateLimitReason::QuotaExhausted,
+            Some("gemini-3-pro-image".to_string()),
+        );
+        assert!(
+            tracker.get_remaining_wait("acc-inferred-reset", Some("gemini-3-pro-image")) <= 300
+        );
+    }
+
+    #[test]
+    fn task_claude_baseline_ignores_retry_info_delay() {
+        for (index, delay) in ["1s", "3s"].into_iter().enumerate() {
+            let body = format!(
+                r#"{{"error":{{"details":[{{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"{}"}}]}}}}"#,
+                delay
+            );
+            let current = RateLimitTracker::new()
+                .parse_from_error(
+                    &format!("current-{}", index),
+                    429,
+                    None,
+                    &body,
+                    None,
+                    &[60, 300],
+                )
+                .unwrap();
+            assert_eq!(current.retry_after_sec, if index == 0 { 2 } else { 3 });
+
+            let baseline = RateLimitTracker::new()
+                .parse_from_error_baseline(
+                    &format!("baseline-{}", index),
+                    429,
+                    None,
+                    &body,
+                    None,
+                    &[60, 300],
+                )
+                .unwrap();
+            assert_eq!(baseline.retry_after_sec, 60);
+        }
     }
 
     #[test]

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -16,6 +16,64 @@ enum OnDiskAccountState {
     Unknown,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrackerParserMode {
+    Current,
+    Baseline,
+}
+
+fn classify_rate_limit_reason(error_body: &str) -> crate::proxy::rate_limit::RateLimitReason {
+    use crate::proxy::rate_limit::RateLimitReason;
+
+    let body = error_body.to_lowercase();
+    let generic_resource_exhausted =
+        body.contains("resource has been exhausted") || body.contains("resource_exhausted");
+    let explicit_quota_exhausted = body.contains("quota_exhausted")
+        || body.contains("quotaresetdelay")
+        || body.contains("quota reset")
+        || body.contains("quota limit")
+        || body.contains("per day")
+        || body.contains("daily quota");
+
+    if body.contains("model_capacity") {
+        RateLimitReason::ModelCapacityExhausted
+    } else if body.contains("per minute")
+        || body.contains("rate limit")
+        || body.contains("too many requests")
+        || (generic_resource_exhausted && !explicit_quota_exhausted)
+    {
+        RateLimitReason::RateLimitExceeded
+    } else if explicit_quota_exhausted || body.contains("exhausted") || body.contains("quota") {
+        RateLimitReason::QuotaExhausted
+    } else {
+        RateLimitReason::Unknown
+    }
+}
+
+fn update_account_json(
+    path: &std::path::Path,
+    update: impl FnOnce(&mut serde_json::Value),
+) -> Result<(), String> {
+    let _account_write = crate::modules::account::lock_account_file_updates()?;
+    let raw = std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?;
+    let mut content: serde_json::Value =
+        serde_json::from_str(&raw).map_err(|e| format!("解析 JSON 失败: {}", e))?;
+    update(&mut content);
+    let serialized =
+        serde_json::to_string_pretty(&content).map_err(|e| format!("序列化 JSON 失败: {}", e))?;
+    std::fs::write(path, serialized).map_err(|e| format!("写入文件失败: {}", e))
+}
+
+fn unix_timestamp_ceil(time: std::time::SystemTime) -> Option<i64> {
+    let since_epoch = time
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .ok()?;
+    let seconds = since_epoch
+        .as_secs()
+        .saturating_add(u64::from(since_epoch.subsec_nanos() > 0));
+    i64::try_from(seconds).ok()
+}
+
 #[derive(Debug, Clone)]
 pub struct ProxyToken {
     pub account_id: String,
@@ -138,6 +196,7 @@ impl TokenManager {
 
         // Reload should reflect current on-disk state (accounts can be added/removed/disabled).
         self.tokens.clear();
+        self.rate_limit_tracker.clear_all();
         self.current_index.store(0, Ordering::SeqCst);
         {
             let mut last_used = self.last_used_account.lock().await;
@@ -189,8 +248,6 @@ impl TokenManager {
         match self.load_single_account(&path).await {
             Ok(Some(token)) => {
                 self.tokens.insert(account_id.to_string(), token);
-                // [NEW] 重新加载账号时自动清除该账号的限流记录
-                self.clear_rate_limit(account_id);
                 Ok(())
             }
             Ok(None) => {
@@ -206,10 +263,7 @@ impl TokenManager {
 
     /// 重新加载所有账号
     pub async fn reload_all_accounts(&self) -> Result<usize, String> {
-        let count = self.load_accounts().await?;
-        // [NEW] 重新加载所有账号时自动清除所有限流记录
-        self.clear_all_rate_limits();
-        Ok(count)
+        self.load_accounts().await
     }
 
     /// 从内存中彻底移除指定账号及其关联数据 (Issue #1477)
@@ -219,7 +273,7 @@ impl TokenManager {
             tracing::info!("[Proxy] Removed account {} from memory cache", account_id);
         }
         self.health_scores.remove(account_id);
-        self.clear_rate_limit(account_id);
+        self.rate_limit_tracker.clear(account_id);
         self.session_accounts.retain(|_, v| v != account_id);
         if let Ok(mut preferred) = self.preferred_account_id.try_write() {
             if preferred.as_deref() == Some(account_id) {
@@ -375,9 +429,11 @@ impl TokenManager {
                 account["validation_blocked_until"] = serde_json::json!(0);
                 account["validation_blocked_reason"] = serde_json::Value::Null;
 
-                let updated_json =
-                    serde_json::to_string_pretty(&account).map_err(|e| e.to_string())?;
-                std::fs::write(path, updated_json).map_err(|e| e.to_string())?;
+                update_account_json(path, |latest| {
+                    latest["validation_blocked"] = serde_json::json!(false);
+                    latest["validation_blocked_until"] = serde_json::json!(0);
+                    latest["validation_blocked_reason"] = serde_json::Value::Null;
+                })?;
                 tracing::info!(
                     "Validation block expired and cleared for account: {}",
                     account
@@ -535,6 +591,39 @@ impl TokenManager {
                 ) {
                     model_limits.insert(name.to_string(), limit);
                 }
+            }
+        }
+
+        if let Some(live_limits) = account
+            .get("live_limited_models")
+            .and_then(|value| value.as_object())
+        {
+            let now = chrono::Utc::now().timestamp();
+            for (model_key, status) in live_limits {
+                let Ok(status) = serde_json::from_value::<crate::models::account::LiveLimitStatus>(
+                    status.clone(),
+                ) else {
+                    continue;
+                };
+                if !crate::proxy::rate_limit::is_active_persisted_long_image_limit(
+                    model_key, &status, now,
+                ) {
+                    continue;
+                }
+                let (Ok(until_seconds), Ok(detected_at_seconds)) = (
+                    u64::try_from(status.until),
+                    u64::try_from(status.detected_at),
+                ) else {
+                    continue;
+                };
+                self.rate_limit_tracker.restore_persisted_long_image_limit(
+                    &account_id,
+                    std::time::SystemTime::UNIX_EPOCH
+                        + std::time::Duration::from_secs(until_seconds),
+                    std::time::SystemTime::UNIX_EPOCH
+                        + std::time::Duration::from_secs(detected_at_seconds),
+                    model_key,
+                );
             }
         }
 
@@ -939,11 +1028,22 @@ impl TokenManager {
             );
 
             // 3. 写入磁盘
-            std::fs::write(
-                account_path,
-                serde_json::to_string_pretty(account_json).unwrap(),
-            )
-            .map_err(|e| format!("写入文件失败: {}", e))?;
+            update_account_json(account_path, |latest| {
+                if latest
+                    .get("protected_models")
+                    .and_then(|value| value.as_array())
+                    .is_none()
+                {
+                    latest["protected_models"] = serde_json::Value::Array(Vec::new());
+                }
+                let protected_models = latest["protected_models"].as_array_mut().unwrap();
+                if !protected_models
+                    .iter()
+                    .any(|model| model.as_str() == Some(model_name))
+                {
+                    protected_models.push(serde_json::Value::String(model_name.to_string()));
+                }
+            })?;
 
             // [FIX] 触发 TokenManager 的账号重新加载信号，确保内存中的 protected_models 同步
             crate::proxy::server::trigger_account_reload(account_id);
@@ -1007,12 +1107,14 @@ impl TokenManager {
             }
         }
 
-        account_json["protected_models"] = serde_json::Value::Array(protected_list);
+        account_json["protected_models"] = serde_json::Value::Array(protected_list.clone());
 
-        let _ = std::fs::write(
-            account_path,
-            serde_json::to_string_pretty(account_json).unwrap(),
-        );
+        let _ = update_account_json(account_path, |latest| {
+            latest["proxy_disabled"] = serde_json::Value::Bool(false);
+            latest["proxy_disabled_reason"] = serde_json::Value::Null;
+            latest["proxy_disabled_at"] = serde_json::Value::Null;
+            latest["protected_models"] = serde_json::Value::Array(protected_list);
+        });
 
         false // 返回 false 表示现在已可以尝试加载该账号（模型级过滤会在 get_token 时发生）
     }
@@ -1039,11 +1141,14 @@ impl TokenManager {
                     account_id,
                     model_name
                 );
-                std::fs::write(
-                    account_path,
-                    serde_json::to_string_pretty(account_json).unwrap(),
-                )
-                .map_err(|e| format!("写入文件失败: {}", e))?;
+                update_account_json(account_path, |latest| {
+                    if let Some(protected_models) = latest
+                        .get_mut("protected_models")
+                        .and_then(|value| value.as_array_mut())
+                    {
+                        protected_models.retain(|model| model.as_str() != Some(model_name));
+                    }
+                })?;
                 return Ok(true);
             }
         }
@@ -1183,6 +1288,25 @@ impl TokenManager {
         session_id: Option<&str>,
         target_model: &str,
     ) -> Result<(String, String, String, String, u64), String> {
+        let excluded_accounts = HashSet::new();
+        self.get_token_filtered(
+            quota_group,
+            force_rotate,
+            session_id,
+            target_model,
+            &excluded_accounts,
+        )
+        .await
+    }
+
+    async fn get_token_filtered(
+        &self,
+        quota_group: &str,
+        force_rotate: bool,
+        session_id: Option<&str>,
+        target_model: &str,
+        excluded_accounts: &HashSet<String>,
+    ) -> Result<(String, String, String, String, u64), String> {
         // [FIX] 检查并处理待重新加载的账号（配额保护同步）
         let pending_reload = crate::proxy::server::take_pending_reload_accounts();
         for account_id in pending_reload {
@@ -1210,7 +1334,13 @@ impl TokenManager {
         let timeout_duration = std::time::Duration::from_secs(5);
         match tokio::time::timeout(
             timeout_duration,
-            self.get_token_internal(quota_group, force_rotate, session_id, target_model),
+            self.get_token_internal(
+                quota_group,
+                force_rotate,
+                session_id,
+                target_model,
+                excluded_accounts,
+            ),
         )
         .await
         {
@@ -1228,9 +1358,11 @@ impl TokenManager {
         force_rotate: bool,
         session_id: Option<&str>,
         target_model: &str,
+        excluded_accounts: &HashSet<String>,
     ) -> Result<(String, String, String, String, u64), String> {
         let mut tokens_snapshot: Vec<ProxyToken> =
             self.tokens.iter().map(|e| e.value().clone()).collect();
+        tokens_snapshot.retain(|token| !excluded_accounts.contains(&token.account_id));
         let mut total = tokens_snapshot.len();
         if total == 0 {
             return Err("Token pool is empty".to_string());
@@ -1762,15 +1894,23 @@ impl TokenManager {
                             tokio::time::sleep(tokio::time::Duration::from_millis(wait_ms)).await;
 
                             // 重新尝试选择账号
-                            let retry_token = tokens_snapshot.iter().find(|t| {
-                                !attempted.contains(&t.account_id)
-                                    && !self.is_rate_limited_sync(
-                                        &t.account_id,
-                                        Some(&normalized_target),
-                                    )
-                                    && !(quota_protection_enabled
-                                        && t.protected_models.contains(&normalized_target))
-                            });
+                            let mut retry_token = None;
+                            for token in &tokens_snapshot {
+                                if attempted.contains(&token.account_id)
+                                    || self
+                                        .is_rate_limited(
+                                            &token.account_id,
+                                            Some(&normalized_target),
+                                        )
+                                        .await
+                                    || (quota_protection_enabled
+                                        && token.protected_models.contains(&normalized_target))
+                                {
+                                    continue;
+                                }
+                                retry_token = Some(token);
+                                break;
+                            }
 
                             if let Some(t) = retry_token {
                                 tracing::info!(
@@ -1786,7 +1926,7 @@ impl TokenManager {
                                 );
 
                                 // 清除所有限流记录
-                                self.rate_limit_tracker.clear_all();
+                                self.rate_limit_tracker.clear_for_optimistic_reset();
 
                                 // 再次尝试选择账号
                                 let final_token = tokens_snapshot.iter().find(|t| {
@@ -1894,9 +2034,13 @@ impl TokenManager {
                                     token.email,
                                     e
                                 );
-                                let is_grant_error = e.contains("\"invalid_grant\"") || e.contains("invalid_grant");
+                                let is_grant_error =
+                                    e.contains("\"invalid_grant\"") || e.contains("invalid_grant");
                                 if is_grant_error {
-                                    let mut fail_count = self.invalid_grant_failures.entry(token.account_id.clone()).or_insert(0);
+                                    let mut fail_count = self
+                                        .invalid_grant_failures
+                                        .entry(token.account_id.clone())
+                                        .or_insert(0);
                                     *fail_count += 1;
                                     let current_fails = *fail_count;
                                     if current_fails >= 2 {
@@ -1974,8 +2118,8 @@ impl TokenManager {
                             Ok(pid) => {
                                 if let Some(mut entry) = self.tokens.get_mut(&token.account_id) {
                                     entry.project_id = Some(pid.clone());
-                                    let _ = self.save_project_id(&token.account_id, &pid).await;
                                 }
+                                let _ = self.save_project_id(&token.account_id, &pid).await;
                                 Ok(pid)
                             }
                             Err(e) => Err(e),
@@ -2005,29 +2149,28 @@ impl TokenManager {
                         .clone();
                     let _guard = refresh_mu.lock().await;
 
-                    if let Some(mut entry) = self.tokens.get_mut(&token.account_id) {
-                        if let Some(pid) = &entry.project_id {
-                            if !pid.is_empty() {
-                                pid.clone()
-                            } else {
-                                match crate::proxy::project_resolver::fetch_project_id(
-                                    &entry.access_token,
-                                )
+                    let project_state = self
+                        .tokens
+                        .get(&token.account_id)
+                        .map(|entry| (entry.project_id.clone(), entry.access_token.clone()));
+                    match project_state {
+                        Some((Some(pid), _)) if !pid.is_empty() => pid,
+                        Some((Some(_), access_token)) => {
+                            match crate::proxy::project_resolver::fetch_project_id(&access_token)
                                 .await
-                                {
-                                    Ok(pid) => {
+                            {
+                                Ok(pid) => {
+                                    if let Some(mut entry) = self.tokens.get_mut(&token.account_id)
+                                    {
                                         entry.project_id = Some(pid.clone());
-                                        let _ = self.save_project_id(&token.account_id, &pid).await;
-                                        pid
                                     }
-                                    Err(_) => "bamboo-precept-lgxtn".to_string(),
+                                    let _ = self.save_project_id(&token.account_id, &pid).await;
+                                    pid
                                 }
+                                Err(_) => "bamboo-precept-lgxtn".to_string(),
                             }
-                        } else {
-                            "bamboo-precept-lgxtn".to_string()
                         }
-                    } else {
-                        "bamboo-precept-lgxtn".to_string()
+                        _ => "bamboo-precept-lgxtn".to_string(),
                     }
                 } else {
                     // 如果不是第一个，则等待结果 (虽然在 Mutex 模式下不需要 rx，但为了严谨性我们可以保留锁)
@@ -2080,24 +2223,15 @@ impl TokenManager {
                 .join(format!("{}.json", account_id))
         };
 
-        let mut content: serde_json::Value = serde_json::from_str(
-            &tokio::fs::read_to_string(&path)
-                .await
-                .map_err(|e| format!("读取文件失败: {}", e))?,
-        )
-        .map_err(|e| format!("解析 JSON 失败: {}", e))?;
-
         let now = chrono::Utc::now().timestamp();
-        content["disabled"] = serde_json::Value::Bool(true);
-        content["disabled_at"] = serde_json::Value::Number(now.into());
-        content["disabled_reason"] = serde_json::Value::String(truncate_reason(reason, 800));
-
-        tokio::fs::write(&path, serde_json::to_string_pretty(&content).unwrap())
-            .await
-            .map_err(|e| format!("写入文件失败: {}", e))?;
+        update_account_json(&path, |content| {
+            content["disabled"] = serde_json::Value::Bool(true);
+            content["disabled_at"] = serde_json::Value::Number(now.into());
+            content["disabled_reason"] = serde_json::Value::String(truncate_reason(reason, 800));
+        })?;
 
         // 【修复 Issue #3】从内存中移除禁用的账号，防止被60s锁定逻辑继续使用
-        self.tokens.remove(account_id);
+        self.remove_account(account_id);
 
         tracing::warn!("Account disabled: {} ({:?})", account_id, path);
         Ok(())
@@ -2105,22 +2239,15 @@ impl TokenManager {
 
     /// 保存 project_id 到账号文件
     async fn save_project_id(&self, account_id: &str, project_id: &str) -> Result<(), String> {
-        let entry = self.tokens.get(account_id).ok_or("账号不存在")?;
-
-        let path = &entry.account_path;
-
-        let mut content: serde_json::Value = serde_json::from_str(
-            &tokio::fs::read_to_string(path)
-                .await
-                .map_err(|e| format!("读取文件失败: {}", e))?,
-        )
-        .map_err(|e| format!("解析 JSON 失败: {}", e))?;
-
-        content["token"]["project_id"] = serde_json::Value::String(project_id.to_string());
-
-        tokio::fs::write(path, serde_json::to_string_pretty(&content).unwrap())
-            .await
-            .map_err(|e| format!("写入文件失败: {}", e))?;
+        let path = self
+            .tokens
+            .get(account_id)
+            .ok_or("账号不存在")?
+            .account_path
+            .clone();
+        update_account_json(&path, |content| {
+            content["token"]["project_id"] = serde_json::Value::String(project_id.to_string());
+        })?;
 
         tracing::debug!("已保存 project_id 到账号 {}", account_id);
         Ok(())
@@ -2132,36 +2259,31 @@ impl TokenManager {
         account_id: &str,
         token_response: &crate::modules::oauth::TokenResponse,
     ) -> Result<(), String> {
-        let entry = self.tokens.get(account_id).ok_or("账号不存在")?;
-
-        let path = &entry.account_path;
-
-        let mut content: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(path).map_err(|e| format!("读取文件失败: {}", e))?,
-        )
-        .map_err(|e| format!("解析 JSON 失败: {}", e))?;
-
+        let path = self
+            .tokens
+            .get(account_id)
+            .ok_or("账号不存在")?
+            .account_path
+            .clone();
         let now = chrono::Utc::now().timestamp();
+        update_account_json(&path, |content| {
+            content["token"]["access_token"] =
+                serde_json::Value::String(token_response.access_token.clone());
+            content["token"]["expires_in"] =
+                serde_json::Value::Number(token_response.expires_in.into());
+            content["token"]["expiry_timestamp"] =
+                serde_json::Value::Number((now + token_response.expires_in).into());
 
-        content["token"]["access_token"] =
-            serde_json::Value::String(token_response.access_token.clone());
-        content["token"]["expires_in"] =
-            serde_json::Value::Number(token_response.expires_in.into());
-        content["token"]["expiry_timestamp"] =
-            serde_json::Value::Number((now + token_response.expires_in).into());
+            // 如果获取到了新的 id_token，则保存它
+            if let Some(ref id_token) = token_response.id_token {
+                content["token"]["id_token"] = serde_json::Value::String(id_token.clone());
+            }
 
-        // 如果获取到了新的 id_token，则保存它
-        if let Some(ref id_token) = token_response.id_token {
-            content["token"]["id_token"] = serde_json::Value::String(id_token.clone());
-        }
-
-        // 如果获取到了新的 refresh_token（Token 轮转），也一并保存
-        if let Some(ref rt) = token_response.refresh_token {
-            content["token"]["refresh_token"] = serde_json::Value::String(rt.clone());
-        }
-
-        std::fs::write(path, serde_json::to_string_pretty(&content).unwrap())
-            .map_err(|e| format!("写入文件失败: {}", e))?;
+            // 如果获取到了新的 refresh_token（Token 轮转），也一并保存
+            if let Some(ref rt) = token_response.refresh_token {
+                content["token"]["refresh_token"] = serde_json::Value::String(rt.clone());
+            }
+        })?;
 
         tracing::debug!("已保存刷新后的 token 到账号 {}", account_id);
         Ok(())
@@ -2303,16 +2425,6 @@ impl TokenManager {
         self.rate_limit_tracker.is_rate_limited(account_id, model)
     }
 
-    /// [NEW] 检查账号是否在限流中 (同步版本，仅用于 Iterator)
-    pub fn is_rate_limited_sync(&self, account_id: &str, model: Option<&str>) -> bool {
-        // 同步版本无法读取 async RwLock，这里使用 blocking_read
-        let config = self.circuit_breaker_config.blocking_read();
-        if !config.enabled {
-            return false;
-        }
-        self.rate_limit_tracker.is_rate_limited(account_id, model)
-    }
-
     /// 获取距离限流重置还有多少秒
     #[allow(dead_code)]
     pub fn get_rate_limit_reset_seconds(&self, account_id: &str) -> Option<u64> {
@@ -2336,12 +2448,60 @@ impl TokenManager {
 
     /// 清除指定账号的限流记录
     pub fn clear_rate_limit(&self, account_id: &str) -> bool {
+        let cleared = self.rate_limit_tracker.clear(account_id);
+        let persisted_cleared = self.clear_all_persisted_live_limits(account_id);
+        cleared || persisted_cleared
+    }
+
+    pub fn clear_rate_limit_memory(&self, account_id: &str) -> bool {
         self.rate_limit_tracker.clear(account_id)
     }
 
     /// 清除所有限流记录
     pub fn clear_all_rate_limits(&self) {
         self.rate_limit_tracker.clear_all();
+        let accounts_dir = self.data_dir.join("accounts");
+        if let Ok(entries) = std::fs::read_dir(accounts_dir) {
+            for entry in entries.flatten() {
+                if entry.path().extension().and_then(|value| value.to_str()) == Some("json") {
+                    if let Some(account_id) =
+                        entry.path().file_stem().and_then(|value| value.to_str())
+                    {
+                        self.clear_all_persisted_live_limits(account_id);
+                    }
+                }
+            }
+        }
+    }
+
+    fn clear_all_persisted_live_limits(&self, account_id: &str) -> bool {
+        let path = self
+            .data_dir
+            .join("accounts")
+            .join(format!("{}.json", account_id));
+        let Ok(_account_write) = crate::modules::account::lock_account_file_updates() else {
+            return false;
+        };
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            return false;
+        };
+        let Ok(mut content) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            return false;
+        };
+        let Some(live_limits) = content
+            .get_mut("live_limited_models")
+            .and_then(|value| value.as_object_mut())
+        else {
+            return false;
+        };
+        if live_limits.is_empty() {
+            return false;
+        }
+        live_limits.clear();
+        let Ok(serialized) = serde_json::to_string_pretty(&content) else {
+            return false;
+        };
+        std::fs::write(path, serialized).is_ok()
     }
 
     /// 标记账号请求成功，重置连续失败计数
@@ -2575,195 +2735,316 @@ impl TokenManager {
         }
     }
 
-    /// 标记账号限流(异步版本,支持实时配额刷新)
-    ///
-    /// 三级降级策略:
-    /// 1. 优先: API 返回 quotaResetDelay → 直接使用
-    /// 2. 次优: 实时刷新配额 → 获取最新 reset_time
-    /// 3. 保底: 使用本地缓存配额 → 读取账号文件
-    /// 4. 兜底: 指数退避策略 → 默认锁定时间
-    ///
-    /// # 参数
-    /// - `email`: 账号邮箱,用于查找账号信息
-    /// - `status`: HTTP 状态码（如 429、500 等）
-    /// - `retry_after_header`: 可选的 Retry-After 响应头
-    /// - `error_body`: 错误响应体,用于解析 quotaResetDelay
-    /// - `model`: 可选的模型名称,用于模型级别限流
+    fn has_explicit_retry_time(
+        parser_mode: TrackerParserMode,
+        retry_after_header: Option<&str>,
+        error_body: &str,
+    ) -> bool {
+        match parser_mode {
+            TrackerParserMode::Current => {
+                crate::proxy::upstream::retry::parse_retry_delay(error_body, retry_after_header)
+                    .is_some()
+            }
+            TrackerParserMode::Baseline => {
+                retry_after_header.is_some() || error_body.contains("quotaResetDelay")
+            }
+        }
+    }
+
+    fn parse_rate_limit_with_mode(
+        &self,
+        account_id: &str,
+        status: u16,
+        retry_after_header: Option<&str>,
+        error_body: &str,
+        model: Option<&str>,
+        backoff_steps: &[u64],
+        parser_mode: TrackerParserMode,
+    ) -> Option<crate::proxy::rate_limit::RateLimitInfo> {
+        match parser_mode {
+            TrackerParserMode::Current => self.rate_limit_tracker.parse_from_error(
+                account_id,
+                status,
+                retry_after_header,
+                error_body,
+                model.map(str::to_string),
+                backoff_steps,
+            ),
+            TrackerParserMode::Baseline => self.rate_limit_tracker.parse_from_error_baseline(
+                account_id,
+                status,
+                retry_after_header,
+                error_body,
+                model.map(str::to_string),
+                backoff_steps,
+            ),
+        }
+    }
+
+    fn record_rate_limit_atomic(
+        &self,
+        account_id: &str,
+        status: u16,
+        retry_after_header: Option<&str>,
+        error_body: &str,
+        model: Option<&str>,
+        backoff_steps: &[u64],
+        parser_mode: TrackerParserMode,
+    ) -> Option<crate::proxy::rate_limit::RateLimitInfo> {
+        if model
+            .and_then(crate::proxy::rate_limit::normalize_image_model_id)
+            .is_some()
+        {
+            match crate::modules::account::lock_account_file_updates() {
+                Ok(_account_write) => {
+                    let info = self.parse_rate_limit_with_mode(
+                        account_id,
+                        status,
+                        retry_after_header,
+                        error_body,
+                        model,
+                        backoff_steps,
+                        parser_mode,
+                    );
+                    if parser_mode == TrackerParserMode::Current {
+                        if let Some(ref info) = info {
+                            self.persist_live_limit_locked(
+                                account_id,
+                                model,
+                                status,
+                                retry_after_header,
+                                error_body,
+                                info,
+                            );
+                        }
+                    }
+                    return info;
+                }
+                Err(error) => {
+                    tracing::debug!(
+                        "Failed to serialize live limit update for {}: {}",
+                        account_id,
+                        error
+                    );
+                }
+            }
+        }
+
+        self.parse_rate_limit_with_mode(
+            account_id,
+            status,
+            retry_after_header,
+            error_body,
+            model,
+            backoff_steps,
+            parser_mode,
+        )
+    }
+
+    /// Register the in-memory image exclusion before releasing its account permit.
+    /// Returns whether a slower quota refresh is still useful after the permit is released.
+    pub async fn mark_rate_limited_fast(
+        &self,
+        email: &str,
+        status: u16,
+        retry_after_header: Option<&str>,
+        error_body: &str,
+        model: Option<&str>,
+    ) -> bool {
+        let normalized_model =
+            model.and_then(crate::proxy::common::model_mapping::normalize_to_standard_id);
+        let model_to_track = normalized_model.as_deref().or(model);
+        let config = self.circuit_breaker_config.read().await.clone();
+        if !config.enabled {
+            return false;
+        }
+
+        let account_id = self
+            .email_to_account_id(email)
+            .unwrap_or_else(|| email.to_string());
+        let has_explicit_retry_time = Self::has_explicit_retry_time(
+            TrackerParserMode::Current,
+            retry_after_header,
+            error_body,
+        );
+        let reason = classify_rate_limit_reason(error_body);
+        let recorded = self.record_rate_limit_atomic(
+            &account_id,
+            status,
+            retry_after_header,
+            error_body,
+            model_to_track,
+            &config.backoff_steps,
+            TrackerParserMode::Current,
+        );
+
+        status == 429
+            && recorded.is_some()
+            && !has_explicit_retry_time
+            && reason == crate::proxy::rate_limit::RateLimitReason::QuotaExhausted
+    }
+
+    pub async fn refresh_quota_lock_after_fast_mark(&self, email: &str, model: Option<&str>) {
+        let normalized_model =
+            model.and_then(crate::proxy::common::model_mapping::normalize_to_standard_id);
+        let model_to_track = normalized_model.as_deref().or(model);
+        let account_id = self
+            .email_to_account_id(email)
+            .unwrap_or_else(|| email.to_string());
+        let reason = crate::proxy::rate_limit::RateLimitReason::QuotaExhausted;
+
+        if self
+            .fetch_and_lock_with_realtime_quota(email, reason, model_to_track.map(str::to_string))
+            .await
+        {
+            tracing::info!("账号 {} 已使用实时配额精确锁定", email);
+            return;
+        }
+        if self.set_precise_lockout(&account_id, reason, model_to_track.map(str::to_string)) {
+            tracing::info!("账号 {} 已使用本地缓存配额锁定", account_id);
+        }
+    }
+
     pub async fn mark_rate_limited_async(
         &self,
         email: &str,
         status: u16,
         retry_after_header: Option<&str>,
         error_body: &str,
-        model: Option<&str>, // 🆕 新增模型参数
+        model: Option<&str>,
     ) {
-        // [FIX #2209] 统一归一化模型名称，确保锁定 Key 与负载均衡检查 Key 一致
-        let normalized_model =
-            model.and_then(|m| crate::proxy::common::model_mapping::normalize_to_standard_id(m));
-        let model_to_track = normalized_model.as_deref().or(model);
+        self.mark_rate_limited_async_with_mode(
+            email,
+            status,
+            retry_after_header,
+            error_body,
+            model,
+            TrackerParserMode::Current,
+        )
+        .await;
+    }
 
-        // [NEW] 检查熔断是否启用
+    pub async fn mark_rate_limited_async_baseline(
+        &self,
+        email: &str,
+        status: u16,
+        retry_after_header: Option<&str>,
+        error_body: &str,
+        model: Option<&str>,
+    ) {
+        self.mark_rate_limited_async_with_mode(
+            email,
+            status,
+            retry_after_header,
+            error_body,
+            model,
+            TrackerParserMode::Baseline,
+        )
+        .await;
+    }
+
+    async fn mark_rate_limited_async_with_mode(
+        &self,
+        email: &str,
+        status: u16,
+        retry_after_header: Option<&str>,
+        error_body: &str,
+        model: Option<&str>,
+        parser_mode: TrackerParserMode,
+    ) {
+        let normalized_model =
+            model.and_then(crate::proxy::common::model_mapping::normalize_to_standard_id);
+        let model_to_track = normalized_model.as_deref().or(model);
         let config = self.circuit_breaker_config.read().await.clone();
         if !config.enabled {
             return;
         }
 
-        // [FIX] Convert email to account_id for consistent tracking
         let account_id = self
             .email_to_account_id(email)
             .unwrap_or_else(|| email.to_string());
-
-        // 检查 API 是否返回了精确的重试时间
-        let has_explicit_retry_time =
-            retry_after_header.is_some() || error_body.contains("quotaResetDelay");
-
-        if has_explicit_retry_time {
-            // API 返回了精确时间(quotaResetDelay),直接使用,无需实时刷新
-            if let Some(m) = model {
-                tracing::debug!(
-                    "账号 {} 的模型 {} 的 429 响应包含 quotaResetDelay,直接使用 API 返回的时间",
-                    account_id,
-                    m
-                );
-            } else {
-                tracing::debug!(
-                    "账号 {} 的 429 响应包含 quotaResetDelay,直接使用 API 返回的时间",
-                    account_id
-                );
-            }
-            self.rate_limit_tracker.parse_from_error(
+        if Self::has_explicit_retry_time(parser_mode, retry_after_header, error_body) {
+            self.record_rate_limit_atomic(
                 &account_id,
                 status,
                 retry_after_header,
                 error_body,
-                model_to_track.map(|s| s.to_string()),
-                &config.backoff_steps, // [NEW] 传入配置
-            );
-            let reason = if error_body.to_lowercase().contains("quota") {
-                crate::proxy::rate_limit::RateLimitReason::QuotaExhausted
-            } else {
-                crate::proxy::rate_limit::RateLimitReason::RateLimitExceeded
-            };
-            self.persist_live_limit(&account_id, model_to_track, status, reason, error_body);
-            return;
-        }
-
-        // 确定限流原因
-        let error_body_lower = error_body.to_lowercase();
-        let generic_resource_exhausted = error_body_lower.contains("resource has been exhausted")
-            || error_body_lower.contains("resource_exhausted");
-        let explicit_quota_exhausted = error_body_lower.contains("quota_exhausted")
-            || error_body_lower.contains("quotaresetdelay")
-            || error_body_lower.contains("quota reset")
-            || error_body_lower.contains("quota limit")
-            || error_body_lower.contains("per day")
-            || error_body_lower.contains("daily quota");
-
-        let reason = if error_body_lower.contains("model_capacity") {
-            crate::proxy::rate_limit::RateLimitReason::ModelCapacityExhausted
-        } else if error_body_lower.contains("per minute")
-            || error_body_lower.contains("rate limit")
-            || error_body_lower.contains("too many requests")
-            || (generic_resource_exhausted && !explicit_quota_exhausted)
-        {
-            crate::proxy::rate_limit::RateLimitReason::RateLimitExceeded
-        } else if explicit_quota_exhausted
-            || error_body_lower.contains("exhausted")
-            || error_body_lower.contains("quota")
-        {
-            crate::proxy::rate_limit::RateLimitReason::QuotaExhausted
-        } else {
-            crate::proxy::rate_limit::RateLimitReason::Unknown
-        };
-
-        if !matches!(
-            reason,
-            crate::proxy::rate_limit::RateLimitReason::QuotaExhausted
-        ) {
-            tracing::info!(
-                "账号 {} 的 {} 响应被识别为 {:?},使用短退避而不是配额重置锁定",
-                account_id,
-                status,
-                reason
-            );
-            self.rate_limit_tracker.parse_from_error(
-                &account_id,
-                status,
-                retry_after_header,
-                error_body,
-                model_to_track.map(|s| s.to_string()),
+                model_to_track,
                 &config.backoff_steps,
+                parser_mode,
             );
-            self.persist_live_limit(&account_id, model_to_track, status, reason, error_body);
             return;
         }
 
-        // API 未返回 quotaResetDelay,需要实时刷新配额获取精确锁定时间
-        if let Some(m) = model_to_track {
-            tracing::info!(
-                "账号 {} 的模型 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...",
-                account_id,
-                m
+        let reason = classify_rate_limit_reason(error_body);
+        if reason != crate::proxy::rate_limit::RateLimitReason::QuotaExhausted {
+            self.record_rate_limit_atomic(
+                &account_id,
+                status,
+                retry_after_header,
+                error_body,
+                model_to_track,
+                &config.backoff_steps,
+                parser_mode,
             );
-        } else {
-            tracing::info!(
-                "账号 {} 的 429 响应未包含 quotaResetDelay,尝试实时刷新配额...",
-                account_id
-            );
+            return;
         }
 
-        // [FIX] 传入 email 而不是 account_id，因为 fetch_and_lock_with_realtime_quota 期望 email
         if self
-            .fetch_and_lock_with_realtime_quota(
-                email,
-                reason,
-                model_to_track.map(|s| s.to_string()),
-            )
+            .fetch_and_lock_with_realtime_quota(email, reason, model_to_track.map(str::to_string))
             .await
         {
             tracing::info!("账号 {} 已使用实时配额精确锁定", email);
-            self.persist_live_limit(&account_id, model_to_track, status, reason, error_body);
             return;
         }
-
-        // 实时刷新失败,尝试使用本地缓存的配额刷新时间
-        if self.set_precise_lockout(&account_id, reason, model_to_track.map(|s| s.to_string())) {
+        if self.set_precise_lockout(&account_id, reason, model_to_track.map(str::to_string)) {
             tracing::info!("账号 {} 已使用本地缓存配额锁定", account_id);
-            self.persist_live_limit(&account_id, model_to_track, status, reason, error_body);
             return;
         }
 
-        // 都失败了,回退到指数退避策略
         tracing::warn!("账号 {} 无法获取配额刷新时间,使用指数退避策略", account_id);
-        self.rate_limit_tracker.parse_from_error(
+        self.record_rate_limit_atomic(
             &account_id,
             status,
             retry_after_header,
             error_body,
-            model_to_track.map(|s| s.to_string()),
-            &config.backoff_steps, // [NEW] 传入配置
+            model_to_track,
+            &config.backoff_steps,
+            parser_mode,
         );
-        self.persist_live_limit(&account_id, model_to_track, status, reason, error_body);
     }
 
-    fn persist_live_limit(
+    fn persist_live_limit_locked(
         &self,
         account_id: &str,
         model: Option<&str>,
         status: u16,
-        reason: crate::proxy::rate_limit::RateLimitReason,
+        retry_after_header: Option<&str>,
         error_body: &str,
+        info: &crate::proxy::rate_limit::RateLimitInfo,
     ) {
-        let Some(model_key) = model.filter(|m| !m.is_empty()) else {
+        let Some(model_key) = model.and_then(crate::proxy::rate_limit::normalize_image_model_id)
+        else {
             return;
         };
-
-        let wait_sec = self
-            .rate_limit_tracker
-            .get_remaining_wait(account_id, Some(model_key));
-        if wait_sec == 0 {
+        let Some(explicit_delay_ms) =
+            crate::proxy::upstream::retry::parse_retry_delay(error_body, retry_after_header)
+        else {
+            return;
+        };
+        if status != 429
+            || info.reason != crate::proxy::rate_limit::RateLimitReason::QuotaExhausted
+            || info.retry_after_sec <= 300
+            || !crate::proxy::rate_limit::has_explicit_quota_exhausted(error_body)
+        {
             return;
         }
+        let (Some(until), Some(detected_at)) = (
+            unix_timestamp_ceil(info.reset_time),
+            unix_timestamp_ceil(info.detected_at),
+        ) else {
+            return;
+        };
 
         let path = if let Some(entry) = self.tokens.get(account_id) {
             entry.account_path.clone()
@@ -2788,25 +3069,33 @@ impl TokenManager {
             content["live_limited_models"] = serde_json::Value::Object(serde_json::Map::new());
         }
 
-        let now = chrono::Utc::now().timestamp();
-        content["live_limited_models"][model_key] = serde_json::json!({
+        content["live_limited_models"][&model_key] = serde_json::json!({
             "model": model_key,
             "status": status,
-            "reason": format!("{:?}", reason),
-            "until": now + wait_sec as i64,
-            "detected_at": now,
-            "message": truncate_reason(error_body, 500),
+            "reason": format!("{:?}", info.reason),
+            "until": until,
+            "detected_at": detected_at,
+            "message": format!(
+                "QUOTA_EXHAUSTED; retry after {}ms; {}",
+                explicit_delay_ms,
+                truncate_reason(error_body, 400)
+            ),
         });
 
-        if let Err(e) = std::fs::write(&path, serde_json::to_string_pretty(&content).unwrap()) {
+        let Ok(serialized) = serde_json::to_string_pretty(&content) else {
+            return;
+        };
+        if let Err(e) = std::fs::write(&path, serialized) {
             tracing::debug!("Failed to persist live limit for {}: {}", account_id, e);
         }
     }
 
-    pub async fn clear_persisted_live_limit(&self, account_id: &str, model: Option<&str>) {
-        let Some(model_key) = model.filter(|m| !m.is_empty()) else {
+    pub fn clear_persisted_live_limit(&self, account_id: &str, model: Option<&str>) {
+        let Some(raw_model) = model.filter(|m| !m.is_empty()) else {
             return;
         };
+        let model_key = crate::proxy::common::model_mapping::normalize_to_standard_id(raw_model)
+            .unwrap_or_else(|| raw_model.to_string());
 
         let path = if let Some(entry) = self.tokens.get(account_id) {
             entry.account_path.clone()
@@ -2816,8 +3105,20 @@ impl TokenManager {
                 .join(format!("{}.json", account_id))
         };
 
-        let Ok(raw) = std::fs::read_to_string(&path) else {
+        let Ok(_account_write) = crate::modules::account::lock_account_file_updates() else {
             return;
+        };
+
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                self.rate_limit_tracker.clear_model(account_id, &model_key);
+                return;
+            }
+            Err(error) => {
+                tracing::debug!("Failed to read live limit for {}: {}", account_id, error);
+                return;
+            }
         };
         let Ok(mut content) = serde_json::from_str::<serde_json::Value>(&raw) else {
             return;
@@ -2827,18 +3128,25 @@ impl TokenManager {
             .get_mut("live_limited_models")
             .and_then(|value| value.as_object_mut())
         else {
+            self.rate_limit_tracker.clear_model(account_id, &model_key);
             return;
         };
 
-        live_limits.remove(model_key);
-        if model_key.contains("image") {
-            live_limits.remove("gemini-3.1-flash-image");
-            live_limits.remove("gemini-3-pro-image");
+        let mut changed = live_limits.remove(&model_key).is_some();
+        if model_key != raw_model {
+            changed |= live_limits.remove(raw_model).is_some();
         }
 
-        if let Err(e) = std::fs::write(&path, serde_json::to_string_pretty(&content).unwrap()) {
-            tracing::debug!("Failed to clear live limit for {}: {}", account_id, e);
+        if changed {
+            let Ok(serialized) = serde_json::to_string_pretty(&content) else {
+                return;
+            };
+            if let Err(error) = std::fs::write(&path, serialized) {
+                tracing::debug!("Failed to clear live limit for {}: {}", account_id, error);
+                return;
+            }
         }
+        self.rate_limit_tracker.clear_model(account_id, &model_key);
     }
 
     // ===== 调度配置相关方法 =====
@@ -3105,17 +3413,6 @@ impl TokenManager {
             return Err(format!("Account file not found: {:?}", path));
         }
 
-        let content = std::fs::read_to_string(&path)
-            .map_err(|e| format!("Failed to read account file: {}", e))?;
-
-        let mut account: serde_json::Value = serde_json::from_str(&content)
-            .map_err(|e| format!("Failed to parse account JSON: {}", e))?;
-
-        account["validation_blocked"] = serde_json::Value::Bool(true);
-        account["validation_blocked_until"] =
-            serde_json::Value::Number(serde_json::Number::from(block_until));
-        account["validation_blocked_reason"] = serde_json::Value::String(reason.to_string());
-
         // [NEW] 尝试从消息中提取验证链接 (#1522)
         let extracted_url = if let Ok(parsed_json) =
             serde_json::from_str::<serde_json::Value>(reason)
@@ -3149,21 +3446,24 @@ impl TokenManager {
             })
         };
 
-        if let Some(url) = extracted_url {
-            account["validation_url"] = serde_json::Value::String(url.clone());
+        if let Some(ref url) = extracted_url {
             if let Some(mut token) = self.tokens.get_mut(account_id) {
-                token.validation_url = Some(url);
+                token.validation_url = Some(url.clone());
             }
         }
 
+        update_account_json(&path, |account| {
+            account["validation_blocked"] = serde_json::Value::Bool(true);
+            account["validation_blocked_until"] =
+                serde_json::Value::Number(serde_json::Number::from(block_until));
+            account["validation_blocked_reason"] = serde_json::Value::String(reason.to_string());
+            if let Some(url) = extracted_url {
+                account["validation_url"] = serde_json::Value::String(url);
+            }
+        })?;
+
         // Clear sticky session if blocked
         self.session_accounts.retain(|_, v| *v != account_id);
-
-        let json_str = serde_json::to_string_pretty(&account)
-            .map_err(|e| format!("Failed to serialize account JSON: {}", e))?;
-
-        std::fs::write(&path, json_str)
-            .map_err(|e| format!("Failed to write account file: {}", e))?;
 
         tracing::info!(
             "🚫 Account {} validation blocked until {} (reason: {})",
@@ -3241,7 +3541,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reload_account_purges_cache_when_account_becomes_proxy_disabled() {
+    async fn task_reload_account_preserves_live_limit_and_syncs_disabled_state() {
         let tmp_root = std::env::temp_dir().join(format!(
             "antigravity-token-manager-test-{}",
             uuid::Uuid::new_v4()
@@ -3250,6 +3550,7 @@ mod tests {
         std::fs::create_dir_all(&accounts_dir).unwrap();
 
         let account_id = "acc1";
+        let model = "gemini-3-pro-image";
         let email = "a@test.com";
         let now = chrono::Utc::now().timestamp();
         let account_path = accounts_dir.join(format!("{}.json", account_id));
@@ -3266,7 +3567,33 @@ mod tests {
             "disabled": false,
             "proxy_disabled": false,
             "created_at": now,
-            "last_used": now
+            "last_used": now,
+            "live_limited_models": {
+                model: {
+                    "model": model,
+                    "status": 429,
+                    "reason": "QuotaExhausted",
+                    "until": now + 7200,
+                    "detected_at": now,
+                    "message": "{\"error\":{\"details\":[{\"reason\":\"QUOTA_EXHAUSTED\",\"metadata\":{\"quotaResetDelay\":\"2h\"}}]}}"
+                },
+                "gemini-3.1-flash-image": {
+                    "model": "gemini-3.1-flash-image",
+                    "status": 429,
+                    "reason": "QuotaExhausted",
+                    "until": now + 7200,
+                    "detected_at": now,
+                    "message": "QUOTA_EXHAUSTED"
+                },
+                "gemini-2.5-pro": {
+                    "model": "gemini-2.5-pro",
+                    "status": 429,
+                    "reason": "QuotaExhausted",
+                    "until": now + 7200,
+                    "detected_at": now,
+                    "message": "QUOTA_EXHAUSTED; reset after 2h"
+                }
+            }
         });
         std::fs::write(
             &account_path,
@@ -3277,6 +3604,40 @@ mod tests {
         let manager = TokenManager::new(tmp_root.clone());
         manager.load_accounts().await.unwrap();
         assert!(manager.tokens.get(account_id).is_some());
+        assert!(manager
+            .rate_limit_tracker
+            .is_rate_limited(account_id, Some(model)));
+        assert!(!manager
+            .rate_limit_tracker
+            .is_rate_limited(account_id, Some("gemini-3.1-flash-image")));
+        assert!(!manager
+            .rate_limit_tracker
+            .is_rate_limited(account_id, Some("gemini-2.5-pro")));
+
+        let temporary_model = "gemini-3.1-flash-image";
+        manager.rate_limit_tracker.parse_from_error(
+            account_id,
+            429,
+            Some("60"),
+            "temporary rate limit",
+            Some(temporary_model.to_string()),
+            &[60, 300],
+        );
+        assert!(manager
+            .rate_limit_tracker
+            .is_rate_limited(account_id, Some(temporary_model)));
+        assert!(manager.clear_rate_limit_memory(account_id));
+        assert!(!manager
+            .rate_limit_tracker
+            .is_rate_limited(account_id, Some(model)));
+
+        manager.reload_account(account_id).await.unwrap();
+        assert!(manager
+            .rate_limit_tracker
+            .is_rate_limited(account_id, Some(model)));
+        assert!(!manager
+            .rate_limit_tracker
+            .is_rate_limited(account_id, Some(temporary_model)));
 
         // Prime extra caches to ensure remove_account() is really called.
         manager
@@ -3303,6 +3664,290 @@ mod tests {
         assert!(manager.tokens.get(account_id).is_none());
         assert!(manager.session_accounts.get("sid1").is_none());
         assert!(manager.preferred_account_id.read().await.is_none());
+
+        disabled_json["proxy_disabled"] = serde_json::Value::Bool(false);
+        std::fs::write(
+            &account_path,
+            serde_json::to_string_pretty(&disabled_json).unwrap(),
+        )
+        .unwrap();
+        manager.reload_account(account_id).await.unwrap();
+        assert!(manager
+            .rate_limit_tracker
+            .is_rate_limited(account_id, Some(model)));
+
+        let restarted = TokenManager::new(tmp_root.clone());
+        restarted.load_accounts().await.unwrap();
+        assert!(restarted
+            .rate_limit_tracker
+            .is_rate_limited(account_id, Some(model)));
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
+    }
+
+    #[tokio::test]
+    async fn task_account_json_update_preserves_live_limits() {
+        let tmp_root = std::env::temp_dir().join(format!(
+            "antigravity-account-update-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let accounts_dir = tmp_root.join("accounts");
+        std::fs::create_dir_all(&accounts_dir).unwrap();
+        let account_id = "acc-update";
+        let account_path = accounts_dir.join(format!("{}.json", account_id));
+        let live_limit = serde_json::json!({
+            "model": "gemini-3-pro-image",
+            "status": 429,
+            "reason": "QuotaExhausted",
+            "until": chrono::Utc::now().timestamp() + 7200,
+            "detected_at": chrono::Utc::now().timestamp(),
+            "message": "QUOTA_EXHAUSTED; reset after 2h"
+        });
+        std::fs::write(
+            &account_path,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "id": account_id,
+                "live_limited_models": {
+                    "gemini-3-pro-image": live_limit
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let manager = TokenManager::new(tmp_root.clone());
+        manager.disable_account(account_id, "test").await.unwrap();
+
+        let updated: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&account_path).unwrap()).unwrap();
+        assert_eq!(
+            updated["live_limited_models"]["gemini-3-pro-image"],
+            live_limit
+        );
+        assert_eq!(updated["disabled"], true);
+
+        let mut account_snapshot = updated;
+        assert!(manager
+            .trigger_quota_protection(
+                &mut account_snapshot,
+                account_id,
+                &account_path,
+                0,
+                10,
+                "gemini-3-flash",
+            )
+            .await
+            .unwrap());
+        assert!(manager
+            .restore_quota_protection(
+                &mut account_snapshot,
+                account_id,
+                &account_path,
+                "gemini-3-flash",
+            )
+            .await
+            .unwrap());
+
+        account_snapshot["proxy_disabled"] = serde_json::Value::Bool(true);
+        account_snapshot["proxy_disabled_reason"] =
+            serde_json::Value::String("quota_protection".to_string());
+        let quota = serde_json::json!({
+            "models": [{ "name": "gemini-3-flash", "percentage": 0 }]
+        });
+        let config = crate::models::QuotaProtectionConfig {
+            enabled: true,
+            threshold_percentage: 10,
+            monitored_models: vec!["gemini-3-flash".to_string()],
+        };
+        manager
+            .check_and_restore_quota(&mut account_snapshot, &account_path, &quota, &config)
+            .await;
+
+        update_account_json(&account_path, |latest| {
+            latest["validation_blocked"] = serde_json::Value::Bool(true);
+            latest["validation_blocked_until"] =
+                serde_json::Value::Number((chrono::Utc::now().timestamp() - 1).into());
+            latest["validation_blocked_reason"] = serde_json::Value::String("expired".to_string());
+        })
+        .unwrap();
+        manager.load_single_account(&account_path).await.unwrap();
+
+        let updated: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&account_path).unwrap()).unwrap();
+        assert_eq!(
+            updated["live_limited_models"]["gemini-3-pro-image"],
+            live_limit
+        );
+        assert_eq!(updated["validation_blocked"], false);
+        assert_eq!(
+            updated["protected_models"],
+            serde_json::json!(["gemini-3-flash"])
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
+    }
+
+    #[tokio::test]
+    async fn task_short_limit_buffer_reselects_without_blocking_runtime() {
+        let tmp_root = std::env::temp_dir().join(format!(
+            "antigravity-short-limit-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let accounts_dir = tmp_root.join("accounts");
+        std::fs::create_dir_all(&accounts_dir).unwrap();
+        let account_id = "acc-short-limit";
+        let model = "gemini-3-flash";
+        let now = chrono::Utc::now().timestamp();
+        std::fs::write(
+            accounts_dir.join(format!("{}.json", account_id)),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "id": account_id,
+                "email": "short-limit@test.com",
+                "token": {
+                    "access_token": "atk",
+                    "refresh_token": "rtk",
+                    "expires_in": 3600,
+                    "expiry_timestamp": now + 3600,
+                    "project_id": "pid"
+                },
+                "quota": {
+                    "models": [{ "name": model, "percentage": 100 }]
+                },
+                "disabled": false,
+                "proxy_disabled": false,
+                "created_at": now,
+                "last_used": now
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let manager = TokenManager::new(tmp_root.clone());
+        manager.load_accounts().await.unwrap();
+        manager.rate_limit_tracker.parse_from_error(
+            account_id,
+            429,
+            Some("1"),
+            r#"{"error":{"details":[{"reason":"QUOTA_EXHAUSTED"}]}}"#,
+            Some(model.to_string()),
+            &[60, 300],
+        );
+
+        let selected = tokio::time::timeout(
+            std::time::Duration::from_secs(4),
+            manager.get_token("gemini", false, None, model),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(selected.3, account_id);
+        assert!(!manager.is_rate_limited(account_id, Some(model)).await);
+
+        let _ = std::fs::remove_dir_all(&tmp_root);
+    }
+
+    #[tokio::test]
+    async fn task_concurrent_image_limits_persist_and_clear_exact_bucket() {
+        let tmp_root = std::env::temp_dir().join(format!(
+            "antigravity-live-limit-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let accounts_dir = tmp_root.join("accounts");
+        std::fs::create_dir_all(&accounts_dir).unwrap();
+        let account_id = "acc-concurrent";
+        let account_path = accounts_dir.join(format!("{}.json", account_id));
+        std::fs::write(
+            &account_path,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "id": account_id,
+                "email": "concurrent@test.com",
+                "live_limited_models": {}
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let manager = TokenManager::new(tmp_root.clone());
+        let body = r#"{"error":{"details":[{"reason":"QUOTA_EXHAUSTED","metadata":{"quotaResetDelay":"72h"}}]}}"#;
+        assert!(!manager
+            .mark_rate_limited_fast(
+                account_id,
+                429,
+                None,
+                body,
+                Some("gemini-3.1-flash-image"),
+            )
+            .await);
+        assert!(manager
+            .rate_limit_tracker
+            .is_rate_limited(account_id, Some("gemini-3.1-flash-image")));
+        let persisted: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&account_path).unwrap()).unwrap();
+        let flash_limit = &persisted["live_limited_models"]["gemini-3.1-flash-image"];
+        assert_eq!(flash_limit["status"], 429);
+        assert!(
+            flash_limit["until"].as_i64().unwrap() - chrono::Utc::now().timestamp() > 71 * 3600
+        );
+
+        manager.clear_persisted_live_limit(account_id, Some("gemini-3.1-flash-image-4k"));
+        std::thread::scope(|scope| {
+            for model in ["gemini-3.1-flash-image", "gemini-3-pro-image"] {
+                let manager = &manager;
+                scope.spawn(move || {
+                    manager.record_rate_limit_atomic(
+                        account_id,
+                        429,
+                        None,
+                        body,
+                        Some(model),
+                        &[60, 300],
+                        TrackerParserMode::Current,
+                    );
+                });
+            }
+        });
+
+        let persisted: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&account_path).unwrap()).unwrap();
+        let limits = persisted["live_limited_models"].as_object().unwrap();
+        assert!(limits.contains_key("gemini-3.1-flash-image"));
+        assert!(limits.contains_key("gemini-3-pro-image"));
+
+        manager.clear_persisted_live_limit(account_id, Some("gemini-3.1-flash-image-4k"));
+        let persisted: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&account_path).unwrap()).unwrap();
+        let limits = persisted["live_limited_models"].as_object().unwrap();
+        assert!(!limits.contains_key("gemini-3.1-flash-image"));
+        assert!(limits.contains_key("gemini-3-pro-image"));
+
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                manager.record_rate_limit_atomic(
+                    account_id,
+                    429,
+                    None,
+                    body,
+                    Some("gemini-3-pro-image"),
+                    &[60, 300],
+                    TrackerParserMode::Current,
+                );
+            });
+            scope.spawn(|| {
+                manager.clear_persisted_live_limit(account_id, Some("gemini-3-pro-image"));
+            });
+        });
+        let persisted: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&account_path).unwrap()).unwrap();
+        let disk_has_limit = persisted["live_limited_models"]
+            .as_object()
+            .unwrap()
+            .contains_key("gemini-3-pro-image");
+        assert_eq!(
+            disk_has_limit,
+            manager
+                .rate_limit_tracker
+                .is_rate_limited(account_id, Some("gemini-3-pro-image"))
+        );
 
         let _ = std::fs::remove_dir_all(&tmp_root);
     }

--- a/src-tauri/src/proxy/upstream/retry.rs
+++ b/src-tauri/src/proxy/upstream/retry.rs
@@ -4,9 +4,24 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-static DURATION_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"([\d.]+)\s*(ms|s|m|h)").unwrap());
+static DURATION_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)([\d.]+)\s*(milliseconds?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h)")
+        .unwrap()
+});
 
-static RE_QUOTA_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+static RE_TEXT_DELAY_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        Regex::new(r"(?i)quota will reset after ([^.,;\]\n]+)").unwrap(),
+        Regex::new(r"(?i)quota will reset in ([^.,;\]\n]+)").unwrap(),
+        Regex::new(r"(?i)retry after ([^.,;\]\n]+)").unwrap(),
+        Regex::new(r"(?i)reset after ([^.,;\]\n]+)").unwrap(),
+        Regex::new(r"(?i)try again in ([^.,;\]\n]+)").unwrap(),
+        Regex::new(r"(?i)backoff for ([^.,;\]\n]+)").unwrap(),
+        Regex::new(r"(?i)(?:^|[\s(])wait\s+([^,;\]\n)]+)").unwrap(),
+    ]
+});
+
+static RE_LEGACY_DELAY_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
     vec![
         Regex::new(r"(?i)quota will reset after ([^.,;\]\n]+)").unwrap(),
         Regex::new(r"(?i)retry after ([^.,;\]\n]+)").unwrap(),
@@ -38,13 +53,19 @@ pub fn parse_duration_ms(duration_str: &str) -> Option<u64> {
     for cap in DURATION_RE.captures_iter(duration_str) {
         matched = true;
         let value: f64 = cap[1].parse().ok()?;
-        let unit = &cap[2];
+        let unit = cap[2].to_ascii_lowercase();
 
-        match unit {
-            "ms" => total_ms += value,
-            "s" => total_ms += value * 1000.0,
-            "m" => total_ms += value * 60.0 * 1000.0,
-            "h" => total_ms += value * 60.0 * 60.0 * 1000.0,
+        match unit.as_str() {
+            unit if unit == "ms" || unit.starts_with("millisecond") => total_ms += value,
+            unit if unit == "s" || unit.starts_with("sec") || unit.starts_with("second") => {
+                total_ms += value * 1000.0
+            }
+            unit if unit == "m" || unit.starts_with("min") || unit.starts_with("minute") => {
+                total_ms += value * 60.0 * 1000.0
+            }
+            unit if unit == "h" || unit.starts_with("hr") || unit.starts_with("hour") => {
+                total_ms += value * 60.0 * 60.0 * 1000.0
+            }
             _ => {}
         }
     }
@@ -56,10 +77,80 @@ pub fn parse_duration_ms(duration_str: &str) -> Option<u64> {
     Some(total_ms.round() as u64)
 }
 
-/// 从 429 错误中提取 retry delay (深度递归解析)
-pub fn parse_retry_delay(error_text: &str) -> Option<u64> {
-    // 1. 尝试正则提取 (针对非 JSON 文本或嵌套不深的文本)
-    for re in RE_QUOTA_PATTERNS.iter() {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryDelaySource {
+    Structured,
+    ResponseText,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParsedRetryDelay {
+    pub raw_ms: u64,
+    pub source: RetryDelaySource,
+}
+
+impl ParsedRetryDelay {
+    pub fn actual_wait_ms(self) -> u64 {
+        let buffer_ms = match self.source {
+            RetryDelaySource::Structured => 200,
+            RetryDelaySource::ResponseText => 1000,
+        };
+        self.raw_ms.saturating_add(buffer_ms)
+    }
+}
+
+/// 从 Retry-After 或 429 错误中提取原始 retry delay (深度递归解析)
+pub fn parse_retry_delay(error_text: &str, retry_after: Option<&str>) -> Option<u64> {
+    parse_retry_delay_with_source(error_text, retry_after).map(|delay| delay.raw_ms)
+}
+
+pub fn parse_retry_delay_with_source(
+    error_text: &str,
+    retry_after: Option<&str>,
+) -> Option<ParsedRetryDelay> {
+    // 1. Retry-After delta-seconds，也兼容已有的 duration 字符串来源
+    if let Some(value) = retry_after.map(str::trim).filter(|value| !value.is_empty()) {
+        if let Ok(seconds) = value.parse::<u64>() {
+            return seconds.checked_mul(1000).map(|raw_ms| ParsedRetryDelay {
+                raw_ms,
+                source: RetryDelaySource::Structured,
+            });
+        }
+        if let Some(delay) = parse_duration_ms(value) {
+            return Some(ParsedRetryDelay {
+                raw_ms: delay,
+                source: RetryDelaySource::Structured,
+            });
+        }
+    }
+
+    // 2. 结构化 JSON 字段优先，避免把 JSON 中的 retryDelay 当作响应文字。
+    if let Ok(json) = serde_json::from_str(error_text) {
+        if let Some(raw_ms) = extract_structured_delay_recursive(&json, 0, false) {
+            return Some(ParsedRetryDelay {
+                raw_ms,
+                source: RetryDelaySource::Structured,
+            });
+        }
+    }
+
+    // 3. 仅从响应文字中提取自然语言时长。
+    for re in RE_TEXT_DELAY_PATTERNS.iter() {
+        if let Some(cap) = re.captures(error_text) {
+            if let Some(delay) = parse_duration_ms(&cap[1]) {
+                return Some(ParsedRetryDelay {
+                    raw_ms: delay,
+                    source: RetryDelaySource::ResponseText,
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Preserve the pre-state-machine delay parsing used by the Claude handler.
+pub(crate) fn parse_legacy_retry_delay(error_text: &str) -> Option<u64> {
+    for re in RE_LEGACY_DELAY_PATTERNS.iter() {
         if let Some(cap) = re.captures(error_text) {
             if let Some(delay) = parse_duration_ms(&cap[1]) {
                 return Some(delay);
@@ -67,20 +158,21 @@ pub fn parse_retry_delay(error_text: &str) -> Option<u64> {
         }
     }
 
-    // 2. 尝试结构化 JSON 解析 (递归扫描)
     let delay = if let Ok(json) = serde_json::from_str(error_text) {
-        extract_structured_delay_recursive(&json, 0)
+        extract_structured_delay_recursive(&json, 0, true)
     } else {
         None
     };
 
-    // [NEW] 引入 1500ms 官方 "Grace Window" 缓冲区
-    // 官方实现会在解析出的延迟基础上强制多等 1.5s，以确保 100% 越过 Google 配额重置点。
-    delay.map(|d| d + 1500)
+    delay.map(|delay_ms| delay_ms.saturating_add(1500))
 }
 
 /// 递归提取结构化延迟
-fn extract_structured_delay_recursive(value: &serde_json::Value, depth: usize) -> Option<u64> {
+fn extract_structured_delay_recursive(
+    value: &serde_json::Value,
+    depth: usize,
+    parse_unkeyed_strings: bool,
+) -> Option<u64> {
     if depth > 8 {
         return None;
     }
@@ -103,21 +195,24 @@ fn extract_structured_delay_recursive(value: &serde_json::Value, depth: usize) -
                     }
                 }
                 // 继续深度搜索
-                if let Some(d) = extract_structured_delay_recursive(val, depth + 1) {
+                if let Some(d) =
+                    extract_structured_delay_recursive(val, depth + 1, parse_unkeyed_strings)
+                {
                     return Some(d);
                 }
             }
         }
         serde_json::Value::Array(arr) => {
             for val in arr {
-                if let Some(d) = extract_structured_delay_recursive(val, depth + 1) {
+                if let Some(d) =
+                    extract_structured_delay_recursive(val, depth + 1, parse_unkeyed_strings)
+                {
                     return Some(d);
                 }
             }
         }
-        serde_json::Value::String(s) => {
-            return parse_duration_ms(s);
-        }
+        serde_json::Value::String(s) if parse_unkeyed_strings => return parse_duration_ms(s),
+        serde_json::Value::String(_) => {}
         _ => {}
     }
     None
@@ -155,10 +250,9 @@ fn parse_structured_duration_value(value: &serde_json::Value) -> Option<u64> {
 }
 
 /// [NEW] 判断是否应当执行 Grace Retry (原地重试)
-/// 当 429 报错提示的重置时间在接受范围内（如 2s 内），则原地重试比切换账号更有利。
+/// 当 429 报错提示的重置时间在 5s 内，则原地重试比切换账号更有利。
 pub fn should_grace_retry(duration_ms: u64) -> bool {
-    // 默认阈值：2000ms
-    duration_ms > 0 && duration_ms <= 2000
+    duration_ms > 0 && duration_ms <= 5000
 }
 
 #[cfg(test)]
@@ -170,20 +264,51 @@ mod tests {
         assert_eq!(parse_duration_ms("1.5s"), Some(1500));
         assert_eq!(parse_duration_ms("200ms"), Some(200));
         assert_eq!(parse_duration_ms("1h16m0.667s"), Some(4560667));
+        assert_eq!(parse_duration_ms("58h24m53s"), Some(210_293_000));
+        assert_eq!(parse_duration_ms("72h"), Some(259_200_000));
         assert_eq!(parse_duration_ms("invalid"), None);
     }
 
     #[test]
-    fn test_parse_retry_delay() {
-        let error_json = r#"{
+    fn task_parses_google_retry_info_and_retry_after() {
+        let retry_info_1s = r#"{
             "error": {
                 "details": [{
                     "@type": "type.googleapis.com/google.rpc.RetryInfo",
-                    "retryDelay": "1.203608125s"
+                    "retryDelay": "1s"
+                }]
+            }
+        }"#;
+        let retry_info_3s = r#"{
+            "error": {
+                "details": [{
+                    "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                    "retryDelay": "3s"
                 }]
             }
         }"#;
 
-        assert_eq!(parse_retry_delay(error_json), Some(2704)); // 1204 + 1500ms grace window
+        let structured_1s = parse_retry_delay_with_source(retry_info_1s, None).unwrap();
+        assert_eq!(structured_1s.raw_ms, 1000);
+        assert_eq!(structured_1s.source, RetryDelaySource::Structured);
+        assert_eq!(structured_1s.actual_wait_ms(), 1200);
+
+        let structured_3s = parse_retry_delay_with_source(retry_info_3s, None).unwrap();
+        assert_eq!(structured_3s.actual_wait_ms(), 3200);
+
+        let quota_reset = parse_retry_delay_with_source(
+            r#"{"error":{"details":[{"metadata":{"quotaResetDelay":"5s"}}]}}"#,
+            None,
+        )
+        .unwrap();
+        assert_eq!(quota_reset.actual_wait_ms(), 5200);
+        assert!(should_grace_retry(quota_reset.raw_ms));
+
+        let retry_after = parse_retry_delay_with_source("", Some("3")).unwrap();
+        assert_eq!(retry_after.actual_wait_ms(), 3200);
+
+        let response_text = parse_retry_delay_with_source("quota reset after 3s", None).unwrap();
+        assert_eq!(response_text.source, RetryDelaySource::ResponseText);
+        assert_eq!(response_text.actual_wait_ms(), 4000);
     }
 }


### PR DESCRIPTION
## Summary

Parse short 429 delays without inflating the grace-retry decision, retry the same account at most once, and preserve only explicit long-lived image quota deadlines.

Closes #3351.
Closes #3353.

Depends on #3362. This is a stacked PR; the new behavior is contained in commit `38a276bf` and the diff will narrow after #3362 merges.

## Changes

- Parse structured Google retry delays and `Retry-After` separately from source-specific wait buffers.
- Track one same-account grace retry per account without consuming account-rotation budget.
- Pass retry state through OpenAI Chat, Responses, Gemini, and Images handlers.
- Preserve long deadlines only for explicit structured `QUOTA_EXHAUSTED` responses on recognized image models.
- Persist and restore qualified image lockouts across quota refresh, account reload, and restart.
- Retain qualified locks through optimistic reset and clear only the matching normalized model bucket.
- Serialize account-file updates so concurrent limit and account-state writes do not discard one another.
- Avoid blocking the async runtime while reselecting after a short lock expires.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --offline --lib task_`
- Result: 11 passed, 0 failed.
- Coverage includes structured 1s/3s parsing, same-account rotation state, explicit 58-hour/72-hour image locks, refresh/reload/restart retention, exact-bucket clearing, and nonblocking short-lock reselection.

## Compatibility

- Generic prose, inferred reset times, and text-model limits remain capped at 300 seconds.
- Existing account JSON remains compatible.
- OpenAI Chat, Responses, Gemini, and Images use the new request retry state.
- Claude retains its baseline retry wrapper and parser behavior; same-account grace-retry parity is not claimed.
- No image scheduler or per-account concurrency behavior is included in this PR.
