### PR TITLE
fix(opencode): add Claude Opus 4.5/4.6 base variants with thinking

### DIFF
--- a/src-tauri/src/proxy/opencode_sync.rs
+++ b/src-tauri/src/proxy/opencode_sync.rs
@@ -95,8 +95,28 @@ fn build_model_catalog() -> Vec<ModelDef> {
             variant_type: Some(VariantType::ClaudeThinking),
         },
         ModelDef {
+            id: "claude-opus-4-5",
+            name: "Claude Opus 4.5",
+            context_limit: 200_000,
+            output_limit: 64_000,
+            input_modalities: &["text", "image", "pdf"],
+            output_modalities: &["text"],
+            reasoning: true,
+            variant_type: Some(VariantType::ClaudeThinking),
+        },
+        ModelDef {
             id: "claude-opus-4-5-thinking",
             name: "Claude Opus 4.5 Thinking",
+            context_limit: 200_000,
+            output_limit: 64_000,
+            input_modalities: &["text", "image", "pdf"],
+            output_modalities: &["text"],
+            reasoning: true,
+            variant_type: Some(VariantType::ClaudeThinking),
+        },
+        ModelDef {
+            id: "claude-opus-4-6",
+            name: "Claude Opus 4.6",
             context_limit: 200_000,
             output_limit: 64_000,
             input_modalities: &["text", "image", "pdf"],
@@ -1060,11 +1080,11 @@ fn build_variants_object(variant_type: Option<VariantType>) -> Option<Value> {
                 "low".to_string(),
                 build_gemini3_effort_variant(VariantTier::Low),
             );
+            variants.insert("medium".to_string(), serde_json::json!({ "disabled": true }));
             variants.insert(
                 "high".to_string(),
                 build_gemini3_effort_variant(VariantTier::High),
             );
-            variants.insert("medium".to_string(), serde_json::json!({ "disabled": true }));
             variants.insert("max".to_string(), serde_json::json!({ "disabled": true }));
             Some(Value::Object(variants))
         }


### PR DESCRIPTION
## Description
Ensures OpenCode sync exposes thinking variants for Claude Opus base models, matching the existing Claude Sonnet behavior.

## Problem
`build_model_catalog` only defined `claude-opus-4-5-thinking` and `claude-opus-4-6-thinking` with `ClaudeThinking` variants. Syncing the base ids `claude-opus-4-5` / `claude-opus-4-6` (the ids shown by default in OpenCode) produced no `variants` object, so the dropdown showed without thinking options while `claude-sonnet-4-6` correctly showed `Low / Medium / High / Max`.

Additionally, `Gemini3Pro` variants were inserted as `low -> high -> medium` which rendered in the UI as `High` before `Low`/`Medium` due to `preserve_order` JSON serialization.

## Changes
- `opencode_sync.rs: build_model_catalog`: add `claude-opus-4-5` and `claude-opus-4-6` base entries with `variant_type: ClaudeThinking` so both base and `-thinking` ids expose `low/medium/high/max` via `build_claude_thinking_variant`.
- `opencode_sync.rs: build_variants_object`: reorder `Gemini3Pro` to `low -> medium(disabled) -> high -> max(disabled)` for consistent `Default -> Low -> Medium -> High` ordering.

## Validation
- `cargo check` 0 errors
- Existing unit and integration tests unaffected (catalog order change only affects generated `opencode.json`)
