### PR TITLE
fix(responses): correct session identity and branching

### DIFF
--- a/src-tauri/src/proxy/adapters/apply_patch_preflight.rs
+++ b/src-tauri/src/proxy/adapters/apply_patch_preflight.rs
@@ -242,6 +242,14 @@ pub fn remember_cwd_from_request(request: Option<&Value>) {
     }
 }
 
+pub fn remember_cwd_from_text(text: &str) -> bool {
+    let Some(cwd) = extract_cwd_from_str(text) else {
+        return false;
+    };
+    remember_cwd(&cwd);
+    true
+}
+
 /// apply_patch **中间层总入口**:按白名单规则**逐条恢复已知格式错误**,使模型不遵循 prompt 时
 /// 产出的畸形 patch 仍能被 Codex 正确 apply。**只动确定的已知坑;未知一律原样放行(不猜不丢)。**
 ///

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -17,6 +17,9 @@ use crate::proxy::server::AppState;
 use crate::proxy::upstream::client::mask_email;
 
 const MAX_RETRY_ATTEMPTS: usize = 3;
+const MAX_INPUT_IMAGES: usize = 16;
+const MAX_INPUT_IMAGE_BYTES: usize = 20 * 1024 * 1024;
+const MAX_TOTAL_INPUT_IMAGE_BYTES: usize = 32 * 1024 * 1024;
 const CODEX_VISIBLE_THOUGHT_MESSAGE_PREFIX: &str = "msg_thought_";
 use super::common::{
     apply_retry_strategy, determine_retry_strategy, should_rotate_account, RetryStrategy,
@@ -27,6 +30,226 @@ use crate::proxy::session_manager::SessionManager;
 use axum::http::HeaderMap;
 use std::collections::VecDeque;
 use tokio::time::Duration;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct NormalizedInputImage {
+    mime_type: String,
+    base64_data: String,
+    decoded_len: usize,
+}
+
+fn validate_input_image_limits(
+    image_count: usize,
+    image_bytes: usize,
+    total_bytes: usize,
+) -> Result<(), String> {
+    if image_count > MAX_INPUT_IMAGES {
+        return Err(format!(
+            "Too many input images: maximum is {}",
+            MAX_INPUT_IMAGES
+        ));
+    }
+    if image_bytes > MAX_INPUT_IMAGE_BYTES {
+        return Err(format!(
+            "Input image is too large: maximum decoded size is {} bytes",
+            MAX_INPUT_IMAGE_BYTES
+        ));
+    }
+    if total_bytes > MAX_TOTAL_INPUT_IMAGE_BYTES {
+        return Err(format!(
+            "Total input image data is too large: maximum decoded size is {} bytes",
+            MAX_TOTAL_INPUT_IMAGE_BYTES
+        ));
+    }
+    Ok(())
+}
+
+fn normalized_image_from_bytes(
+    bytes: &[u8],
+    mime_type: &str,
+    image_count: usize,
+    total_bytes: usize,
+) -> Result<NormalizedInputImage, String> {
+    let next_total = total_bytes.saturating_add(bytes.len());
+    validate_input_image_limits(image_count, bytes.len(), next_total)?;
+    Ok(NormalizedInputImage {
+        mime_type: mime_type.to_string(),
+        base64_data: base64::engine::general_purpose::STANDARD.encode(bytes),
+        decoded_len: bytes.len(),
+    })
+}
+
+fn parse_image_data_url(
+    data_url: &str,
+    image_count: usize,
+    total_bytes: usize,
+) -> Result<NormalizedInputImage, String> {
+    let (metadata, encoded) = data_url
+        .strip_prefix("data:")
+        .and_then(|value| value.split_once(','))
+        .ok_or_else(|| "Input image must be a base64 data:image URL".to_string())?;
+    let mut metadata_parts = metadata.split(';');
+    let mime_type = metadata_parts.next().unwrap_or_default();
+    if !mime_type.starts_with("image/") || mime_type.len() <= "image/".len() {
+        return Err("Input image data URL must use an image MIME type".to_string());
+    }
+    if !metadata_parts.any(|part| part.eq_ignore_ascii_case("base64")) {
+        return Err("Input image data URL must be base64 encoded".to_string());
+    }
+    if encoded.is_empty() {
+        return Err("Input image data URL is empty".to_string());
+    }
+
+    let max_encoded_len = MAX_INPUT_IMAGE_BYTES.div_ceil(3).saturating_mul(4);
+    if encoded.len() > max_encoded_len {
+        return Err(format!(
+            "Input image is too large: maximum decoded size is {} bytes",
+            MAX_INPUT_IMAGE_BYTES
+        ));
+    }
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|_| "Input image contains invalid base64 data".to_string())?;
+    normalized_image_from_bytes(&decoded, mime_type, image_count, total_bytes)
+}
+
+fn parse_generation_input_images(image: Option<&Value>) -> Result<Vec<NormalizedInputImage>, String> {
+    let Some(image) = image else {
+        return Ok(Vec::new());
+    };
+
+    let urls: Vec<&str> = match image {
+        Value::String(url) => vec![url.as_str()],
+        Value::Array(urls) if urls.is_empty() => {
+            return Err("Input image array must not be empty".to_string())
+        }
+        Value::Array(urls) => urls
+            .iter()
+            .map(|url| {
+                url.as_str()
+                    .ok_or_else(|| "Every input image must be a base64 data:image URL".to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        _ => return Err("Input image must be a string or an array of strings".to_string()),
+    };
+
+    validate_input_image_limits(urls.len(), 0, 0)?;
+    let mut images = Vec::with_capacity(urls.len());
+    let mut total_bytes = 0;
+    for url in urls {
+        let image = parse_image_data_url(url, images.len() + 1, total_bytes)?;
+        total_bytes = total_bytes.saturating_add(image.decoded_len);
+        images.push(image);
+    }
+    Ok(images)
+}
+
+fn generation_image_size_param(body: &Value) -> Result<Option<&str>, String> {
+    for key in ["image_size", "imageSize"] {
+        let Some(value) = body.get(key) else {
+            continue;
+        };
+        if value.is_null() {
+            continue;
+        }
+        return value.as_str().map(Some).ok_or_else(|| {
+            "Invalid image_size: expected one of 1K, 2K, 4K, or auto".to_string()
+        });
+    }
+    Ok(None)
+}
+
+fn is_edit_image_field(name: &str) -> bool {
+    name == "image"
+        || name == "image[]"
+        || name
+            .strip_prefix("image")
+            .is_some_and(|suffix| !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+fn edit_size_input<'a>(aspect_ratio: Option<&'a str>, size: Option<&'a str>) -> Option<&'a str> {
+    aspect_ratio
+        .filter(|value| {
+            crate::proxy::mappers::common_utils::image_aspect_ratio_from_size(value).is_some()
+        })
+        .or_else(|| {
+            size.filter(|value| {
+                crate::proxy::mappers::common_utils::image_aspect_ratio_from_size(value).is_some()
+            })
+        })
+}
+
+fn image_account_selection_target(model_to_use: &str) -> &str {
+    model_to_use
+}
+
+fn image_inline_part(image: &NormalizedInputImage) -> Value {
+    json!({
+        "inlineData": {
+            "mimeType": image.mime_type,
+            "data": image.base64_data
+        }
+    })
+}
+
+fn build_image_contents(
+    prompt: String,
+    input_images: &[NormalizedInputImage],
+    mask: Option<&NormalizedInputImage>,
+) -> Vec<Value> {
+    let mut parts = Vec::with_capacity(1 + input_images.len() + usize::from(mask.is_some()));
+    parts.push(json!({ "text": prompt }));
+    for (index, image) in input_images.iter().enumerate() {
+        parts.push(image_inline_part(image));
+        if index == 0 {
+            if let Some(mask) = mask {
+                parts.push(image_inline_part(mask));
+            }
+        }
+    }
+    if input_images.is_empty() {
+        if let Some(mask) = mask {
+            parts.push(image_inline_part(mask));
+        }
+    }
+    parts
+}
+
+fn build_image_edit_body(
+    project_id: String,
+    resolved_model: &str,
+    contents_parts: Vec<Value>,
+    image_config: Value,
+) -> Value {
+    json!({
+        "project": project_id,
+        "requestId": format!("img-edit-{}", uuid::Uuid::new_v4()),
+        "model": resolved_model,
+        "userAgent": "antigravity",
+        "requestType": "image_gen",
+        "request": {
+            "contents": [{
+                "role": "user",
+                "parts": contents_parts
+            }],
+            "generationConfig": {
+                "candidateCount": 1,
+                "imageConfig": image_config,
+                "maxOutputTokens": 8192,
+                "stopSequences": [],
+                "temperature": 1.0,
+                "topP": 0.95,
+                "topK": 40
+            },
+            "safetySettings": [
+                { "category": "HARM_CATEGORY_HARASSMENT", "threshold": "OFF" },
+                { "category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "OFF" },
+                { "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "OFF" },
+                { "category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "OFF" },
+            ]
+        }
+    })
+}
 
 /// Return true only when a streamed chunk contains an actual error event.
 ///
@@ -301,15 +524,24 @@ fn is_codex_transcript_only_assistant_message(item: &Value, text: &str) -> bool 
 
 #[cfg(test)]
 mod stream_peek_tests {
+    use super::build_image_contents;
+    use super::build_image_edit_body;
     use super::convert_chat_response_to_responses;
     use super::convert_codex_to_openai_request;
     use super::drop_leading_orphan_tool_history;
+    use super::edit_size_input;
+    use super::generation_image_size_param;
+    use super::image_account_selection_target;
     use super::is_codex_transcript_only_assistant_message;
+    use super::is_edit_image_field;
+    use super::parse_generation_input_images;
     use super::responses_input_item_type;
     use super::responses_message_parts;
     use super::rewrite_terminal_assistant_prefill;
     use super::stream_chunk_has_error_event;
-    use serde_json::json;
+    use super::validate_input_image_limits;
+    use super::{MAX_INPUT_IMAGES, MAX_INPUT_IMAGE_BYTES, MAX_TOTAL_INPUT_IMAGE_BYTES};
+    use serde_json::{json, Value};
 
     #[test]
     fn responses_created_with_null_error_is_not_an_error_event() {
@@ -589,6 +821,142 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
             &clean_final,
             "done"
         ));
+    }
+
+    #[test]
+    fn generation_image_extension_adds_single_and_array_images_in_order() {
+        let single = json!("data:image/png;base64,AQ==");
+        let single_images = parse_generation_input_images(Some(&single)).expect("single data URL");
+        let single_parts = build_image_contents("prompt".to_string(), &single_images, None);
+        assert_eq!(single_parts.len(), 2);
+        assert_eq!(single_parts[1]["inlineData"]["data"], "AQ==");
+
+        let multiple = json!([
+            "data:image/png;base64,AQ==",
+            "data:image/jpeg;base64,Ag=="
+        ]);
+        let multiple_images =
+            parse_generation_input_images(Some(&multiple)).expect("ordered data URL array");
+        let multiple_parts = build_image_contents("prompt".to_string(), &multiple_images, None);
+        assert_eq!(multiple_parts.len(), 3);
+        assert_eq!(multiple_parts[1]["inlineData"]["data"], "AQ==");
+        assert_eq!(multiple_parts[2]["inlineData"]["data"], "Ag==");
+    }
+
+    #[test]
+    fn generation_without_image_remains_text_only() {
+        let images = parse_generation_input_images(None).expect("absent image is standard text-to-image");
+        let parts = build_image_contents("prompt".to_string(), &images, None);
+        assert_eq!(parts, vec![json!({"text": "prompt"})]);
+    }
+
+    #[test]
+    fn generation_image_extension_rejects_invalid_or_remote_inputs() {
+        let invalid_inputs = [
+            json!("https://example.invalid/image.png"),
+            json!("data:text/plain;base64,AQ=="),
+            json!("data:image/png;base64,not-base64"),
+            json!([]),
+            json!(["data:image/png;base64,AQ==", 2]),
+        ];
+        for input in invalid_inputs {
+            assert!(parse_generation_input_images(Some(&input)).is_err());
+        }
+
+        let too_many = Value::Array(
+            (0..=MAX_INPUT_IMAGES)
+                .map(|_| json!("data:image/png;base64,AQ=="))
+                .collect(),
+        );
+        assert!(parse_generation_input_images(Some(&too_many)).is_err());
+        assert!(validate_input_image_limits(1, MAX_INPUT_IMAGE_BYTES + 1, 0).is_err());
+        assert!(
+            validate_input_image_limits(1, 1, MAX_TOTAL_INPUT_IMAGE_BYTES + 1).is_err()
+        );
+
+        assert!(generation_image_size_param(&json!({"imageSize": 4})).is_err());
+    }
+
+    #[test]
+    fn edit_image_fields_preserve_all_supported_forms_in_arrival_order() {
+        let field_names = [
+            "image",
+            "image",
+            "image[]",
+            "image[]",
+            "image1",
+            "image2",
+            "imageSize",
+            "image_size",
+            "imageReference",
+        ];
+        let accepted: Vec<(usize, &str)> = field_names
+            .iter()
+            .enumerate()
+            .filter(|(_, name)| is_edit_image_field(name))
+            .map(|(index, name)| (index, *name))
+            .collect();
+        assert_eq!(
+            accepted,
+            vec![
+                (0, "image"),
+                (1, "image"),
+                (2, "image[]"),
+                (3, "image[]"),
+                (4, "image1"),
+                (5, "image2"),
+            ]
+        );
+    }
+
+    #[test]
+    fn edit_aspect_ratio_priority_preserves_suffix_without_explicit_size() {
+        use crate::proxy::mappers::common_utils::try_parse_image_config_with_params;
+
+        let suffix_input = edit_size_input(None, None);
+        let (suffix_config, _) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image-16x9",
+            suffix_input,
+            None,
+            None,
+        )
+        .expect("model suffix config");
+        assert_eq!(suffix_config["aspectRatio"], "16:9");
+
+        let explicit_input = edit_size_input(Some("4:3"), Some("1280x720"));
+        let (explicit_config, _) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image-16x9",
+            explicit_input,
+            None,
+            None,
+        )
+        .expect("explicit aspect ratio config");
+        assert_eq!(explicit_config["aspectRatio"], "4:3");
+    }
+
+    #[test]
+    fn edit_flash_model_is_used_for_account_selection_and_resolved_upstream_body() {
+        use crate::proxy::mappers::common_utils::try_parse_image_config_with_params;
+
+        let (image_config, model_to_use) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image",
+            None,
+            None,
+            None,
+        )
+        .expect("flash edit model config");
+        assert_eq!(
+            image_account_selection_target(&model_to_use),
+            "gemini-3.1-flash-image"
+        );
+
+        let body = build_image_edit_body(
+            "project".to_string(),
+            "account-resolved-image-model",
+            json!([{"text": "prompt"}]).as_array().cloned().expect("parts"),
+            image_config,
+        );
+        assert_eq!(body["model"], "account-resolved-image-model");
     }
 }
 
@@ -3430,31 +3798,36 @@ pub async fn handle_images_generations_internal(
 
     let quality = body.get("quality").and_then(|v| v.as_str());
 
-    let image_size = body
-        .get("image_size")
-        .or(body.get("imageSize"))
-        .and_then(|v| v.as_str());
+    let image_size = generation_image_size_param(&body)
+        .map_err(|message| (StatusCode::BAD_REQUEST, message, None))?;
 
     let style = body
         .get("style")
         .and_then(|v| v.as_str())
         .unwrap_or("vivid");
 
+    // Canvas compatibility extension: OpenAI's standard generations endpoint does not define
+    // this top-level field. Accept only inline data:image URLs and never fetch remote URLs.
+    let input_images = parse_generation_input_images(body.get("image")).map_err(|message| {
+        (StatusCode::BAD_REQUEST, message, None)
+    })?;
+
     info!(
-        "[Images] Received request: model={}, prompt={:.50}..., n={}, size={}, quality={}, style={}",
-        model,
-        prompt,
-        n,
-        size.unwrap_or("auto"),
-        quality.unwrap_or("auto"),
-        style
+        model = model,
+        image_count = input_images.len(),
+        n = n,
+        size = size.unwrap_or("auto"),
+        quality = quality.unwrap_or("auto"),
+        style = style,
+        "[Images] Received generation request"
     );
 
     // 2. 使用 common_utils 解析图片配置（统一逻辑，支持动态计算宽高比和 quality 映射）
     let (image_config, clean_model_name) =
-        crate::proxy::mappers::common_utils::parse_image_config_with_params(
+        crate::proxy::mappers::common_utils::try_parse_image_config_with_params(
             model, size, quality, image_size,
-        );
+        )
+        .map_err(|message| (StatusCode::BAD_REQUEST, message, None))?;
 
     // 3. Prompt Enhancement（保留原有逻辑）
     let mut final_prompt = prompt.to_string();
@@ -3466,6 +3839,7 @@ pub async fn handle_images_generations_internal(
         "natural" => final_prompt.push_str(", (natural lighting, realistic, photorealistic)"),
         _ => {}
     }
+    let contents_parts = build_image_contents(final_prompt, &input_images, None);
 
     // 4. 并发发送请求
     // 注意：不再在外部获取 Token，而是移入 Task 内部并在重试时获取
@@ -3485,7 +3859,7 @@ pub async fn handle_images_generations_internal(
     for _ in 0..n {
         let upstream = upstream.clone();
         let token_manager = token_manager.clone();
-        let final_prompt = final_prompt.clone();
+        let contents_parts = contents_parts.clone();
         let image_config = image_config.clone(); // 使用解析后的完整配置
         let _response_format = response_format.to_string();
 
@@ -3532,7 +3906,7 @@ pub async fn handle_images_generations_internal(
                     "request": {
                         "contents": [{
                             "role": "user",
-                            "parts": [{"text": final_prompt}]
+                            "parts": contents_parts
                         }],
                         "generationConfig": {
                             "candidateCount": 1, // 强制单张
@@ -3742,16 +4116,17 @@ pub async fn handle_images_edits(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     tracing::info!("[Images] Received edit request");
 
-    let mut image_data: Option<(String, String)> = None;
-    let mut mask_data: Option<(String, String)> = None;
-    let mut reference_images: Vec<(String, String)> = Vec::new(); // Store (base64 data, mime type) reference images
+    let mut input_images: Vec<NormalizedInputImage> = Vec::new();
+    let mut mask_data: Option<NormalizedInputImage> = None;
+    let mut total_input_image_bytes = 0;
     let mut prompt = String::new();
     let mut n = 1;
-    let mut size = "1024x1024".to_string();
+    let mut size: Option<String> = None;
     let mut response_format = "b64_json".to_string();
     let mut model = "gemini-3.1-flash-image".to_string();
     let mut aspect_ratio: Option<String> = None;
     let mut image_size_param: Option<String> = None;
+    let mut quality: Option<String> = None;
     let mut style: Option<String> = None;
 
     while let Some(field) = multipart
@@ -3761,7 +4136,7 @@ pub async fn handle_images_edits(
     {
         let name = field.name().unwrap_or("").to_string();
 
-        if name == "image" {
+        if is_edit_image_field(&name) {
             let mime_type = field
                 .content_type()
                 .map(|content_type| content_type.to_string())
@@ -3770,10 +4145,15 @@ pub async fn handle_images_edits(
                 .bytes()
                 .await
                 .map_err(|e| (StatusCode::BAD_REQUEST, format!("Image read error: {}", e)))?;
-            image_data = Some((
-                base64::engine::general_purpose::STANDARD.encode(data),
-                mime_type,
-            ));
+            let image = normalized_image_from_bytes(
+                &data,
+                &mime_type,
+                input_images.len() + 1,
+                total_input_image_bytes,
+            )
+            .map_err(|message| (StatusCode::BAD_REQUEST, message))?;
+            total_input_image_bytes = total_input_image_bytes.saturating_add(image.decoded_len);
+            input_images.push(image);
         } else if name == "mask" {
             let mime_type = field
                 .content_type()
@@ -3783,26 +4163,15 @@ pub async fn handle_images_edits(
                 .bytes()
                 .await
                 .map_err(|e| (StatusCode::BAD_REQUEST, format!("Mask read error: {}", e)))?;
-            mask_data = Some((
-                base64::engine::general_purpose::STANDARD.encode(data),
-                mime_type,
-            ));
-        } else if name.starts_with("image") && name != "image_size" {
-            // Support image1, image2, etc.
-            let mime_type = field
-                .content_type()
-                .map(|content_type| content_type.to_string())
-                .unwrap_or_else(|| "image/jpeg".to_string());
-            let data = field.bytes().await.map_err(|e| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("Reference image read error: {}", e),
-                )
-            })?;
-            reference_images.push((
-                base64::engine::general_purpose::STANDARD.encode(data),
-                mime_type,
-            ));
+            let mask = normalized_image_from_bytes(
+                &data,
+                &mime_type,
+                input_images.len(),
+                total_input_image_bytes,
+            )
+            .map_err(|message| (StatusCode::BAD_REQUEST, message))?;
+            total_input_image_bytes = total_input_image_bytes.saturating_add(mask.decoded_len);
+            mask_data = Some(mask);
         } else if name == "prompt" {
             prompt = field
                 .text()
@@ -3813,12 +4182,18 @@ pub async fn handle_images_edits(
                 n = val.parse().unwrap_or(1);
             }
         } else if name == "size" {
-            if let Ok(val) = field.text().await {
-                size = val;
-            }
-        } else if name == "image_size" {
+            let val = field
+                .text()
+                .await
+                .map_err(|e| (StatusCode::BAD_REQUEST, format!("Size read error: {}", e)))?;
+            size = Some(val);
+        } else if name == "image_size" || name == "imageSize" {
             if let Ok(val) = field.text().await {
                 image_size_param = Some(val);
+            }
+        } else if name == "quality" {
+            if let Ok(val) = field.text().await {
+                quality = Some(val);
             }
         } else if name == "aspect_ratio" {
             if let Ok(val) = field.text().await {
@@ -3848,16 +4223,16 @@ pub async fn handle_images_edits(
     }
 
     tracing::info!(
-        "[Images] Edit/Ref Request: model={}, prompt={}, n={}, size={}, aspect_ratio={:?}, image_size={:?}, style={:?}, refs={}, has_main_image={}",
-        model,
-        prompt,
-        n,
-        size,
-        aspect_ratio,
-        image_size_param,
-        style,
-        reference_images.len(),
-        image_data.is_some()
+        model = model,
+        n = n,
+        size = size.as_deref().unwrap_or("auto"),
+        aspect_ratio = aspect_ratio.as_deref().unwrap_or("auto"),
+        image_size = image_size_param.as_deref().unwrap_or("auto"),
+        quality = quality.as_deref().unwrap_or("auto"),
+        style = style.as_deref().unwrap_or("auto"),
+        image_count = input_images.len(),
+        has_mask = mask_data.is_some(),
+        "[Images] Received edit request metadata"
     );
 
     // 2. Prepare Config (Aspect Ratio / Size)
@@ -3865,65 +4240,23 @@ pub async fn handle_images_edits(
     // Priority: image_size param > quality param (derived from model suffix or default)
 
     // We reuse parse_image_config_with_params but need to adapt the inputs
-    let size_input = aspect_ratio.as_deref().or(Some(&size)); // If aspect_ratio is "16:9", it works. If it's just "1:1", it also works.
-
-    // Map 'image_size' (2K) to 'quality' semantics if needed, or pass directly if logic supports
-    // common_utils logic: 'hd' -> 4K, 'medium' -> 2K.
-    let quality_input = match image_size_param.as_deref() {
-        Some("4K") => Some("hd"),
-        Some("2K") => Some("medium"),
-        _ => None, // Fallback to standard
-    };
+    let size_input = edit_size_input(aspect_ratio.as_deref(), size.as_deref());
 
     let (image_config, clean_model_name) =
-        crate::proxy::mappers::common_utils::parse_image_config_with_params(
+        crate::proxy::mappers::common_utils::try_parse_image_config_with_params(
             &model,
             size_input,
-            quality_input,
-            image_size_param.as_deref(), // [NEW] Pass direct image_size param
-        );
+            quality.as_deref(),
+            image_size_param.as_deref(),
+        )
+        .map_err(|message| (StatusCode::BAD_REQUEST, message))?;
 
     // 3. Construct Contents
-    let mut contents_parts = Vec::new();
-
-    // Add Prompt
     let mut final_prompt = prompt.clone();
     if let Some(s) = style {
         final_prompt.push_str(&format!(", style: {}", s));
     }
-    contents_parts.push(json!({
-        "text": final_prompt
-    }));
-
-    // Add Main Image (if standard edit)
-    if let Some((data, mime_type)) = image_data {
-        contents_parts.push(json!({
-            "inlineData": {
-                "mimeType": mime_type,
-                "data": data
-            }
-        }));
-    }
-
-    // Add Mask (if standard edit)
-    if let Some((data, mime_type)) = mask_data {
-        contents_parts.push(json!({
-            "inlineData": {
-                "mimeType": mime_type,
-                "data": data
-            }
-        }));
-    }
-
-    // Add Reference Images (Image-to-Image)
-    for (ref_data, mime_type) in reference_images {
-        contents_parts.push(json!({
-            "inlineData": {
-                "mimeType": mime_type,
-                "data": ref_data
-            }
-        }));
-    }
+    let contents_parts = build_image_contents(final_prompt, &input_images, mask_data.as_ref());
 
     // 4. 并发发送请求
     // 注意：不再在外部获取 Token，而是移入 Task 内部
@@ -3951,7 +4284,12 @@ pub async fn handle_images_edits(
             for attempt in 0..max_attempts {
                 // 4.1 获取 Token
                 let (access_token, project_id, email, account_id, _wait_ms) = match token_manager
-                    .get_token("image_gen", force_rotate, None, "gemini-3-pro-image")
+                    .get_token(
+                        "image_gen",
+                        force_rotate,
+                        None,
+                        image_account_selection_target(&model_to_use),
+                    )
                     .await
                 {
                     Ok(t) => t,
@@ -3965,35 +4303,17 @@ pub async fn handle_images_edits(
                     }
                 };
 
-                // 4.2 Construct Request Body (Need project_id)
-                let gemini_body = json!({
-                    "project": project_id,
-                    "requestId": format!("img-edit-{}", uuid::Uuid::new_v4()),
-                    "model": model_to_use,
-                    "userAgent": "antigravity",
-                    "requestType": "image_gen",
-                    "request": {
-                        "contents": [{
-                            "role": "user",
-                            "parts": contents_parts
-                        }],
-                        "generationConfig": {
-                            "candidateCount": 1,
-                            "imageConfig": image_config,
-                            "maxOutputTokens": 8192,
-                            "stopSequences": [],
-                            "temperature": 1.0,
-                            "topP": 0.95,
-                            "topK": 40
-                        },
-                        "safetySettings": [
-                            { "category": "HARM_CATEGORY_HARASSMENT", "threshold": "OFF" },
-                            { "category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "OFF" },
-                            { "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "OFF" },
-                            { "category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "OFF" },
-                        ]
-                    }
-                });
+                let resolved_model = token_manager
+                    .resolve_dynamic_model_for_account(&account_id, &model_to_use)
+                    .await;
+
+                // 4.2 Construct Request Body (Need project_id and account-resolved model)
+                let gemini_body = build_image_edit_body(
+                    project_id,
+                    &resolved_model,
+                    contents_parts.clone(),
+                    image_config.clone(),
+                );
 
                 match upstream
                     .call_v1_internal(

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -1082,9 +1082,7 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
     fn responses_omits_old_images_before_validating_current_turn() {
         let images = |count| {
             (0..count)
-                .map(|_| {
-                    json!({"type": "input_image", "image_url": "data:image/png;base64,AQ=="})
-                })
+                .map(|_| json!({"type": "input_image", "image_url": "data:image/png;base64,AQ=="}))
                 .collect::<Vec<_>>()
         };
         let mut input = vec![
@@ -2585,15 +2583,6 @@ pub async fn handle_completions(
         debug_logger::is_enabled(&debug_cfg).then(|| debug_value_without_inline_data(&body));
     let is_codex_style = body.get("input").is_some() || body.get("instructions").is_some();
 
-    if is_codex_style {
-        if let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) {
-            omit_media_before_latest_user_turn(input);
-        }
-        if let Err(message) = validate_responses_input_image_limits(body.get("input")) {
-            return (StatusCode::BAD_REQUEST, message).into_response();
-        }
-    }
-
     // [MULTI-TURN] 支持 previous_response_id 链式历史恢复
     // 当客户端通过 HTTP POST /v1/responses 传入 previous_response_id 时，
     // 从服务器端 session store 取出上一轮的历史，合并到本轮的 input 中
@@ -2604,40 +2593,61 @@ pub async fn handle_completions(
     let response_id_for_save = format!("resp-{}", uuid::Uuid::new_v4());
     let http_tool_call_cache: std::collections::HashMap<String, serde_json::Value> =
         std::collections::HashMap::new();
-    if let Some(ref prev_id) = previous_response_id {
-        if let Some(session) = crate::proxy::http_session_store::get_session(prev_id).await {
-            // 把历史 input items 合并进来
-            let existing_input = body
-                .as_object_mut()
-                .and_then(|obj| obj.remove("input"))
-                .and_then(|value| match value {
-                    Value::Array(items) => Some(items),
-                    _ => None,
-                })
-                .unwrap_or_default();
-            let merged = crate::proxy::http_session_store::merge_history_with_new_input(
-                session.input_items,
-                &[],
-                existing_input,
-                &http_tool_call_cache,
-            );
-            let merged_len = merged.len();
-            if let Some(obj) = body.as_object_mut() {
-                obj.insert("input".to_string(), Value::Array(merged));
-                // 从历史 session 继承 instructions（如果本轮没带）
-                if !obj.contains_key("instructions") && !session.instructions.is_empty() {
-                    obj.insert("instructions".to_string(), json!(session.instructions));
+    let mut session_parent = None;
+    let mut session_delta_input = Vec::new();
+    if is_codex_style {
+        let mut existing_input = body
+            .as_object_mut()
+            .and_then(|obj| obj.remove("input"))
+            .and_then(|value| match value {
+                Value::Array(items) => Some(items),
+                _ => None,
+            })
+            .unwrap_or_default();
+        // 完整回放先裁掉最新用户轮次之前的内联媒体，再执行硬限制校验。
+        omit_media_before_latest_user_turn(&mut existing_input);
+
+        let merged = if let Some(ref prev_id) = previous_response_id {
+            if let Some((session, parent)) =
+                crate::proxy::http_session_store::get_session_with_parent(prev_id).await
+            {
+                let prepared = crate::proxy::http_session_store::prepare_session_input(
+                    session.input_items,
+                    existing_input,
+                    &http_tool_call_cache,
+                );
+                session_delta_input = prepared.delta;
+                if !prepared.reset_parent {
+                    session_parent = Some(parent);
                 }
-                // 继承 model（如果本轮没带）
-                if !obj.contains_key("model") && !session.model.is_empty() {
-                    obj.insert("model".to_string(), json!(session.model));
+                if let Some(obj) = body.as_object_mut() {
+                    if !obj.contains_key("instructions") && !session.instructions.is_empty() {
+                        obj.insert("instructions".to_string(), json!(session.instructions));
+                    }
+                    if !obj.contains_key("model") && !session.model.is_empty() {
+                        obj.insert("model".to_string(), json!(session.model));
+                    }
                 }
+                tracing::debug!(
+                    "[MultiTurn] Restored session from prev_id={}, {} items in history",
+                    prev_id,
+                    prepared.merged.len()
+                );
+                prepared.merged
+            } else {
+                session_delta_input = existing_input.clone();
+                existing_input
             }
-            tracing::debug!(
-                "[MultiTurn] Restored session from prev_id={}, {} items in history",
-                prev_id,
-                merged_len
-            );
+        } else {
+            session_delta_input = existing_input.clone();
+            existing_input
+        };
+
+        if let Some(obj) = body.as_object_mut() {
+            obj.insert("input".to_string(), Value::Array(merged));
+        }
+        if let Err(message) = validate_responses_input_image_limits(body.get("input")) {
+            return (StatusCode::BAD_REQUEST, message).into_response();
         }
     }
 
@@ -2660,9 +2670,9 @@ pub async fn handle_completions(
             })
             .unwrap_or_default();
         bounded_session_input = Some(
-            input_items
-                .iter()
-                .map(history_without_inline_media)
+            session_delta_input
+                .drain(..)
+                .filter_map(into_history_without_inline_media)
                 .filter(|item| !item.is_null())
                 .collect(),
         );
@@ -3590,14 +3600,19 @@ pub async fn handle_completions(
                 // and we already have logic to convert Chat JSON -> Legacy JSON.
 
                 if client_wants_stream {
+                    let mut session_completion_rx = None;
                     let mut openai_stream = if is_codex_style {
                         use crate::proxy::mappers::openai::streaming::create_codex_sse_stream;
+                        let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+                        session_completion_rx = Some(completion_rx);
                         create_codex_sse_stream(
                             gemini_stream,
                             openai_req.model.clone(),
                             session_id,
                             message_count,
                             assistant_turn_index,
+                            response_id_for_save.clone(),
+                            Some(completion_tx),
                         )
                     } else {
                         use crate::proxy::mappers::openai::streaming::create_legacy_sse_stream;
@@ -3684,22 +3699,30 @@ pub async fn handle_completions(
                         converted_meta,
                     );
 
-                    // [MULTI-TURN][FIX] 保存本次完整 input_items 到 session store
-                    // 使用从 body 中提取的原始 input（含文本/工具调用/工具结果全量历史），
-                    // 而非从 openai_req.messages 重建（会丢失 tool_calls/tool 角色等信息）
-                    {
+                    // 仅当转换器产生 response.completed 时保存本轮增量及必要输出。
+                    if let Some(completion_rx) = session_completion_rx {
+                        let save_parent = session_parent;
                         let save_input = session_save_input;
                         let save_instructions = session_save_instructions;
                         let save_model = openai_req.model.clone();
-                        let entry = crate::proxy::http_session_store::HttpSessionEntry {
-                            input_items: save_input,
-                            instructions: save_instructions,
-                            model: save_model,
-                            last_accessed: std::time::Instant::now(),
-                        };
                         let rid = response_id_for_save.clone();
                         tokio::spawn(async move {
-                            crate::proxy::http_session_store::save_session(rid, entry).await;
+                            if let Ok((outputs, ack_tx)) = completion_rx.await {
+                                let outputs = outputs
+                                    .into_iter()
+                                    .filter_map(into_history_without_inline_media)
+                                    .collect();
+                                crate::proxy::http_session_store::save_session_delta(
+                                    rid,
+                                    save_parent,
+                                    save_input,
+                                    outputs,
+                                    save_instructions,
+                                    save_model,
+                                )
+                                .await;
+                                let _ = ack_tx.send(());
+                            }
                         });
                     }
                     return Response::builder()

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -29,6 +29,8 @@ use crate::proxy::common::client_adapter::CLIENT_ADAPTERS; // [NEW] Adapter Regi
 use crate::proxy::session_manager::SessionManager;
 use axum::http::HeaderMap;
 use std::collections::VecDeque;
+use std::io;
+use tokio::task::JoinSet;
 use tokio::time::Duration;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -84,6 +86,22 @@ fn parse_image_data_url(
     image_count: usize,
     total_bytes: usize,
 ) -> Result<NormalizedInputImage, String> {
+    let (mime_type, encoded) = parse_image_data_url_parts(data_url)?;
+
+    let max_encoded_len = MAX_INPUT_IMAGE_BYTES.div_ceil(3).saturating_mul(4);
+    if encoded.len() > max_encoded_len {
+        return Err(format!(
+            "Input image is too large: maximum decoded size is {} bytes",
+            MAX_INPUT_IMAGE_BYTES
+        ));
+    }
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|_| "Input image contains invalid base64 data".to_string())?;
+    normalized_image_from_bytes(&decoded, mime_type, image_count, total_bytes)
+}
+
+fn parse_image_data_url_parts(data_url: &str) -> Result<(&str, &str), String> {
     let (metadata, encoded) = data_url
         .strip_prefix("data:")
         .and_then(|value| value.split_once(','))
@@ -99,18 +117,7 @@ fn parse_image_data_url(
     if encoded.is_empty() {
         return Err("Input image data URL is empty".to_string());
     }
-
-    let max_encoded_len = MAX_INPUT_IMAGE_BYTES.div_ceil(3).saturating_mul(4);
-    if encoded.len() > max_encoded_len {
-        return Err(format!(
-            "Input image is too large: maximum decoded size is {} bytes",
-            MAX_INPUT_IMAGE_BYTES
-        ));
-    }
-    let decoded = base64::engine::general_purpose::STANDARD
-        .decode(encoded)
-        .map_err(|_| "Input image contains invalid base64 data".to_string())?;
-    normalized_image_from_bytes(&decoded, mime_type, image_count, total_bytes)
+    Ok((mime_type, encoded))
 }
 
 fn parse_generation_input_images(image: Option<&Value>) -> Result<Vec<NormalizedInputImage>, String> {
@@ -279,55 +286,381 @@ fn responses_input_item_type(item: &Value) -> &str {
         .unwrap_or("")
 }
 
-fn responses_message_parts(item: &Value) -> (Vec<String>, Vec<Value>) {
-    let mut text_parts = Vec::new();
-    let mut image_parts = Vec::new();
+fn push_responses_content_part(
+    mut part: Value,
+    text_parts: &mut Vec<String>,
+    media_parts: &mut Vec<Value>,
+) -> Result<(), Value> {
+    let part_type = part
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    if let Some(Value::String(text)) = part.as_object_mut().and_then(|obj| obj.remove("text")) {
+        text_parts.push(text);
+        Ok(())
+    } else if part_type == "input_image" {
+        if let Some(Value::String(image_url)) =
+            part.as_object_mut().and_then(|obj| obj.remove("image_url"))
+        {
+            media_parts.push(json!({
+                "type": "image_url",
+                "image_url": { "url": image_url }
+            }));
+            Ok(())
+        } else {
+            Err(part)
+        }
+    } else if part_type == "image_url" {
+        if let Some(image_url) = part.as_object_mut().and_then(|obj| obj.remove("image_url")) {
+            media_parts.push(json!({
+                "type": "image_url",
+                "image_url": image_url
+            }));
+            Ok(())
+        } else {
+            Err(part)
+        }
+    } else if matches!(part_type.as_str(), "input_audio" | "audio") {
+        if let Some(input_audio) = part
+            .as_object_mut()
+            .and_then(|obj| obj.remove("input_audio"))
+        {
+            media_parts.push(json!({
+                "type": "input_audio",
+                "input_audio": input_audio
+            }));
+            Ok(())
+        } else {
+            Err(part)
+        }
+    } else if part_type == "audio_url" {
+        if let Some(audio_url) = part.as_object_mut().and_then(|obj| obj.remove("audio_url")) {
+            media_parts.push(json!({
+                "type": "audio_url",
+                "audio_url": audio_url
+            }));
+            Ok(())
+        } else {
+            Err(part)
+        }
+    } else {
+        Err(part)
+    }
+}
 
-    match item.get("content") {
-        Some(Value::String(text)) => text_parts.push(text.clone()),
+fn responses_content_parts(content: Option<Value>) -> (Vec<String>, Vec<Value>, Vec<Value>) {
+    let mut text_parts = Vec::new();
+    let mut media_parts = Vec::new();
+    let mut unhandled_parts = Vec::new();
+
+    match content {
+        Some(Value::String(text)) => text_parts.push(text),
         Some(Value::Array(parts)) => {
             for part in parts {
-                if let Some(text) = part.get("text").and_then(Value::as_str) {
-                    text_parts.push(text.to_string());
-                } else if part.get("type").and_then(Value::as_str) == Some("input_image") {
-                    if let Some(image_url) = part.get("image_url").and_then(Value::as_str) {
-                        image_parts.push(json!({
-                            "type": "image_url",
-                            "image_url": { "url": image_url }
-                        }));
-                    }
-                } else if part.get("type").and_then(Value::as_str) == Some("image_url") {
-                    if let Some(image_url) = part.get("image_url") {
-                        image_parts.push(json!({
-                            "type": "image_url",
-                            "image_url": image_url.clone()
-                        }));
-                    }
-                } else if matches!(
-                    part.get("type").and_then(Value::as_str),
-                    Some("input_audio") | Some("audio")
-                ) {
-                    // [NEW] Responses API 音频入参透传给 chat/completions 映射层
-                    if let Some(input_audio) = part.get("input_audio") {
-                        image_parts.push(json!({
-                            "type": "input_audio",
-                            "input_audio": input_audio.clone()
-                        }));
-                    }
-                } else if part.get("type").and_then(Value::as_str) == Some("audio_url") {
-                    if let Some(audio_url) = part.get("audio_url") {
-                        image_parts.push(json!({
-                            "type": "audio_url",
-                            "audio_url": audio_url.clone()
-                        }));
-                    }
+                if let Err(part) =
+                    push_responses_content_part(part, &mut text_parts, &mut media_parts)
+                {
+                    unhandled_parts.push(part);
                 }
             }
         }
-        _ => {}
+        Some(part @ Value::Object(_)) => {
+            if let Err(part) = push_responses_content_part(part, &mut text_parts, &mut media_parts)
+            {
+                unhandled_parts.push(part);
+            }
+        }
+        Some(other) => unhandled_parts.push(other),
+        None => {}
     }
 
-    (text_parts, image_parts)
+    (text_parts, media_parts, unhandled_parts)
+}
+
+fn responses_message_parts(item: &mut Value) -> (Vec<String>, Vec<Value>) {
+    let content = item.as_object_mut().and_then(|obj| obj.remove("content"));
+    let (text, media, _) = responses_content_parts(content);
+    (text, media)
+}
+
+fn responses_tool_output_parts(item: &mut Value) -> (String, Vec<Value>) {
+    let Some(output) = item.as_object_mut().and_then(|obj| obj.remove("output")) else {
+        return (String::new(), Vec::new());
+    };
+    let mut output = output;
+    let content = output
+        .as_object_mut()
+        .and_then(|obj| obj.remove("content"))
+        .unwrap_or(output);
+
+    match content {
+        Value::String(text) => (text, Vec::new()),
+        content @ Value::Array(_) => {
+            let (text_parts, media_parts, unhandled) = responses_content_parts(Some(content));
+            if text_parts.is_empty() && media_parts.is_empty() {
+                (Value::Array(unhandled).to_string(), Vec::new())
+            } else {
+                (text_parts.join("\n"), media_parts)
+            }
+        }
+        content @ Value::Object(_) if content.get("type").is_some() => {
+            let (text_parts, media_parts, unhandled) = responses_content_parts(Some(content));
+            if text_parts.is_empty() && media_parts.is_empty() {
+                (
+                    unhandled
+                        .into_iter()
+                        .next()
+                        .unwrap_or(Value::Null)
+                        .to_string(),
+                    Vec::new(),
+                )
+            } else {
+                (text_parts.join("\n"), media_parts)
+            }
+        }
+        _ => (content.to_string(), Vec::new()),
+    }
+}
+
+fn decoded_base64_len(encoded: &str) -> Result<usize, String> {
+    let mut decoder = base64::read::DecoderReader::new(
+        encoded.as_bytes(),
+        &base64::engine::general_purpose::STANDARD,
+    );
+    let mut sink = io::sink();
+    usize::try_from(
+        io::copy(&mut decoder, &mut sink)
+            .map_err(|_| "Input image contains invalid base64 data".to_string())?,
+    )
+    .map_err(|_| "Input image is too large".to_string())
+}
+
+fn validate_responses_image_data_url(
+    data_url: &str,
+    image_count: usize,
+    total_bytes: usize,
+) -> Result<usize, String> {
+    let (_, encoded) = parse_image_data_url_parts(data_url)?;
+    validate_input_image_limits(image_count, 0, total_bytes)?;
+    let max_encoded_len = MAX_INPUT_IMAGE_BYTES.div_ceil(3).saturating_mul(4);
+    if encoded.len() > max_encoded_len {
+        return Err(format!(
+            "Input image is too large: maximum decoded size is {} bytes",
+            MAX_INPUT_IMAGE_BYTES
+        ));
+    }
+    let decoded_len = decoded_base64_len(encoded)?;
+    validate_input_image_limits(
+        image_count,
+        decoded_len,
+        total_bytes.saturating_add(decoded_len),
+    )?;
+    Ok(decoded_len)
+}
+
+fn validate_responses_input_image_limits(input: Option<&Value>) -> Result<(), String> {
+    fn visit(value: &Value, count: &mut usize, total: &mut usize) -> Result<(), String> {
+        match value {
+            Value::Array(values) => {
+                for value in values {
+                    visit(value, count, total)?;
+                }
+            }
+            Value::Object(values) => {
+                if matches!(
+                    values.get("type").and_then(Value::as_str),
+                    Some("input_image") | Some("image_url")
+                ) {
+                    let image_url = values.get("image_url").and_then(|value| {
+                        value
+                            .as_str()
+                            .or_else(|| value.get("url").and_then(Value::as_str))
+                    });
+                    if let Some(data_url) = image_url {
+                        if !data_url.starts_with("data:") {
+                            return Ok(());
+                        }
+                        *count = count.saturating_add(1);
+                        let decoded_len =
+                            validate_responses_image_data_url(data_url, *count, *total)?;
+                        *total = total.saturating_add(decoded_len);
+                    }
+                    return Ok(());
+                }
+                for value in values.values() {
+                    visit(value, count, total)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    let mut count = 0;
+    let mut total = 0;
+    if let Some(input) = input {
+        visit(input, &mut count, &mut total)?;
+    }
+    Ok(())
+}
+
+fn historical_media_placeholder(value: &serde_json::Map<String, Value>) -> Option<Value> {
+    match value.get("type").and_then(Value::as_str) {
+        Some("input_image") | Some("image_url") => Some(json!({
+            "type": "input_text",
+            "text": "[historical image omitted]"
+        })),
+        Some("input_audio") | Some("audio") | Some("audio_url") => Some(json!({
+            "type": "input_text",
+            "text": "[historical audio omitted]"
+        })),
+        _ => None,
+    }
+}
+
+fn history_without_inline_media(value: &Value) -> Value {
+    fn clone_bounded(value: &Value) -> Option<Value> {
+        match value {
+            Value::String(text)
+                if text.starts_with("data:image/") || text.starts_with("data:audio/") =>
+            {
+                None
+            }
+            Value::Array(values) => Some(Value::Array(
+                values.iter().filter_map(clone_bounded).collect(),
+            )),
+            Value::Object(values) => historical_media_placeholder(values).or_else(|| {
+                Some(Value::Object(
+                    values
+                        .iter()
+                        .filter_map(|(key, value)| {
+                            clone_bounded(value).map(|value| (key.clone(), value))
+                        })
+                        .collect(),
+                ))
+            }),
+            _ => Some(value.clone()),
+        }
+    }
+
+    clone_bounded(value).unwrap_or(Value::Null)
+}
+
+fn into_history_without_inline_media(value: Value) -> Option<Value> {
+    match value {
+        Value::String(text)
+            if text.starts_with("data:image/") || text.starts_with("data:audio/") =>
+        {
+            None
+        }
+        Value::Array(values) => Some(Value::Array(
+            values
+                .into_iter()
+                .filter_map(into_history_without_inline_media)
+                .collect(),
+        )),
+        Value::Object(values) => {
+            if let Some(placeholder) = historical_media_placeholder(&values) {
+                Some(placeholder)
+            } else {
+                Some(Value::Object(
+                    values
+                        .into_iter()
+                        .filter_map(|(key, value)| {
+                            into_history_without_inline_media(value).map(|value| (key, value))
+                        })
+                        .collect(),
+                ))
+            }
+        }
+        other => Some(other),
+    }
+}
+
+fn omit_media_before_latest_user_turn(items: &mut [Value]) {
+    let Some(current_turn_start) = items.iter().rposition(|item| {
+        item.get("role").and_then(Value::as_str) == Some("user")
+            && matches!(
+                item.get("type").and_then(Value::as_str),
+                None | Some("message")
+            )
+    }) else {
+        return;
+    };
+
+    for item in &mut items[..current_turn_start] {
+        let historical = std::mem::take(item);
+        *item = into_history_without_inline_media(historical).unwrap_or(Value::Null);
+    }
+}
+
+fn build_responses_tool_output_content(text: String, mut media_parts: Vec<Value>) -> Value {
+    if media_parts.is_empty() {
+        return Value::String(text);
+    }
+
+    let mut content = Vec::with_capacity(media_parts.len() + usize::from(!text.is_empty()));
+    if !text.is_empty() {
+        content.push(json!({ "type": "text", "text": text }));
+    }
+    content.append(&mut media_parts);
+    Value::Array(content)
+}
+
+fn debug_value_without_inline_data(value: &Value) -> Value {
+    match value {
+        Value::String(text)
+            if text.starts_with("data:image/") || text.starts_with("data:audio/") =>
+        {
+            Value::String(format!("[inline data omitted: {} chars]", text.len()))
+        }
+        Value::Array(values) => {
+            Value::Array(values.iter().map(debug_value_without_inline_data).collect())
+        }
+        Value::Object(values) => {
+            let is_inline_data = values.get("mimeType").and_then(Value::as_str).is_some()
+                && values.get("data").and_then(Value::as_str).is_some();
+            Value::Object(
+                values
+                    .iter()
+                    .map(|(key, value)| {
+                        let value = if is_inline_data && key == "data" {
+                            Value::String(format!(
+                                "[inline data omitted: {} chars]",
+                                value.as_str().map(str::len).unwrap_or_default()
+                            ))
+                        } else {
+                            debug_value_without_inline_data(value)
+                        };
+                        (key.clone(), value)
+                    })
+                    .collect(),
+            )
+        }
+        _ => value.clone(),
+    }
+}
+
+#[derive(Default)]
+struct JsonByteCounter(usize);
+
+impl std::io::Write for JsonByteCounter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0 += bytes.len();
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn serialized_json_len(value: &Value) -> usize {
+    let mut counter = JsonByteCounter::default();
+    serde_json::to_writer(&mut counter, value)
+        .map(|_| counter.0)
+        .unwrap_or_default()
 }
 
 fn rewrite_terminal_assistant_prefill(messages: &mut [Value]) -> bool {
@@ -531,16 +864,22 @@ mod stream_peek_tests {
     use super::drop_leading_orphan_tool_history;
     use super::edit_size_input;
     use super::generation_image_size_param;
+    use super::history_without_inline_media;
     use super::image_account_selection_target;
+    use super::into_history_without_inline_media;
     use super::is_codex_transcript_only_assistant_message;
     use super::is_edit_image_field;
+    use super::omit_media_before_latest_user_turn;
     use super::parse_generation_input_images;
     use super::responses_input_item_type;
     use super::responses_message_parts;
     use super::rewrite_terminal_assistant_prefill;
     use super::stream_chunk_has_error_event;
     use super::validate_input_image_limits;
+    use super::validate_responses_image_data_url;
+    use super::validate_responses_input_image_limits;
     use super::{MAX_INPUT_IMAGES, MAX_INPUT_IMAGE_BYTES, MAX_TOTAL_INPUT_IMAGE_BYTES};
+    use crate::proxy::mappers::openai::{transform_openai_request, OpenAIRequest};
     use serde_json::{json, Value};
 
     #[test]
@@ -590,11 +929,11 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
 
         assert_eq!(responses_input_item_type(&string_message), "message");
         assert_eq!(
-            responses_message_parts(&string_message).0,
+            responses_message_parts(&mut string_message.clone()).0,
             vec!["Follow the system instructions."]
         );
         assert_eq!(
-            responses_message_parts(&array_message).0,
+            responses_message_parts(&mut array_message.clone()).0,
             vec!["Continue planning."]
         );
 
@@ -618,6 +957,149 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
                 {"role": "user", "content": "Continue planning."}
             ])
         );
+    }
+
+    #[test]
+    fn responses_tool_output_image_is_sent_as_inline_data() {
+        let converted = convert_codex_to_openai_request(json!({
+            "model": "gemini-3.7-flash-high",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Generate an image."}]
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_image",
+                    "name": "view_image",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_image",
+                    "output": [
+                        {"type": "input_text", "text": "image generated"},
+                        {"type": "input_image", "image_url": "data:image/png;base64,AQ=="}
+                    ]
+                }
+            ]
+        }));
+        assert!(converted.get("input").is_none());
+        let request: OpenAIRequest =
+            serde_json::from_value(converted).expect("valid OpenAI request");
+
+        let (upstream, _, _, _) =
+            transform_openai_request(&request, "project", "gemini-3.7-flash-high", None);
+        let parts = upstream["request"]["contents"]
+            .as_array()
+            .expect("contents")
+            .iter()
+            .flat_map(|content| content["parts"].as_array().expect("content parts").iter())
+            .collect::<Vec<_>>();
+        let function_response = parts
+            .iter()
+            .find(|part| part.get("functionResponse").is_some())
+            .expect("function response");
+        let inline_data = parts
+            .iter()
+            .find(|part| part.get("inlineData").is_some())
+            .expect("inline image data");
+
+        assert_eq!(
+            function_response["functionResponse"]["response"]["result"],
+            "image generated"
+        );
+        assert!(!function_response.to_string().contains("data:image/"));
+        assert_eq!(inline_data["inlineData"]["mimeType"], "image/png");
+        assert_eq!(inline_data["inlineData"]["data"], "AQ==");
+    }
+
+    #[test]
+    fn pure_image_tool_history_keeps_small_placeholder() {
+        let history = json!({
+            "type": "function_call_output",
+            "call_id": "call_image",
+            "output": [{
+                "type": "input_image",
+                "image_url": "data:image/png;base64,AQ=="
+            }]
+        });
+        let expected = json!({
+            "type": "function_call_output",
+            "call_id": "call_image",
+            "output": [{
+                "type": "input_text",
+                "text": "[historical image omitted]"
+            }]
+        });
+
+        let borrowed = history_without_inline_media(&history);
+        let moved = into_history_without_inline_media(history).expect("bounded history");
+        assert_eq!(borrowed, expected);
+        assert_eq!(moved, expected);
+        assert!(!borrowed.to_string().contains("base64"));
+    }
+
+    #[test]
+    fn responses_data_url_metadata_and_byte_limits() {
+        assert_eq!(
+            validate_responses_image_data_url("data:image/png;BASE64,AQ==", 1, 0)
+                .expect("uppercase base64 token"),
+            1
+        );
+        let encoded = "AAAA".repeat(MAX_INPUT_IMAGE_BYTES / 3 + 1);
+        assert_eq!(
+            validate_responses_image_data_url(&format!("data:image/png;BASE64,{encoded}"), 1, 0)
+                .unwrap_err(),
+            format!(
+                "Input image is too large: maximum decoded size is {} bytes",
+                MAX_INPUT_IMAGE_BYTES
+            )
+        );
+        assert!(validate_responses_image_data_url(
+            "data:image/png;BASE64,AQ==",
+            1,
+            MAX_TOTAL_INPUT_IMAGE_BYTES
+        )
+        .unwrap_err()
+        .starts_with("Total input image data is too large"));
+        assert!(validate_input_image_limits(
+            MAX_INPUT_IMAGES,
+            2 * 1024 * 1024,
+            MAX_TOTAL_INPUT_IMAGE_BYTES
+        )
+        .is_ok());
+        assert!(validate_input_image_limits(
+            MAX_INPUT_IMAGES,
+            2 * 1024 * 1024,
+            MAX_TOTAL_INPUT_IMAGE_BYTES + 1
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn responses_omits_old_images_before_validating_current_turn() {
+        let images = |count| {
+            (0..count)
+                .map(|_| {
+                    json!({"type": "input_image", "image_url": "data:image/png;base64,AQ=="})
+                })
+                .collect::<Vec<_>>()
+        };
+        let mut input = vec![
+            json!({"type": "message", "role": "user", "content": images(16)}),
+            json!({"type": "message", "role": "assistant", "content": "done"}),
+            json!({"type": "message", "role": "user", "content": images(16)}),
+        ];
+
+        omit_media_before_latest_user_turn(&mut input);
+        assert!(input[0].to_string().contains("[historical image omitted]"));
+        assert!(!input[0].to_string().contains("data:image/"));
+        assert!(validate_responses_input_image_limits(Some(&Value::Array(input.clone()))).is_ok());
+
+        input[2]["content"] = Value::Array(images(17));
+        assert!(validate_responses_input_image_limits(Some(&Value::Array(input))).is_err());
     }
 
     #[test]
@@ -1103,9 +1585,9 @@ pub async fn handle_chat_completions(
         return intercept_chat_to_image(state, body, &model_name).await;
     }
 
-    // [FIX] 保存原始请求体的完整副本，用于日志记录
-    // 这确保了即使结构体定义遗漏字段，日志也能完整记录所有参数
-    let original_body = body.clone();
+    let debug_cfg = state.debug_logging.read().await.clone();
+    let original_body =
+        debug_logger::is_enabled(&debug_cfg).then(|| debug_value_without_inline_data(&body));
 
     // [NEW] 自动检测并转换 Responses 格式
     // 如果请求包含 instructions 或 input 但没有 messages，则认为是 Responses 格式
@@ -1190,8 +1672,6 @@ pub async fn handle_chat_completions(
         openai_req.messages.len(),
         openai_req.stream
     );
-    let debug_cfg = state.debug_logging.read().await.clone();
-
     let mut force_rotate = false;
 
     if debug_logger::is_enabled(&debug_cfg) {
@@ -1218,7 +1698,7 @@ pub async fn handle_chat_completions(
             "protocol": "openai",
             "trace_id": trace_id,
             "original_model": openai_req.model,
-            "request": original_body,  // 使用原始请求体，不是结构体序列化
+            "request": original_body.as_ref(),
         });
         debug_logger::write_exchange_payload(
             &debug_cfg,
@@ -1351,7 +1831,8 @@ pub async fn handle_chat_completions(
             &mapped_model,
             proxy_token.as_ref(),
         );
-        let gemini_body_for_debug = gemini_body.clone();
+        let gemini_body_for_debug = debug_logger::is_enabled(&debug_cfg)
+            .then(|| debug_value_without_inline_data(&gemini_body));
 
         if debug_logger::is_enabled(&debug_cfg) {
             let payload = json!({
@@ -1362,7 +1843,7 @@ pub async fn handle_chat_completions(
                 "mapped_model": mapped_model,
                 "request_type": config.request_type,
                 "attempt": attempt,
-                "v1internal_request": gemini_body.clone(),
+                "v1internal_request": gemini_body_for_debug.as_ref(),
             });
             debug_logger::write_exchange_payload(
                 &debug_cfg,
@@ -1373,10 +1854,10 @@ pub async fn handle_chat_completions(
             .await;
         }
 
-        // [New] 打印转换后的报文 (Gemini Body) 供调试
-        if let Ok(body_json) = serde_json::to_string_pretty(&gemini_body) {
-            debug!("[OpenAI-Request] Transformed Gemini Body:\n{}", body_json);
-        }
+        debug!(
+            "[OpenAI-Request] Transformed Gemini body: {} bytes",
+            serialized_json_len(&gemini_body)
+        );
 
         // 5. 发送请求
         let client_wants_stream = openai_req.stream;
@@ -1668,8 +2149,8 @@ pub async fn handle_chat_completions(
                                     "kind": "exchange_summary",
                                     "protocol": "openai",
                                     "trace_id": trace_id,
-                                    "original_codex_request": original_body,
-                                    "gemini_request": gemini_body_for_debug,
+                                    "original_codex_request": original_body.as_ref(),
+                                    "gemini_request": gemini_body_for_debug.as_ref(),
                                     "converted_codex_response": converted_response,
                                     "gemini_raw_response_ref": "see upstream_response file with the same trace_id",
                                 });
@@ -1745,8 +2226,8 @@ pub async fn handle_chat_completions(
                     "kind": "exchange_summary",
                     "protocol": "openai",
                     "trace_id": trace_id,
-                    "original_codex_request": original_body,
-                    "gemini_request": gemini_body_for_debug,
+                    "original_codex_request": original_body.as_ref(),
+                    "gemini_request": gemini_body_for_debug.as_ref(),
                     "gemini_raw_response": gemini_resp,
                     "converted_codex_response": converted_response,
                 });
@@ -2096,11 +2577,22 @@ pub async fn handle_completions(
     Json(mut body): Json<Value>,
 ) -> Response {
     debug!(
-        "Received /v1/completions or /v1/responses payload: {:?}",
-        body
+        "Received /v1/completions or /v1/responses payload: {} bytes",
+        serialized_json_len(&body)
     );
-    let original_body = body.clone();
     let debug_cfg = state.debug_logging.read().await.clone();
+    let original_body =
+        debug_logger::is_enabled(&debug_cfg).then(|| debug_value_without_inline_data(&body));
+    let is_codex_style = body.get("input").is_some() || body.get("instructions").is_some();
+
+    if is_codex_style {
+        if let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) {
+            omit_media_before_latest_user_turn(input);
+        }
+        if let Err(message) = validate_responses_input_image_limits(body.get("input")) {
+            return (StatusCode::BAD_REQUEST, message).into_response();
+        }
+    }
 
     // [MULTI-TURN] 支持 previous_response_id 链式历史恢复
     // 当客户端通过 HTTP POST /v1/responses 传入 previous_response_id 时，
@@ -2116,19 +2608,22 @@ pub async fn handle_completions(
         if let Some(session) = crate::proxy::http_session_store::get_session(prev_id).await {
             // 把历史 input items 合并进来
             let existing_input = body
-                .get("input")
-                .and_then(|v| v.as_array())
-                .cloned()
+                .as_object_mut()
+                .and_then(|obj| obj.remove("input"))
+                .and_then(|value| match value {
+                    Value::Array(items) => Some(items),
+                    _ => None,
+                })
                 .unwrap_or_default();
             let merged = crate::proxy::http_session_store::merge_history_with_new_input(
                 session.input_items,
                 &[],
-                &existing_input,
+                existing_input,
                 &http_tool_call_cache,
             );
             let merged_len = merged.len();
             if let Some(obj) = body.as_object_mut() {
-                obj.insert("input".to_string(), json!(merged));
+                obj.insert("input".to_string(), Value::Array(merged));
                 // 从历史 session 继承 instructions（如果本轮没带）
                 if !obj.contains_key("instructions") && !session.instructions.is_empty() {
                     obj.insert("instructions".to_string(), json!(session.instructions));
@@ -2146,16 +2641,31 @@ pub async fn handle_completions(
         }
     }
 
-    let is_codex_style = body.get("input").is_some() || body.get("instructions").is_some();
+    let mut bounded_session_input = None;
 
     // 1. Convert Payload to Messages (Shared Chat Format)
     if is_codex_style {
         let instructions = body
             .get("instructions")
             .and_then(|v| v.as_str())
-            .unwrap_or_default();
-        let input_items = body.get("input").and_then(|v| v.as_array());
+            .unwrap_or_default()
+            .to_string();
         let (interaction_ledger, mut step_markers) = codex_ledger_from_body(&body);
+        let input_items = body
+            .as_object_mut()
+            .and_then(|obj| obj.remove("input"))
+            .and_then(|value| match value {
+                Value::Array(items) => Some(items),
+                _ => None,
+            })
+            .unwrap_or_default();
+        bounded_session_input = Some(
+            input_items
+                .iter()
+                .map(history_without_inline_media)
+                .filter(|item| !item.is_null())
+                .collect(),
+        );
 
         let mut messages = Vec::new();
 
@@ -2168,9 +2678,9 @@ pub async fn handle_completions(
         let mut skipped_incomplete_custom_call_ids = std::collections::HashSet::new();
 
         // Pass 1: Build Call ID to Name Map
-        if let Some(items) = input_items {
-            for item in items {
-                let item_type = responses_input_item_type(item);
+        {
+            for item in &input_items {
+                let item_type = responses_input_item_type(&item).to_string();
                 if item_type == "custom_tool_call"
                     && item.get("status").and_then(|v| v.as_str()) == Some("incomplete")
                 {
@@ -2183,7 +2693,7 @@ pub async fn handle_completions(
                     }
                     continue;
                 }
-                match item_type {
+                match item_type.as_str() {
                     "function_call" | "custom_tool_call" | "local_shell_call"
                     | "web_search_call" => {
                         let call_id = item
@@ -2216,22 +2726,30 @@ pub async fn handle_completions(
         // Pass 2: Map durable conversation items to Gemini messages. Visible
         // assistant commentary stays in Codex's local transcript and must not
         // be replayed as model history.
-        if let Some(items) = input_items {
-            for item in items {
-                let item_type = responses_input_item_type(item);
+        {
+            for mut item in input_items {
+                let item_type = responses_input_item_type(&item).to_string();
                 let step_marker = step_markers.pop_front();
                 if item_type == "custom_tool_call"
                     && item.get("status").and_then(|v| v.as_str()) == Some("incomplete")
                 {
                     continue;
                 }
-                match item_type {
+                match item_type.as_str() {
                     "message" => {
-                        let role = item.get("role").and_then(|v| v.as_str()).unwrap_or("user");
-                        let (text_parts, image_parts) = responses_message_parts(item);
+                        let role = item
+                            .get("role")
+                            .and_then(Value::as_str)
+                            .unwrap_or("user")
+                            .to_string();
+                        let transcript_only_metadata =
+                            is_codex_transcript_only_assistant_message(&item, "");
+                        let (text_parts, image_parts) = responses_message_parts(&mut item);
 
                         let joined_text = text_parts.join("\n");
-                        if is_codex_transcript_only_assistant_message(item, &joined_text) {
+                        if transcript_only_metadata
+                            || joined_text.trim_start().starts_with("**Thinking**")
+                        {
                             continue;
                         }
 
@@ -2341,9 +2859,10 @@ pub async fn handle_completions(
                         let call_id = item
                             .get("call_id")
                             .and_then(|v| v.as_str())
-                            .unwrap_or("unknown");
+                            .unwrap_or("unknown")
+                            .to_string();
                         if item_type == "custom_tool_call_output"
-                            && skipped_incomplete_custom_call_ids.contains(call_id)
+                            && skipped_incomplete_custom_call_ids.contains(&call_id)
                         {
                             tracing::warn!(
                                 "Skipping output for incomplete custom tool call {}",
@@ -2351,21 +2870,9 @@ pub async fn handle_completions(
                             );
                             continue;
                         }
-                        let output = item.get("output");
-                        let mut output_str = if let Some(o) = output {
-                            if o.is_string() {
-                                o.as_str().unwrap().to_string()
-                            } else if let Some(content) = o.get("content").and_then(|v| v.as_str())
-                            {
-                                content.to_string()
-                            } else {
-                                o.to_string()
-                            }
-                        } else {
-                            "".to_string()
-                        };
+                        let (mut output_str, output_media) = responses_tool_output_parts(&mut item);
 
-                        let name = if let Some(name) = call_id_to_name.get(call_id).cloned() {
+                        let name = if let Some(name) = call_id_to_name.get(&call_id).cloned() {
                             name
                         } else if item_type == "custom_tool_call_output" {
                             tracing::warn!(
@@ -2389,12 +2896,14 @@ pub async fn handle_completions(
                             );
                         }
                         output_str = prefix_with_step_marker(step_marker, output_str);
+                        let output_content =
+                            build_responses_tool_output_content(output_str, output_media);
 
                         messages.push(json!({
                             "role": "tool",
                             "tool_call_id": call_id,
                             "name": name,
-                            "content": output_str
+                            "content": output_content
                         }));
                     }
                     _ => {}
@@ -2402,7 +2911,7 @@ pub async fn handle_completions(
             }
         }
         if let Some(obj) = body.as_object_mut() {
-            obj.insert("messages".to_string(), json!(messages));
+            obj.insert("messages".to_string(), Value::Array(messages));
             if let Some(ledger) = interaction_ledger {
                 obj.insert("_interaction_ledger".to_string(), json!(ledger));
             }
@@ -2589,7 +3098,7 @@ pub async fn handle_completions(
                 "[Codex] Injecting normalized messages: {} messages",
                 messages.len()
             );
-            obj.insert("messages".to_string(), json!(messages));
+            obj.insert("messages".to_string(), Value::Array(messages));
         }
     } else if already_normalized {
         tracing::debug!(
@@ -2616,23 +3125,23 @@ pub async fn handle_completions(
 
     // [FIX] 在 openai_req 反序列化之前，从 body 中捕获原始 input 和 instructions
     // 用于后续 session 保存时，保留完整的工具调用历史（而非从 openai_req.messages 重建丢失信息）
-    let session_save_input: Vec<serde_json::Value> = body
-        .get("input")
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
-    let session_save_instructions: String = body
-        .get("instructions")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
     let normalized_interaction_ledger = body.get("_interaction_ledger").cloned();
+    let (session_save_input, session_save_instructions) = if let Some(obj) = body.as_object_mut() {
+        let input = bounded_session_input.take().unwrap_or_default();
+        obj.remove("input");
+        let instructions = obj
+            .remove("instructions")
+            .and_then(|value| match value {
+                Value::String(text) => Some(text),
+                _ => None,
+            })
+            .unwrap_or_default();
+        (input, instructions)
+    } else {
+        (Vec::new(), String::new())
+    };
 
-    if let Some(obj) = body.as_object_mut() {
-        obj.remove("instructions");
-    }
-
-    let mut openai_req: OpenAIRequest = match serde_json::from_value(body.clone()) {
+    let mut openai_req: OpenAIRequest = match serde_json::from_value(body) {
         Ok(req) => req,
         Err(e) => {
             return (StatusCode::BAD_REQUEST, format!("Invalid request: {}", e)).into_response();
@@ -2880,7 +3389,7 @@ pub async fn handle_completions(
             "protocol": "openai",
             "trace_id": trace_id,
             "request_path": uri.path(),
-            "request": original_body,
+            "request": original_body.as_ref(),
         });
         debug_logger::write_exchange_payload(
             &debug_cfg,
@@ -2950,7 +3459,8 @@ pub async fn handle_completions(
             &mapped_model,
             proxy_token.as_ref(),
         );
-        let gemini_body_for_debug = gemini_body.clone();
+        let gemini_body_for_debug = debug_logger::is_enabled(&debug_cfg)
+            .then(|| debug_value_without_inline_data(&gemini_body));
         if debug_logger::is_enabled(&debug_cfg) {
             let payload = json!({
                 "kind": "v1internal_request",
@@ -2961,7 +3471,7 @@ pub async fn handle_completions(
                 "mapped_model": mapped_model,
                 "request_type": config.request_type,
                 "attempt": attempt,
-                "v1internal_request": gemini_body_for_debug.clone(),
+                "v1internal_request": gemini_body_for_debug.as_ref(),
             });
             debug_logger::write_exchange_payload(
                 &debug_cfg,
@@ -2980,20 +3490,24 @@ pub async fn handle_completions(
                     .get("role")
                     .and_then(|r| r.as_str())
                     .unwrap_or("unknown");
-                let msg_str = serde_json::to_string(msg).unwrap_or_default();
-                sizes.push(format!("msg_{}[{}]: {} chars", idx, role, msg_str.len()));
+                sizes.push(format!(
+                    "msg_{}[{}]: {} chars",
+                    idx,
+                    role,
+                    serialized_json_len(msg)
+                ));
             }
 
             let system_instruction_len = gemini_body
                 .get("request")
                 .and_then(|r| r.get("systemInstruction"))
-                .map(|s| serde_json::to_string(s).unwrap_or_default().len())
+                .map(serialized_json_len)
                 .unwrap_or(0);
 
             let tools_len = gemini_body
                 .get("request")
                 .and_then(|r| r.get("tools"))
-                .map(|t| serde_json::to_string(t).unwrap_or_default().len())
+                .map(serialized_json_len)
                 .unwrap_or(0);
 
             tracing::info!(
@@ -3174,8 +3688,8 @@ pub async fn handle_completions(
                     // 使用从 body 中提取的原始 input（含文本/工具调用/工具结果全量历史），
                     // 而非从 openai_req.messages 重建（会丢失 tool_calls/tool 角色等信息）
                     {
-                        let save_input = session_save_input.clone();
-                        let save_instructions = session_save_instructions.clone();
+                        let save_input = session_save_input;
+                        let save_instructions = session_save_instructions;
                         let save_model = openai_req.model.clone();
                         let entry = crate::proxy::http_session_store::HttpSessionEntry {
                             input_items: save_input,
@@ -3298,8 +3812,8 @@ pub async fn handle_completions(
                                         "protocol": "openai",
                                         "trace_id": trace_id,
                                         "request_path": uri.path(),
-                                        "original_codex_request": original_body.clone(),
-                                        "gemini_request": gemini_body_for_debug.clone(),
+                                        "original_codex_request": original_body.as_ref(),
+                                        "gemini_request": gemini_body_for_debug.as_ref(),
                                         "converted_codex_response": resp.clone(),
                                         "gemini_raw_response_ref": "see upstream_response file with the same trace_id",
                                     });
@@ -3362,8 +3876,8 @@ pub async fn handle_completions(
                                     "protocol": "openai",
                                     "trace_id": trace_id,
                                     "request_path": uri.path(),
-                                    "original_codex_request": original_body.clone(),
-                                    "gemini_request": gemini_body_for_debug.clone(),
+                                    "original_codex_request": original_body.as_ref(),
+                                    "gemini_request": gemini_body_for_debug.as_ref(),
                                     "converted_codex_response": legacy_resp.clone(),
                                     "gemini_raw_response_ref": "see upstream_response file with the same trace_id",
                                 });
@@ -3426,8 +3940,8 @@ pub async fn handle_completions(
                         "protocol": "openai",
                         "trace_id": trace_id,
                         "request_path": uri.path(),
-                        "original_codex_request": original_body.clone(),
-                        "gemini_request": gemini_body_for_debug.clone(),
+                        "original_codex_request": original_body.as_ref(),
+                        "gemini_request": gemini_body_for_debug.as_ref(),
                         "gemini_raw_response": gemini_resp.clone(),
                         "converted_codex_response": resp.clone(),
                     });
@@ -3478,8 +3992,8 @@ pub async fn handle_completions(
                     "protocol": "openai",
                     "trace_id": trace_id,
                     "request_path": uri.path(),
-                    "original_codex_request": original_body.clone(),
-                    "gemini_request": gemini_body_for_debug.clone(),
+                    "original_codex_request": original_body.as_ref(),
+                    "gemini_request": gemini_body_for_debug.as_ref(),
                     "gemini_raw_response": gemini_resp.clone(),
                     "converted_codex_response": legacy_resp.clone(),
                 });
@@ -4595,6 +5109,7 @@ async fn handle_websocket_session(mut socket: WebSocket, headers: HeaderMap, sta
                 continue;
             }
         };
+        drop(text);
         let ws_trace_id = format!("ws_{}", chrono::Utc::now().timestamp_subsec_millis());
         let debug_cfg = state.debug_logging.read().await.clone();
         if debug_logger::is_enabled(&debug_cfg) {
@@ -4602,8 +5117,7 @@ async fn handle_websocket_session(mut socket: WebSocket, headers: HeaderMap, sta
                 "kind": "codex_websocket_raw_request",
                 "protocol": "codex_websocket",
                 "trace_id": ws_trace_id,
-                "raw_text": text.clone(),
-                "payload": payload.clone(),
+                "payload": debug_value_without_inline_data(&payload),
             });
             debug_logger::write_exchange_payload(
                 &debug_cfg,
@@ -4636,7 +5150,7 @@ async fn handle_websocket_session(mut socket: WebSocket, headers: HeaderMap, sta
             continue;
         }
 
-        let normalized = match normalize_responses_websocket_request(&payload, &mut session_state) {
+        let normalized = match normalize_responses_websocket_request(payload, &mut session_state) {
             Ok(n) => n,
             Err(e) => {
                 let error_ev = json!({
@@ -4777,8 +5291,8 @@ async fn handle_websocket_session(mut socket: WebSocket, headers: HeaderMap, sta
                 "kind": "codex_websocket_converted_response",
                 "protocol": "codex_websocket",
                 "trace_id": ws_trace_id,
-                "events": outgoing_ws_events,
-                "completed_output": completed_output.clone(),
+                "events": debug_value_without_inline_data(&Value::Array(outgoing_ws_events)),
+                "completed_output": debug_value_without_inline_data(&completed_output),
             });
             debug_logger::write_exchange_payload(
                 &debug_cfg,
@@ -4789,7 +5303,8 @@ async fn handle_websocket_session(mut socket: WebSocket, headers: HeaderMap, sta
             .await;
         }
 
-        session_state.last_response_output = completed_output;
+        session_state.last_response_output =
+            into_history_without_inline_media(completed_output).unwrap_or_else(|| json!([]));
         session_state.last_response_id = translation_state.response_id.clone();
         session_state.last_response_pending_tool_call_ids = translation_state
             .tool_calls
@@ -4864,7 +5379,7 @@ fn handle_prewarm_locally(payload: &Value, state: &mut WebsocketSessionState) ->
         }
     });
 
-    let mut normalized = payload.clone();
+    let mut normalized = history_without_inline_media(payload);
     if let Some(obj) = normalized.as_object_mut() {
         obj.remove("type");
         obj.remove("generate");
@@ -4878,30 +5393,31 @@ fn handle_prewarm_locally(payload: &Value, state: &mut WebsocketSessionState) ->
 }
 
 fn normalize_responses_websocket_request(
-    payload: &Value,
+    mut payload: Value,
     state: &mut WebsocketSessionState,
 ) -> Result<Value, String> {
-    let event_type = payload.get("type").and_then(|v| v.as_str()).unwrap_or("");
-    match event_type {
+    let event_type = payload
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    match event_type.as_str() {
         "response.create" => {
             if state.last_request.is_none() {
-                let mut normalized = payload.clone();
-                if let Some(obj) = normalized.as_object_mut() {
+                if let Some(obj) = payload.as_object_mut() {
                     obj.remove("type");
                     obj.insert("stream".to_string(), Value::Bool(true));
                     if !obj.contains_key("input") {
                         obj.insert("input".to_string(), json!([]));
                     }
                 }
-                let model_name = normalized
-                    .get("model")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
+                let model_name = payload.get("model").and_then(|v| v.as_str()).unwrap_or("");
                 if model_name.is_empty() {
                     return Err("missing model in response.create request".to_string());
                 }
-                state.last_request = Some(normalized.clone());
-                Ok(normalized)
+                validate_responses_input_image_limits(payload.get("input"))?;
+                state.last_request = Some(history_without_inline_media(&payload));
+                Ok(payload)
             } else {
                 normalize_response_subsequent_request(payload, state)
             }
@@ -4915,101 +5431,100 @@ fn normalize_responses_websocket_request(
 }
 
 fn normalize_response_subsequent_request(
-    payload: &Value,
+    mut payload: Value,
     state: &mut WebsocketSessionState,
 ) -> Result<Value, String> {
     if state.last_request.is_none() {
         return Err("websocket request received before response.create".to_string());
     }
+    validate_responses_input_image_limits(payload.get("input"))?;
 
     // [FIX] 拦截 compaction 和完整历史替换事件
-    if should_replace_websocket_transcript(payload) {
-        let mut normalized = payload.clone();
-        if let Some(obj) = normalized.as_object_mut() {
+    if should_replace_websocket_transcript(&payload) {
+        if let Some(obj) = payload.as_object_mut() {
             obj.remove("type");
             obj.remove("previous_response_id");
             obj.insert("stream".to_string(), Value::Bool(true));
         }
-        state.last_request = Some(normalized.clone());
-        return Ok(normalized);
+        state.last_request = Some(history_without_inline_media(&payload));
+        return Ok(payload);
     }
 
     // [FIX] 始终走完整的 merge 逻辑，废弃 transcript replacement 分支
     // 旧逻辑在检测到 function_call/assistant 时直接替换整个历史，导致多轮对话历史丢失
     // 正确做法：last_request.input + last_response_output + new payload.input 全部合并
-    let mut merged_input = Vec::new();
+    let mut last_request = state.last_request.take().expect("checked above");
+    let mut merged_input = last_request
+        .as_object_mut()
+        .and_then(|obj| obj.remove("input"))
+        .and_then(|value| match value {
+            Value::Array(items) => Some(items),
+            _ => None,
+        })
+        .unwrap_or_default();
 
-    // 1. 上一轮请求的 input（已含此前所有历史）
-    if let Some(last_req) = &state.last_request {
-        if let Some(arr) = last_req.get("input").and_then(|v| v.as_array()) {
-            merged_input.extend(arr.clone());
-        }
-    }
-
+    // 上一轮请求的 input 已按所有权移入 merged_input。
     // 2. 上一轮 response 的 output items（assistant 回复、工具调用等）
-    if let Some(arr) = state.last_response_output.as_array() {
-        merged_input.extend(arr.clone());
+    if let Value::Array(items) = std::mem::take(&mut state.last_response_output) {
+        merged_input.extend(items);
     }
 
     // 3. 本轮新的 input items（用户消息、工具调用结果等）
-    if let Some(arr) = payload.get("input").and_then(|v| v.as_array()) {
-        for item in arr {
-            let t = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
-            if t == "compaction" || t == "compaction_summary" {
-                continue;
-            }
-            if t == "function_call_output" || t == "custom_tool_call_output" {
-                if let Some(call_id) = item.get("call_id").and_then(|v| v.as_str()) {
-                    state
-                        .last_response_pending_tool_call_ids
-                        .retain(|x| x != call_id);
-                }
-            }
-            merged_input.push(item.clone());
+    let current_input = payload
+        .as_object_mut()
+        .and_then(|obj| obj.remove("input"))
+        .and_then(|value| match value {
+            Value::Array(items) => Some(items),
+            _ => None,
+        })
+        .unwrap_or_default();
+    for item in current_input {
+        let t = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if t == "compaction" || t == "compaction_summary" {
+            continue;
         }
+        if t == "function_call_output" || t == "custom_tool_call_output" {
+            if let Some(call_id) = item.get("call_id").and_then(|v| v.as_str()) {
+                state
+                    .last_response_pending_tool_call_ids
+                    .retain(|x| x != call_id);
+            }
+        }
+        merged_input.push(item);
     }
 
     repair_tool_calls(&mut merged_input, &state.tool_call_cache);
 
     let deduped = dedupe_function_calls_by_call_id(dedupe_input_items_by_id(merged_input));
 
-    let mut normalized = payload.clone();
-    if let Some(obj) = normalized.as_object_mut() {
+    if let Some(obj) = payload.as_object_mut() {
         obj.remove("type");
         obj.remove("previous_response_id");
-        obj.insert("input".to_string(), json!(deduped));
+        obj.insert("input".to_string(), Value::Array(deduped));
         if !obj.contains_key("model") {
-            if let Some(last_req) = &state.last_request {
-                if let Some(model) = last_req.get("model") {
-                    obj.insert("model".to_string(), model.clone());
-                }
+            if let Some(model) = last_request.get_mut("model").map(Value::take) {
+                obj.insert("model".to_string(), model);
             }
         }
         if !obj.contains_key("instructions") {
-            if let Some(last_req) = &state.last_request {
-                if let Some(instructions) = last_req.get("instructions") {
-                    obj.insert("instructions".to_string(), instructions.clone());
-                }
+            if let Some(instructions) = last_request.get_mut("instructions").map(Value::take) {
+                obj.insert("instructions".to_string(), instructions);
             }
         }
         if !obj.contains_key("tools") {
-            if let Some(last_req) = &state.last_request {
-                if let Some(tools) = last_req.get("tools") {
-                    obj.insert("tools".to_string(), tools.clone());
-                }
+            if let Some(tools) = last_request.get_mut("tools").map(Value::take) {
+                obj.insert("tools".to_string(), tools);
             }
         }
         if !obj.contains_key("tool_choice") {
-            if let Some(last_req) = &state.last_request {
-                if let Some(tool_choice) = last_req.get("tool_choice") {
-                    obj.insert("tool_choice".to_string(), tool_choice.clone());
-                }
+            if let Some(tool_choice) = last_request.get_mut("tool_choice").map(Value::take) {
+                obj.insert("tool_choice".to_string(), tool_choice);
             }
         }
         obj.insert("stream".to_string(), Value::Bool(true));
     }
-    state.last_request = Some(normalized.clone());
-    Ok(normalized)
+    state.last_request = Some(history_without_inline_media(&payload));
+    Ok(payload)
 }
 #[allow(dead_code)]
 fn should_replace_websocket_transcript(payload: &Value) -> bool {
@@ -5022,7 +5537,7 @@ fn should_replace_websocket_transcript(payload: &Value) -> bool {
     }
     if let Some(input_array) = payload.get("input").and_then(|v| v.as_array()) {
         for item in input_array {
-            let item_type = responses_input_item_type(item);
+            let item_type = responses_input_item_type(&item).to_string();
             if item_type == "function_call" || item_type == "custom_tool_call" {
                 return true;
             }
@@ -5035,27 +5550,6 @@ fn should_replace_websocket_transcript(payload: &Value) -> bool {
         }
     }
     false
-}
-
-#[allow(dead_code)]
-fn normalize_response_transcript_replacement(payload: &Value, last_request: &Value) -> Value {
-    let mut normalized = payload.clone();
-    if let Some(obj) = normalized.as_object_mut() {
-        obj.remove("type");
-        obj.remove("previous_response_id");
-        obj.insert("stream".to_string(), Value::Bool(true));
-        if !obj.contains_key("model") {
-            if let Some(model) = last_request.get("model") {
-                obj.insert("model".to_string(), model.clone());
-            }
-        }
-        if !obj.contains_key("instructions") {
-            if let Some(instructions) = last_request.get("instructions") {
-                obj.insert("instructions".to_string(), instructions.clone());
-            }
-        }
-    }
-    normalized
 }
 
 fn dedupe_input_items_by_id(items: Vec<Value>) -> Vec<Value> {
@@ -5168,9 +5662,17 @@ fn convert_codex_to_openai_request(mut body: Value) -> Value {
     let instructions = body
         .get("instructions")
         .and_then(|v| v.as_str())
-        .unwrap_or_default();
-    let input_items = body.get("input").and_then(|v| v.as_array());
+        .unwrap_or_default()
+        .to_string();
     let (interaction_ledger, mut step_markers) = codex_ledger_from_body(&body);
+    let input_items = body
+        .as_object_mut()
+        .and_then(|obj| obj.remove("input"))
+        .and_then(|value| match value {
+            Value::Array(items) => Some(items),
+            _ => None,
+        })
+        .unwrap_or_default();
 
     let mut messages = Vec::new();
     if !instructions.is_empty() {
@@ -5180,8 +5682,8 @@ fn convert_codex_to_openai_request(mut body: Value) -> Value {
     let mut call_id_to_name = std::collections::HashMap::new();
     let mut skipped_incomplete_custom_call_ids = std::collections::HashSet::new();
 
-    if let Some(items) = input_items {
-        for item in items {
+    {
+        for item in &input_items {
             let item_type = responses_input_item_type(item);
             if item_type == "custom_tool_call"
                 && item.get("status").and_then(|v| v.as_str()) == Some("incomplete")
@@ -5219,21 +5721,25 @@ fn convert_codex_to_openai_request(mut body: Value) -> Value {
         }
     }
 
-    if let Some(items) = input_items {
+    {
         let mut seen_apply_patch_failures = std::collections::HashSet::new();
         let mut apply_patch_failure_distinct_count = 0usize;
-        for item in items {
-            let item_type = responses_input_item_type(item);
+        for mut item in input_items {
+            let item_type = responses_input_item_type(&item).to_string();
             let step_marker = step_markers.pop_front();
             if item_type == "custom_tool_call"
                 && item.get("status").and_then(|v| v.as_str()) == Some("incomplete")
             {
                 continue;
             }
-            match item_type {
+            match item_type.as_str() {
                 "message" => {
-                    let role = item.get("role").and_then(|v| v.as_str()).unwrap_or("user");
-                    let (text_parts, image_parts) = responses_message_parts(item);
+                    let role = item
+                        .get("role")
+                        .and_then(Value::as_str)
+                        .unwrap_or("user")
+                        .to_string();
+                    let (text_parts, image_parts) = responses_message_parts(&mut item);
 
                     if image_parts.is_empty() {
                         let content = prefix_with_step_marker(step_marker, text_parts.join("\n"));
@@ -5318,9 +5824,10 @@ fn convert_codex_to_openai_request(mut body: Value) -> Value {
                     let call_id = item
                         .get("call_id")
                         .and_then(|v| v.as_str())
-                        .unwrap_or("unknown");
+                        .unwrap_or("unknown")
+                        .to_string();
                     if item_type == "custom_tool_call_output"
-                        && skipped_incomplete_custom_call_ids.contains(call_id)
+                        && skipped_incomplete_custom_call_ids.contains(&call_id)
                     {
                         tracing::warn!(
                             "Skipping output for incomplete custom tool call {}",
@@ -5328,21 +5835,10 @@ fn convert_codex_to_openai_request(mut body: Value) -> Value {
                         );
                         continue;
                     }
-                    let output = item.get("output");
-                    let mut output_str = if let Some(o) = output {
-                        if o.is_string() {
-                            o.as_str().unwrap().to_string()
-                        } else if let Some(content) = o.get("content").and_then(|v| v.as_str()) {
-                            content.to_string()
-                        } else {
-                            o.to_string()
-                        }
-                    } else {
-                        "".to_string()
-                    };
+                    let (mut output_str, output_media) = responses_tool_output_parts(&mut item);
 
-                    let name = match call_id_to_name.get(call_id).cloned().or_else(|| {
-                        get_cached_tool_call(call_id).and_then(|v| {
+                    let name = match call_id_to_name.get(&call_id).cloned().or_else(|| {
+                        get_cached_tool_call(&call_id).and_then(|v| {
                             v.get("name")
                                 .and_then(|n| n.as_str())
                                 .map(|s| s.to_string())
@@ -5367,12 +5863,14 @@ fn convert_codex_to_openai_request(mut body: Value) -> Value {
                         );
                     }
                     output_str = prefix_with_step_marker(step_marker, output_str);
+                    let output_content =
+                        build_responses_tool_output_content(output_str, output_media);
 
                     messages.push(json!({
                         "role": "tool",
                         "tool_call_id": call_id,
                         "name": name,
-                        "content": output_str
+                        "content": output_content
                     }));
                 }
                 _ => {}
@@ -5394,10 +5892,11 @@ fn convert_codex_to_openai_request(mut body: Value) -> Value {
     }
 
     if let Some(obj) = body.as_object_mut() {
-        obj.insert("messages".to_string(), json!(messages));
+        obj.insert("messages".to_string(), Value::Array(messages));
         if let Some(ledger) = interaction_ledger {
             obj.insert("_interaction_ledger".to_string(), json!(ledger));
         }
+        obj.remove("input");
         obj.remove("instructions");
     }
     body

--- a/src-tauri/src/proxy/http_session_store.rs
+++ b/src-tauri/src/proxy/http_session_store.rs
@@ -81,7 +81,7 @@ pub async fn append_outputs(response_id: &str, new_outputs: Vec<Value>) {
 pub fn merge_history_with_new_input(
     mut history: Vec<Value>,
     response_output: &[Value],
-    new_input: &[Value],
+    new_input: Vec<Value>,
     tool_call_cache: &HashMap<String, Value>,
 ) -> Vec<Value> {
     // 检测新输入中是否包含 compaction / compaction_summary，如果包含，说明客户端正在发送压缩后的全新完整历史
@@ -102,7 +102,7 @@ pub fn merge_history_with_new_input(
             if t == "compaction" || t == "compaction_summary" {
                 continue;
             }
-            filtered.push(item.clone());
+            filtered.push(item);
         }
         repair_tool_calls(&mut filtered, tool_call_cache);
         return dedupe_input_items(filtered);
@@ -119,7 +119,7 @@ pub fn merge_history_with_new_input(
         if t == "compaction" || t == "compaction_summary" {
             continue;
         }
-        history.push(item.clone());
+        history.push(item);
     }
 
     // 修复工具调用（确保function_call_output前有对应的function_call）

--- a/src-tauri/src/proxy/http_session_store.rs
+++ b/src-tauri/src/proxy/http_session_store.rs
@@ -5,7 +5,7 @@
 use crate::proxy::handlers::openai::get_cached_tool_call;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
@@ -23,8 +23,25 @@ pub struct HttpSessionEntry {
     pub last_accessed: Instant,
 }
 
+#[derive(Debug)]
+struct SessionNode {
+    parent: Option<Arc<SessionNode>>,
+    input_delta: Vec<Value>,
+    response_output: Vec<Value>,
+    instructions: String,
+    model: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionParent(Arc<SessionNode>);
+
+struct StoredSession {
+    node: Arc<SessionNode>,
+    last_accessed: Instant,
+}
+
 struct HttpSessionStore {
-    sessions: HashMap<String, HttpSessionEntry>,
+    sessions: HashMap<String, StoredSession>,
 }
 
 impl HttpSessionStore {
@@ -34,22 +51,83 @@ impl HttpSessionStore {
         }
     }
 
-    fn get(&mut self, response_id: &str) -> Option<HttpSessionEntry> {
-        let entry = self.sessions.get_mut(response_id)?;
-        entry.last_accessed = Instant::now();
-        Some(entry.clone())
+    fn get(&mut self, response_id: &str) -> Option<(HttpSessionEntry, SessionParent)> {
+        let stored = self.sessions.get_mut(response_id)?;
+        stored.last_accessed = Instant::now();
+        let node = stored.node.clone();
+        Some((
+            HttpSessionEntry {
+                input_items: materialize_history(&node),
+                instructions: node.instructions.clone(),
+                model: node.model.clone(),
+                last_accessed: stored.last_accessed,
+            },
+            SessionParent(node),
+        ))
     }
 
     fn insert(&mut self, response_id: String, entry: HttpSessionEntry) {
-        self.sessions.insert(response_id, entry);
+        self.insert_delta(
+            response_id,
+            None,
+            entry.input_items,
+            Vec::new(),
+            entry.instructions,
+            entry.model,
+        );
+    }
+
+    fn insert_delta(
+        &mut self,
+        response_id: String,
+        parent: Option<SessionParent>,
+        input_delta: Vec<Value>,
+        response_output: Vec<Value>,
+        instructions: String,
+        model: String,
+    ) {
+        self.sessions.insert(
+            response_id,
+            StoredSession {
+                node: Arc::new(SessionNode {
+                    parent: parent.map(|parent| parent.0),
+                    input_delta,
+                    response_output,
+                    instructions,
+                    model,
+                }),
+                last_accessed: Instant::now(),
+            },
+        );
         // 顺便淘汰过期 session（惰性清理）
         self.evict_expired();
     }
 
     fn evict_expired(&mut self) {
         let ttl = Duration::from_secs(SESSION_TTL_SECS);
-        self.sessions.retain(|_, v| v.last_accessed.elapsed() < ttl);
+        self.sessions
+            .retain(|_, stored| stored.last_accessed.elapsed() < ttl);
     }
+}
+
+fn materialize_history(node: &Arc<SessionNode>) -> Vec<Value> {
+    let mut chain = Vec::new();
+    let mut current = Some(node.clone());
+    while let Some(node) = current {
+        chain.push(node.clone());
+        current = node.parent.clone();
+    }
+
+    let capacity = chain
+        .iter()
+        .map(|node| node.input_delta.len() + node.response_output.len())
+        .sum();
+    let mut history = Vec::with_capacity(capacity);
+    for node in chain.into_iter().rev() {
+        history.extend(node.input_delta.iter().cloned());
+        history.extend(node.response_output.iter().cloned());
+    }
+    history
 }
 
 static STORE: OnceLock<Mutex<HttpSessionStore>> = OnceLock::new();
@@ -60,6 +138,16 @@ fn store() -> &'static Mutex<HttpSessionStore> {
 
 /// 根据 previous_response_id 查找历史会话
 pub async fn get_session(previous_response_id: &str) -> Option<HttpSessionEntry> {
+    store()
+        .lock()
+        .await
+        .get(previous_response_id)
+        .map(|(entry, _)| entry)
+}
+
+pub async fn get_session_with_parent(
+    previous_response_id: &str,
+) -> Option<(HttpSessionEntry, SessionParent)> {
     store().lock().await.get(previous_response_id)
 }
 
@@ -68,10 +156,78 @@ pub async fn save_session(response_id: String, entry: HttpSessionEntry) {
     store().lock().await.insert(response_id, entry);
 }
 
-/// 追加本轮模型输出项到会话历史中
-pub async fn append_outputs(response_id: &str, new_outputs: Vec<Value>) {
-    if let Some(entry) = store().lock().await.sessions.get_mut(response_id) {
-        entry.input_items.extend(new_outputs);
+/// 保存 Responses 本轮增量；父节点的 Arc 强引用保证分支共享祖先。
+pub async fn save_session_delta(
+    response_id: String,
+    parent: Option<SessionParent>,
+    input_delta: Vec<Value>,
+    response_output: Vec<Value>,
+    instructions: String,
+    model: String,
+) {
+    store().lock().await.insert_delta(
+        response_id,
+        parent,
+        input_delta,
+        response_output,
+        instructions,
+        model,
+    );
+}
+
+pub struct PreparedSessionInput {
+    pub merged: Vec<Value>,
+    pub delta: Vec<Value>,
+    pub reset_parent: bool,
+}
+
+/// 合并请求历史，并在客户端回放完整历史时仅提取新增项。
+pub fn prepare_session_input(
+    history: Vec<Value>,
+    new_input: Vec<Value>,
+    tool_call_cache: &HashMap<String, Value>,
+) -> PreparedSessionInput {
+    let reset_parent = new_input.iter().any(|item| {
+        matches!(
+            item.get("type").and_then(Value::as_str),
+            Some("compaction") | Some("compaction_summary")
+        )
+    });
+    let exact_replay = !history.is_empty() && new_input.starts_with(&history);
+    let replayed_through = if reset_parent || exact_replay {
+        None
+    } else {
+        let history_ids: std::collections::HashSet<&str> = history
+            .iter()
+            .filter_map(|item| item.get("id").and_then(Value::as_str))
+            .filter(|id| !id.is_empty())
+            .collect();
+        new_input.iter().rposition(|item| {
+            item.get("id")
+                .and_then(Value::as_str)
+                .is_some_and(|id| history_ids.contains(id))
+        })
+    };
+    let delta_source = if reset_parent || history.is_empty() {
+        new_input.clone()
+    } else if exact_replay {
+        new_input[history.len()..].to_vec()
+    } else if let Some(index) = replayed_through {
+        new_input[index + 1..].to_vec()
+    } else {
+        new_input.clone()
+    };
+    let delta = merge_history_with_new_input(Vec::new(), &[], delta_source, tool_call_cache);
+    let merged = if reset_parent || history.is_empty() {
+        delta.clone()
+    } else {
+        merge_history_with_new_input(history, &[], delta.clone(), tool_call_cache)
+    };
+
+    PreparedSessionInput {
+        merged,
+        delta,
+        reset_parent,
     }
 }
 
@@ -217,4 +373,80 @@ fn dedupe_input_items(items: Vec<Value>) -> Vec<Value> {
         filtered.push(item);
     }
     filtered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn entry(text: &str) -> HttpSessionEntry {
+        HttpSessionEntry {
+            input_items: vec![json!({
+                "id": format!("msg-{text}"),
+                "type": "message",
+                "role": "user",
+                "content": text
+            })],
+            instructions: "be concise".to_string(),
+            model: "gemini-3.7-flash-high".to_string(),
+            last_accessed: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn session_chain_stores_delta_and_materializes_history() {
+        let mut store = HttpSessionStore::new();
+        store.insert("resp-1".to_string(), entry("first"));
+        let (root, parent) = store.get("resp-1").expect("root");
+        let mut replay = root.input_items.clone();
+        replay.push(json!({"id": "msg-second", "content": "second"}));
+        let prepared = prepare_session_input(root.input_items, replay, &HashMap::new());
+        assert_eq!(prepared.delta.len(), 1);
+        assert_eq!(prepared.merged.len(), 2);
+        store.insert_delta(
+            "resp-2".to_string(),
+            Some(parent),
+            prepared.delta,
+            vec![json!({"id": "out-second", "content": "answer"})],
+            "be concise".to_string(),
+            "gemini-3.7-flash-high".to_string(),
+        );
+
+        let (previous, _) = store.get("resp-2").expect("child");
+        assert_eq!(previous.input_items[0]["content"], "first");
+        assert_eq!(previous.input_items.len(), 3);
+        assert_eq!(store.sessions["resp-2"].node.input_delta.len(), 1);
+        assert_eq!(store.sessions["resp-2"].node.response_output.len(), 1);
+    }
+
+    #[test]
+    fn old_response_id_branches_share_parent() {
+        let mut store = HttpSessionStore::new();
+        store.insert("resp-root".to_string(), entry("root"));
+        let (_, parent_a) = store.get("resp-root").expect("parent a");
+        let (_, parent_b) = store.get("resp-root").expect("parent b");
+        assert!(Arc::ptr_eq(&parent_a.0, &parent_b.0));
+
+        store.insert_delta(
+            "resp-a".to_string(),
+            Some(parent_a),
+            vec![json!({"content": "branch a"})],
+            Vec::new(),
+            String::new(),
+            String::new(),
+        );
+        store.insert_delta(
+            "resp-b".to_string(),
+            Some(parent_b),
+            vec![json!({"content": "branch b"})],
+            Vec::new(),
+            String::new(),
+            String::new(),
+        );
+
+        let parent_a = store.sessions["resp-a"].node.parent.as_ref().unwrap();
+        let parent_b = store.sessions["resp-b"].node.parent.as_ref().unwrap();
+        assert!(Arc::ptr_eq(parent_a, parent_b));
+    }
 }

--- a/src-tauri/src/proxy/mappers/common_utils.rs
+++ b/src-tauri/src/proxy/mappers/common_utils.rs
@@ -159,6 +159,23 @@ pub fn parse_image_config(model_name: &str) -> (Value, String) {
     parse_image_config_with_params(model_name, None, None, None)
 }
 
+/// Parse image configuration while rejecting an explicit, unsupported `imageSize` value.
+/// API handlers should use this variant so invalid client input becomes a boundary error.
+pub fn try_parse_image_config_with_params(
+    model_name: &str,
+    size: Option<&str>,
+    quality: Option<&str>,
+    image_size: Option<&str>,
+) -> Result<(Value, String), String> {
+    let image_size = normalize_image_size(image_size)?;
+    Ok(parse_image_config_with_normalized_params(
+        model_name,
+        size,
+        quality,
+        image_size,
+    ))
+}
+
 /// Extended version that accepts OpenAI size and quality parameters
 ///
 /// This function supports parsing image configuration from:
@@ -180,11 +197,23 @@ pub fn parse_image_config_with_params(
     quality: Option<&str>,
     image_size: Option<&str>,
 ) -> (Value, String) {
+    // Legacy internal callers cannot return an HTTP boundary error. Invalid explicit values are
+    // ignored here; public API handlers use `try_parse_image_config_with_params` instead.
+    let image_size = normalize_image_size(image_size).ok().flatten();
+    parse_image_config_with_normalized_params(model_name, size, quality, image_size)
+}
+
+fn parse_image_config_with_normalized_params(
+    model_name: &str,
+    size: Option<&str>,
+    quality: Option<&str>,
+    image_size: Option<&'static str>,
+) -> (Value, String) {
     let mut aspect_ratio = "1:1";
 
     // 1. 优先从 size 参数解析宽高比
-    if let Some(s) = size {
-        aspect_ratio = calculate_aspect_ratio_from_size(s);
+    if let Some(parsed_ratio) = size.and_then(image_aspect_ratio_from_size) {
+        aspect_ratio = parsed_ratio;
     } else {
         // 2. 回退到模型后缀解析（保持向后兼容）
         if model_name.contains("-21x9") || model_name.contains("-21-9") {
@@ -214,32 +243,24 @@ pub fn parse_image_config_with_params(
     config.insert("aspectRatio".to_string(), json!(aspect_ratio));
 
     // [NEW] 0. 最高优先级：直接使用 image_size 参数
-    if let Some(is) = image_size {
-        config.insert("imageSize".to_string(), json!(is.to_uppercase()));
+    if let Some(image_size) = image_size {
+        config.insert("imageSize".to_string(), json!(image_size));
     } else {
         // 3. 优先从 quality 参数解析分辨率
-        if let Some(q) = quality {
-            match q.to_lowercase().as_str() {
-                "hd" | "4k" => {
-                    config.insert("imageSize".to_string(), json!("4K"));
-                }
-                "medium" | "2k" => {
-                    config.insert("imageSize".to_string(), json!("2K"));
-                }
-                "standard" | "1k" => {
-                    config.insert("imageSize".to_string(), json!("1K"));
-                }
-                _ => {} // 其他值不设置，使用默认
-            }
+        if let Some(image_size) = quality.and_then(image_size_from_quality) {
+            config.insert("imageSize".to_string(), json!(image_size));
         } else {
             // 4. 回退到模型后缀解析（保持向后兼容）
             let is_hd = model_name.contains("-4k") || model_name.contains("-hd");
             let is_2k = model_name.contains("-2k");
+            let is_1k = model_name.contains("-1k") || model_name.contains("-standard");
 
             if is_hd {
                 config.insert("imageSize".to_string(), json!("4K"));
             } else if is_2k {
                 config.insert("imageSize".to_string(), json!("2K"));
+            } else if is_1k {
+                config.insert("imageSize".to_string(), json!("1K"));
             }
         }
     }
@@ -247,6 +268,33 @@ pub fn parse_image_config_with_params(
     let clean_model_name = clean_image_model_name(model_name);
 
     (serde_json::Value::Object(config), clean_model_name)
+}
+
+fn normalize_image_size(image_size: Option<&str>) -> Result<Option<&'static str>, String> {
+    let Some(image_size) = image_size.map(str::trim) else {
+        return Ok(None);
+    };
+
+    if image_size.is_empty() || image_size.eq_ignore_ascii_case("auto") {
+        return Ok(None);
+    }
+
+    match image_size.to_ascii_lowercase().as_str() {
+        "1k" => Ok(Some("1K")),
+        "2k" => Ok(Some("2K")),
+        "4k" => Ok(Some("4K")),
+        _ => Err("Invalid image_size: expected one of 1K, 2K, 4K, or auto".to_string()),
+    }
+}
+
+fn image_size_from_quality(quality: &str) -> Option<&'static str> {
+    match quality.trim().to_ascii_lowercase().as_str() {
+        "low" | "standard" | "1k" => Some("1K"),
+        "medium" | "2k" => Some("2K"),
+        "high" | "hd" | "4k" => Some("4K"),
+        "auto" | "" => None,
+        _ => None,
+    }
 }
 
 /// Helper function to clean image model names by removing resolution/aspect-ratio suffixes.
@@ -309,19 +357,24 @@ fn clean_image_model_name(model_name: &str) -> String {
 ///
 /// # Returns
 /// 标准宽高比字符串 ("1:1", "16:9", "9:16", "4:3", "3:4", "21:9")
-fn calculate_aspect_ratio_from_size(size: &str) -> &'static str {
+pub fn image_aspect_ratio_from_size(size: &str) -> Option<&'static str> {
+    let size = size.trim();
+    if size.is_empty() || size.eq_ignore_ascii_case("auto") {
+        return None;
+    }
+
     // 0. Explicitly check known aspect ratios first
     match size {
-        "21:9" => return "21:9",
-        "16:9" => return "16:9",
-        "9:16" => return "9:16",
-        "4:3" => return "4:3",
-        "3:4" => return "3:4",
-        "3:2" => return "3:2",
-        "2:3" => return "2:3",
-        "5:4" => return "5:4",
-        "4:5" => return "4:5",
-        "1:1" => return "1:1",
+        "21:9" => return Some("21:9"),
+        "16:9" => return Some("16:9"),
+        "9:16" => return Some("9:16"),
+        "4:3" => return Some("4:3"),
+        "3:4" => return Some("3:4"),
+        "3:2" => return Some("3:2"),
+        "2:3" => return Some("2:3"),
+        "5:4" => return Some("5:4"),
+        "4:5" => return Some("4:5"),
+        "1:1" => return Some("1:1"),
         _ => {}
     }
 
@@ -332,40 +385,44 @@ fn calculate_aspect_ratio_from_size(size: &str) -> &'static str {
 
                 // 容差匹配常见比例（容差 0.05，避免 3:4 和 2:3 重叠）
                 if (ratio - 21.0 / 9.0).abs() < 0.05 {
-                    return "21:9";
+                    return Some("21:9");
                 }
                 if (ratio - 16.0 / 9.0).abs() < 0.05 {
-                    return "16:9";
+                    return Some("16:9");
                 }
                 if (ratio - 4.0 / 3.0).abs() < 0.05 {
-                    return "4:3";
+                    return Some("4:3");
                 }
                 if (ratio - 3.0 / 4.0).abs() < 0.05 {
-                    return "3:4";
+                    return Some("3:4");
                 }
                 if (ratio - 9.0 / 16.0).abs() < 0.05 {
-                    return "9:16";
+                    return Some("9:16");
                 }
                 if (ratio - 3.0 / 2.0).abs() < 0.05 {
-                    return "3:2";
+                    return Some("3:2");
                 }
                 if (ratio - 2.0 / 3.0).abs() < 0.05 {
-                    return "2:3";
+                    return Some("2:3");
                 }
                 if (ratio - 5.0 / 4.0).abs() < 0.05 {
-                    return "5:4";
+                    return Some("5:4");
                 }
                 if (ratio - 4.0 / 5.0).abs() < 0.05 {
-                    return "4:5";
+                    return Some("4:5");
                 }
                 if (ratio - 1.0).abs() < 0.05 {
-                    return "1:1";
+                    return Some("1:1");
                 }
             }
         }
     }
 
-    "1:1" // 默认回退
+    None
+}
+
+fn calculate_aspect_ratio_from_size(size: &str) -> &'static str {
+    image_aspect_ratio_from_size(size).unwrap_or("1:1")
 }
 
 /// Inject current googleSearch tool and ensure no duplicate legacy search tools
@@ -887,6 +944,79 @@ mod tests {
         );
         assert_eq!(config_3["imageSize"], "4K");
         assert_eq!(config_3["aspectRatio"], "16:9");
+    }
+
+    #[test]
+    fn image_quality_aliases_map_to_unified_image_sizes() {
+        let cases = [
+            ("low", "1K"),
+            ("standard", "1K"),
+            ("1k", "1K"),
+            ("medium", "2K"),
+            ("2k", "2K"),
+            ("high", "4K"),
+            ("hd", "4K"),
+            ("4k", "4K"),
+        ];
+        for (quality, expected) in cases {
+            let (config, _) = try_parse_image_config_with_params(
+                "gemini-3.1-flash-image",
+                None,
+                Some(quality),
+                None,
+            )
+            .expect("quality alias must parse");
+            assert_eq!(config["imageSize"], expected, "quality={quality}");
+        }
+    }
+
+    #[test]
+    fn image_size_priority_and_auto_fallback_are_enforced() {
+        let (explicit, _) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image-1k",
+            None,
+            Some("high"),
+            Some("2k"),
+        )
+        .expect("case-insensitive explicit image size");
+        assert_eq!(explicit["imageSize"], "2K");
+
+        let (quality, _) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image-1k",
+            None,
+            Some("medium"),
+            None,
+        )
+        .expect("quality overrides suffix");
+        assert_eq!(quality["imageSize"], "2K");
+
+        for quality in [Some("auto"), Some(""), None] {
+            let (fallback, _) = try_parse_image_config_with_params(
+                "gemini-3.1-flash-image-4k",
+                None,
+                quality,
+                Some("auto"),
+            )
+            .expect("auto values fall back to suffix");
+            assert_eq!(fallback["imageSize"], "4K");
+        }
+
+        let (upstream_default, _) = try_parse_image_config_with_params(
+            "gemini-3.1-flash-image",
+            None,
+            Some("auto"),
+            None,
+        )
+        .expect("auto without suffix uses upstream default");
+        assert!(upstream_default.get("imageSize").is_none());
+
+        assert!(try_parse_image_config_with_params(
+            "gemini-3.1-flash-image",
+            None,
+            None,
+            Some("8K"),
+        )
+        .is_err());
     }
 }
 

--- a/src-tauri/src/proxy/mappers/openai/request.rs
+++ b/src-tauri/src/proxy/mappers/openai/request.rs
@@ -186,10 +186,32 @@ pub fn transform_openai_request(
     mapped_model: &str,
     token: Option<&ProxyToken>,
 ) -> (Value, String, usize, String) {
-    let original_request_value = serde_json::to_value(request).ok();
-    crate::proxy::adapters::apply_patch_preflight::remember_cwd_from_request(
-        original_request_value.as_ref(),
-    );
+    let remember_cwd =
+        |text: &str| crate::proxy::adapters::apply_patch_preflight::remember_cwd_from_text(text);
+    let found_cwd = request.instructions.as_deref().is_some_and(remember_cwd);
+    if !found_cwd {
+        'messages: for message in &request.messages {
+            let Some(content) = &message.content else {
+                continue;
+            };
+            match content {
+                OpenAIContent::String(text) => {
+                    if remember_cwd(text) {
+                        break 'messages;
+                    }
+                }
+                OpenAIContent::Array(blocks) => {
+                    for block in blocks {
+                        if let OpenAIContentBlock::Text { text } = block {
+                            if remember_cwd(text) {
+                                break 'messages;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     let session_id =
         crate::proxy::session_manager::SessionManager::extract_openai_session_id(request);

--- a/src-tauri/src/proxy/mappers/openai/streaming.rs
+++ b/src-tauri/src/proxy/mappers/openai/streaming.rs
@@ -552,26 +552,23 @@ pub fn create_codex_sse_stream<S, E>(
     session_id: String,
     message_count: usize,
     _assistant_turn_index: usize,
+    response_id: String,
+    completion_tx: Option<
+        tokio::sync::oneshot::Sender<(Vec<Value>, tokio::sync::oneshot::Sender<()>)>,
+    >,
 ) -> Pin<Box<dyn Stream<Item = Result<Bytes, String>> + Send>>
 where
     S: Stream<Item = Result<Bytes, E>> + Send + ?Sized + 'static,
     E: std::fmt::Display + Send + 'static,
 {
     let mut buffer = BytesMut::new();
-    let charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    let mut rng = rand::thread_rng();
-    let random_str: String = (0..24)
-        .map(|_| {
-            let idx = rng.gen_range(0..charset.len());
-            charset.chars().nth(idx).unwrap()
-        })
-        .collect();
-    let response_id = format!("resp-{}", random_str);
-    let message_item_id = format!("msg_{}_0", &random_str[..16]);
+    let item_id_prefix = uuid::Uuid::new_v4().simple().to_string();
+    let message_item_id = format!("msg_{}_0", &item_id_prefix[..16]);
     let created_at = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
+    let mut completion_tx = completion_tx;
     let stream = async_stream::stream! {
         let mut sequence_number: u64 = 0;
 
@@ -715,7 +712,11 @@ where
                                                                     if !reasoning_open {
                                                                         reasoning_output_index = next_output_index;
                                                                         next_output_index += 1;
-                                                                        active_reasoning_item_id = format!("msg_thought_{}_{}", &random_str[..16], reasoning_item_seq);
+                                                                        active_reasoning_item_id = format!(
+                                                                            "msg_thought_{}_{}",
+                                                                            &item_id_prefix[..16],
+                                                                            reasoning_item_seq
+                                                                        );
                                                                         reasoning_item_seq += 1;
                                                                         accumulated_thinking.clear();
 
@@ -1179,6 +1180,15 @@ where
             .unwrap_or_default()
             .as_secs();
 
+        if terminal_status == "completed" {
+            if let Some(tx) = completion_tx.take() {
+                let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+                if tx.send((final_outputs.clone(), ack_tx)).is_err() || ack_rx.await.is_err() {
+                    return;
+                }
+            }
+        }
+
         let mut completed_ev = json!({
             "type": terminal_type,
             "response": {
@@ -1238,6 +1248,8 @@ mod tests {
             "test-codex-session".to_string(),
             0,
             0,
+            "resp-test-codex-session".to_string(),
+            None,
         );
 
         let mut raw = String::new();
@@ -1250,6 +1262,62 @@ mod tests {
             .filter_map(|data| serde_json::from_str::<Value>(data).ok())
             .collect();
         (raw, events)
+    }
+
+    #[tokio::test]
+    async fn codex_response_id_matches_saved_session_key() {
+        let response_id = format!("resp-test-{}", uuid::Uuid::new_v4());
+        let upstream = vec![Ok::<Bytes, String>(Bytes::from(
+            "data: {\"response\":{\"candidates\":[{\"finishReason\":\"STOP\",\"content\":{\"parts\":[{\"text\":\"done\"}]}}]}}\n\n",
+        ))];
+        let (completion_tx, completion_rx) =
+            tokio::sync::oneshot::channel::<(Vec<Value>, tokio::sync::oneshot::Sender<()>)>();
+        let save_response_id = response_id.clone();
+        let save_task = tokio::spawn(async move {
+            let (outputs, ack_tx) = completion_rx.await.expect("completed output");
+            crate::proxy::http_session_store::save_session_delta(
+                save_response_id,
+                None,
+                vec![json!({"id": "user-1", "role": "user", "content": "hello"})],
+                outputs,
+                String::new(),
+                "gemini-pro-agent".to_string(),
+            )
+            .await;
+            ack_tx.send(()).expect("acknowledge session save");
+        });
+        let mut stream = create_codex_sse_stream(
+            Box::pin(stream::iter(upstream)),
+            "gemini-pro-agent".to_string(),
+            "test-session".to_string(),
+            1,
+            0,
+            response_id.clone(),
+            Some(completion_tx),
+        );
+
+        let mut raw = String::new();
+        let mut saw_completed = false;
+        while let Some(item) = stream.next().await {
+            let item = item.expect("stream item");
+            let text = String::from_utf8_lossy(&item);
+            if text.contains("event: response.completed") {
+                saw_completed = true;
+                let restored = crate::proxy::http_session_store::get_session(&response_id)
+                    .await
+                    .expect("session exists when response.completed is visible");
+                assert_eq!(restored.input_items[0]["id"], "user-1");
+                assert!(restored
+                    .input_items
+                    .iter()
+                    .any(|item| item["role"] == "assistant"));
+            }
+            raw.push_str(&text);
+        }
+        save_task.await.expect("session save task");
+
+        assert!(saw_completed);
+        assert!(raw.contains(&format!("\"id\":\"{response_id}\"")));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Make streaming HTTP Responses IDs address the sessions actually saved under those IDs, and replace full-history copies with a persistent parent-linked session graph that supports branching, replay deltas, misses, and compaction.

Closes #3356.

Depends on #3365 for bounded Responses media handling. This is a stacked PR; its new behavior is contained in one independent commit and the displayed diff will narrow after the prerequisite PR merges.

## Changes

- Generate one response ID in the HTTP handler and pass it to both the Responses SSE converter and the session save path.
- Return completed output from the converter to the save task and wait for the save acknowledgement before emitting `response.completed`.
- Save sessions only after a completed streaming response, including the model output needed by the next turn.
- Store each session as an immutable parent-linked node containing only the current input delta and response output.
- Materialize the full history on lookup while allowing multiple children to share the same parent node.
- Detect full replay and the last overlapping item ID so a client replay stores only new items.
- Treat an unknown `previous_response_id` as a new root using the supplied input.
- Treat `compaction` and `compaction_summary` as history replacement, remove the marker, and clear the parent link.
- Continue stripping historical inline media from stored deltas and completed output through the bounded-media helpers from the prerequisite PR.

## Files

- `src-tauri/src/proxy/handlers/openai.rs`
- `src-tauri/src/proxy/http_session_store.rs`
- `src-tauri/src/proxy/mappers/openai/streaming.rs`

## Tests

- `cargo test --manifest-path src-tauri/Cargo.toml --offline --lib session`
- Result: 8 passed, 0 failed.
- Direct coverage includes matching the emitted response ID to the saved session key, storing and materializing parent-linked deltas, and branching twice from an older response ID while sharing its parent.
- `cargo test --manifest-path src-tauri/Cargo.toml --offline --lib proxy::handlers::openai::stream_peek_tests`
- Result: 19 passed, 0 failed.
- `git diff --check` passed.

## Compatibility

- The existing in-memory one-hour session TTL remains unchanged.
- Unknown previous IDs fall back to a new root instead of rejecting otherwise valid supplied input.
- Full replay and compaction behavior is scoped to streaming HTTP Responses in this PR. WebSocket transcript replacement retains its existing compatibility path.
- Non-streaming Responses persistence is unchanged and is not claimed as covered here.
- The save acknowledgement establishes completed-session consistency. Disconnect-aware cancellation of a pending save is intentionally left to the following PR.
