### PR TITLE
fix(linux): niri/Hyprland 上不再强制 X11，避免 WebKit 窗口全黑

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 > 完整版本历史记录。返回项目主页请查看 [README.md](README.md) | [English Changelog](CHANGELOG_EN.md)。
 
 *   **版本演进**:
+    *   **Unreleased**:
+        -   **[Linux 修复] niri / Hyprland 等合成器上窗口全黑 (Issue #3388)**:
+            -   **不再仅因存在 DISPLAY 就强制 GDK_BACKEND=x11**: niri / Hyprland / sway / river / labwc / wayfire 常年挂着 Xwayland，被强制进 X11 后 WebKitGTK 主界面全黑。这些合成器改为保持原生 Wayland；GNOME / KDE 的历史 X11 回退不变。
+            -   **按需关闭 WebKit DMA-BUF**: 在 Wayland 且（上述合成器或本机加载了 NVIDIA 专有驱动）时，若用户未自行设置，则自动 `WEBKIT_DISABLE_DMABUF_RENDERER=1`。GNOME + AMD/Intel 仍走快路径。已有环境变量一律不覆盖。
     *   **v4.6.7 (2026-09-04)**:
         -   **[核心修复] 彻底修复多轮 Agent 对话上下文异常膨胀与 Session 历史重复追加 BUG (Issue #3382)**:
             -   **解除工具调用历史消息的思考链压缩阻断**: 修复此前因 `!has_tool_calls` 守卫过于严格，导致 OpenClaw 等工具调用密集的 Agent 场景下历史 Assistant 消息的长思考文本（`reasoning_content`）完全无法被压缩的问题。允许在保留合法工具调用及其 `thoughtSignature` 前提下，将历史长思考精简为占位符 `...`，彻底释放数十万 Token 的冗余负担并确保 Google API 签名验证正常通过。

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -3,6 +3,10 @@
 > Complete version history for Antigravity Tools. Return to project home at [README_EN.md](README_EN.md).
 
 *   **Version History**:
+    *   **Unreleased**:
+        -   **[Linux] Black window on niri / Hyprland (Issue #3388)**:
+            -   **Do not force `GDK_BACKEND=x11` just because `DISPLAY` is set**: niri / Hyprland / sway / river / labwc / wayfire always expose Xwayland, and forcing X11 makes the WebKitGTK UI go black. Those compositors keep native Wayland; the historical GNOME / KDE X11 fallback is unchanged.
+            -   **Disable WebKit DMA-BUF only when needed**: on Wayland, if the compositor is in that set or a proprietary NVIDIA driver is loaded, and the user has not set it, set `WEBKIT_DISABLE_DMABUF_RENDERER=1`. GNOME + AMD/Intel keep the fast path. Existing env vars are never overridden.
     *   **v4.6.7 (2026-09-04)**:
         -   **[Core Fix] Fix Multi-Turn Agent Context Explosion & Session History Duplication BUG (Issue #3382)**:
             -   **Unblock Thinking Compression on Historical Assistant Messages with Tool Calls**: Fixed an issue where the strict `!has_tool_calls` check prevented compressing historical assistant `reasoning_content` in agent environments (e.g. OpenClaw) where almost every assistant turn contains tool calls. Allows pruning long thoughts down to placeholder `...` while fully preserving tool calls and their valid `thoughtSignature` tokens, eliminating token bloat and preventing upstream Google API 400 signature errors.

--- a/README.md
+++ b/README.md
@@ -250,6 +250,17 @@ Copyright © 2024-2026 [lbjlaq](https://github.com/lbjlaq)
 2.  **Homebrew 安装优势**:
     现在通过 Homebrew (`brew install --cask antigravity-tools`) 安装时，系统会在安装末尾自动执行清理属性的操作，**真正实现开箱即用**。
 
+#### Linux 窗口全黑 / 透明框？
+在 niri、Hyprland、Sway 等合成器上，旧版本会因为会话里总有 `DISPLAY` 而强制走 X11，WebKit 主界面可能全黑。请更新到包含该修复的版本；或临时：
+
+```bash
+env WEBKIT_DISABLE_DMABUF_RENDERER=1 ANTIGRAVITY_FORCE_WAYLAND=1 antigravity-tools
+```
+
+- `ANTIGRAVITY_FORCE_WAYLAND=1`：保持原生 Wayland（不要强制 `GDK_BACKEND=x11`）
+- `ANTIGRAVITY_FORCE_X11=1`：仍要 X11 时使用
+- `WEBKIT_DISABLE_DMABUF_RENDERER=1`：关掉 WebKit DMA-BUF 渲染器
+
 ## 🔌 快速接入示例
 
 ### 🔐 OAuth 授权流程（添加账号）

--- a/README_EN.md
+++ b/README_EN.md
@@ -239,6 +239,17 @@ Due to macOS security gatekeeper, non-App Store apps might show this. Run this i
 sudo xattr -rd com.apple.quarantine "/Applications/Antigravity Tools.app"
 ```
 
+#### Linux window is black or empty?
+On niri, Hyprland, Sway, and similar compositors, older builds forced `GDK_BACKEND=x11` whenever `DISPLAY` was set, and WebKit then drew a black window. Update to a build that includes this fix, or launch once with:
+
+```bash
+env WEBKIT_DISABLE_DMABUF_RENDERER=1 ANTIGRAVITY_FORCE_WAYLAND=1 antigravity-tools
+```
+
+- `ANTIGRAVITY_FORCE_WAYLAND=1`: keep native Wayland (do not force X11)
+- `ANTIGRAVITY_FORCE_X11=1`: force X11 if you still need it
+- `WEBKIT_DISABLE_DMABUF_RENDERER=1`: disable the WebKit DMA-BUF renderer
+
 ## 🔌 Quick Integration Examples
 
 ### 🔐 OAuth Authorization Flow (Add Account)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod commands;
 pub mod constants;
 pub mod error;
+mod linux_graphics;
 mod models;
 mod modules;
 mod proxy; // Proxy service module
@@ -82,23 +83,57 @@ fn credential_state(value: &str) -> &'static str {
 }
 
 #[cfg(target_os = "linux")]
-fn configure_linux_gdk_backend() {
-    if std::env::var("GDK_BACKEND").is_ok() {
-        return;
-    }
+fn nvidia_proprietary_loaded() -> bool {
+    std::path::Path::new("/dev/nvidia0").exists()
+        || std::path::Path::new("/proc/driver/nvidia/version").exists()
+}
+
+#[cfg(target_os = "linux")]
+fn configure_linux_graphics() {
+    use linux_graphics::{
+        desktop_is_wlroots_family, should_disable_webkit_dmabuf, should_force_x11_backend,
+    };
 
     let is_wayland = is_wayland_session();
     let has_x11_display = std::env::var("DISPLAY")
         .map(|v| !v.trim().is_empty())
         .unwrap_or(false);
+    let desktop = std::env::var("XDG_CURRENT_DESKTOP")
+        .unwrap_or_else(|_| std::env::var("XDG_SESSION_DESKTOP").unwrap_or_default());
     let force_wayland = env_flag_enabled("ANTIGRAVITY_FORCE_WAYLAND");
     let force_x11 = env_flag_enabled("ANTIGRAVITY_FORCE_X11");
+    let gdk_already_set = std::env::var("GDK_BACKEND").is_ok();
 
-    if force_x11 || (is_wayland && has_x11_display && !force_wayland) {
-        // Force X11 backend under Wayland sessions to avoid a GTK Wayland shm crash.
+    if should_force_x11_backend(
+        gdk_already_set,
+        force_x11,
+        force_wayland,
+        is_wayland,
+        has_x11_display,
+        &desktop,
+    ) {
+        // Force X11 backend under GNOME/KDE Wayland to avoid a GTK shm crash.
         std::env::set_var("GDK_BACKEND", "x11");
         warn!(
             "Forcing GDK_BACKEND=x11 for stability on Wayland. Set ANTIGRAVITY_FORCE_WAYLAND=1 to keep Wayland backend."
+        );
+    } else if is_wayland && !gdk_already_set && desktop_is_wlroots_family(&desktop) {
+        info!(
+            "Keeping native Wayland GDK backend on {} (Xwayland DISPLAY is not a reason to force X11).",
+            desktop
+        );
+    }
+
+    let webkit_already_set = std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_ok();
+    if should_disable_webkit_dmabuf(
+        webkit_already_set,
+        is_wayland,
+        nvidia_proprietary_loaded(),
+        &desktop,
+    ) {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        info!(
+            "WEBKIT_DISABLE_DMABUF_RENDERER=1 (WebKit DMA-BUF workaround on this Wayland setup). Set it yourself to override."
         );
     }
 }
@@ -211,7 +246,7 @@ pub fn run() {
     logger::init_logger();
 
     #[cfg(target_os = "linux")]
-    configure_linux_gdk_backend();
+    configure_linux_graphics();
 
     // Initialize token stats database
     if let Err(e) = modules::token_stats::init_db() {

--- a/src-tauri/src/linux_graphics.rs
+++ b/src-tauri/src/linux_graphics.rs
@@ -1,0 +1,143 @@
+//! Linux GDK / WebKit startup policy.
+//!
+//! niri / Hyprland / sway always expose an Xwayland `DISPLAY`. The old
+//! "Wayland + DISPLAY ⇒ force GDK_BACKEND=x11" rule then sends WebKitGTK
+//! down a path that draws a black window (issue #3388).
+//!
+//! This module is std-only so the decision table can be tested with
+//! `rustc --test src/linux_graphics.rs` without building the Tauri crate.
+
+/// Compositors that keep an Xwayland `DISPLAY` even for native Wayland clients.
+pub const WLROOTS_FAMILY_DESKTOPS: &[&str] =
+    &["niri", "hyprland", "sway", "river", "labwc", "wayfire"];
+
+pub fn desktop_is_wlroots_family(xdg_current_desktop: &str) -> bool {
+    xdg_current_desktop.split(':').any(|part| {
+        let name = part.trim().to_ascii_lowercase();
+        WLROOTS_FAMILY_DESKTOPS.iter().any(|known| name == *known)
+    })
+}
+
+pub fn should_force_x11_backend(
+    gdk_backend_already_set: bool,
+    force_x11: bool,
+    force_wayland: bool,
+    is_wayland: bool,
+    has_x11_display: bool,
+    xdg_current_desktop: &str,
+) -> bool {
+    if gdk_backend_already_set {
+        return false;
+    }
+    if force_x11 {
+        return true;
+    }
+    if force_wayland {
+        return false;
+    }
+    // Historical GTK Wayland shm workaround for GNOME/KDE. Skip compositors
+    // that always expose Xwayland — forcing X11 there makes WebKit go black.
+    is_wayland && has_x11_display && !desktop_is_wlroots_family(xdg_current_desktop)
+}
+
+pub fn should_disable_webkit_dmabuf(
+    already_set: bool,
+    is_wayland: bool,
+    nvidia_loaded: bool,
+    xdg_current_desktop: &str,
+) -> bool {
+    if already_set || !is_wayland {
+        return false;
+    }
+    nvidia_loaded || desktop_is_wlroots_family(xdg_current_desktop)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        desktop_is_wlroots_family, should_disable_webkit_dmabuf, should_force_x11_backend,
+    };
+
+    #[test]
+    fn wlroots_family_matches_known_desktops() {
+        for desktop in ["niri", "Hyprland", "sway", "niri:wlroots", "river"] {
+            assert!(
+                desktop_is_wlroots_family(desktop),
+                "{desktop} should be treated as wlroots-family",
+                desktop = desktop
+            );
+        }
+        for desktop in ["GNOME", "ubuntu:GNOME", "KDE", "XFCE", ""] {
+            assert!(
+                !desktop_is_wlroots_family(desktop),
+                "{desktop} must keep the historical GNOME/KDE X11 fallback",
+                desktop = desktop
+            );
+        }
+    }
+
+    #[test]
+    fn niri_with_xwayland_display_does_not_force_x11() {
+        assert!(!should_force_x11_backend(
+            false, false, false, true, true, "niri"
+        ));
+    }
+
+    #[test]
+    fn gnome_wayland_with_display_still_forces_x11() {
+        assert!(should_force_x11_backend(
+            false,
+            false,
+            false,
+            true,
+            true,
+            "ubuntu:GNOME"
+        ));
+    }
+
+    #[test]
+    fn existing_gdk_backend_is_never_overridden() {
+        assert!(!should_force_x11_backend(
+            true, true, false, true, true, "GNOME"
+        ));
+    }
+
+    #[test]
+    fn force_wayland_wins_over_gnome_fallback() {
+        assert!(!should_force_x11_backend(
+            false, false, true, true, true, "GNOME"
+        ));
+    }
+
+    #[test]
+    fn force_x11_wins_even_on_niri() {
+        assert!(should_force_x11_backend(
+            false, true, false, true, true, "niri"
+        ));
+    }
+
+    #[test]
+    fn webkit_dmabuf_disabled_on_niri_wayland() {
+        assert!(should_disable_webkit_dmabuf(false, true, false, "niri"));
+    }
+
+    #[test]
+    fn webkit_dmabuf_disabled_on_nvidia_wayland() {
+        assert!(should_disable_webkit_dmabuf(false, true, true, "GNOME"));
+    }
+
+    #[test]
+    fn webkit_dmabuf_left_alone_on_gnome_amd() {
+        assert!(!should_disable_webkit_dmabuf(false, true, false, "GNOME"));
+    }
+
+    #[test]
+    fn webkit_dmabuf_respects_user_override() {
+        assert!(!should_disable_webkit_dmabuf(true, true, true, "niri"));
+    }
+
+    #[test]
+    fn webkit_dmabuf_not_touched_on_x11_session() {
+        assert!(!should_disable_webkit_dmabuf(false, false, true, "niri"));
+    }
+}


### PR DESCRIPTION
Fixes #3388

## 问题

`configure_linux_gdk_backend()` 在 Wayland 且存在 `DISPLAY` 时强制 `GDK_BACKEND=x11`，用来规避 GNOME 上曾经的 GTK shm crash。

niri / Hyprland / sway 等合成器**几乎一定有 Xwayland**，于是所有这类用户都被按进 X11。窗口能出来，WebKitGTK 主界面全黑。`niri msg windows` 里 PID 是 `xwayland-satellite`。

对照：`WEBKIT_DISABLE_DMABUF_RENDERER=1 ANTIGRAVITY_FORCE_WAYLAND=1` 后原生 Wayland、UI 正常。全局 NVIDIA 环境变量去掉之后仍然黑，所以不是那一层。

## 修改

启动时改为 `configure_linux_graphics()`（GTK/WebKit 初始化之前）：

| 条件 | GDK | WebKit DMA-BUF |
|---|---|---|
| 用户已设 `GDK_BACKEND` / `WEBKIT_DISABLE_DMABUF_RENDERER` | 不覆盖 | 不覆盖 |
| `ANTIGRAVITY_FORCE_X11=1` | `x11` | 按下面规则 |
| `ANTIGRAVITY_FORCE_WAYLAND=1` | 不强制 X11 | 按下面规则 |
| niri / Hyprland / sway / river / labwc / wayfire | **保持原生 Wayland** | 若未设置则 `WEBKIT_DISABLE_DMABUF_RENDERER=1` |
| 其他 Wayland + `DISPLAY`（GNOME/KDE） | 仍强制 `x11`（旧行为） | 仅当本机加载了 NVIDIA 专有驱动时才关 DMA-BUF |
| GNOME + AMD/Intel | 不变 | 快路径保留 |

`.desktop` 继续 `Exec=antigravity-tools`，用户不必改快捷方式。

## 验证

- `rustc --test src-tauri/src/linux_graphics.rs`：**11** 项通过（niri 不强制 X11、GNOME 仍强制、NVIDIA Wayland 关 DMA-BUF、GNOME+AMD 不关、用户变量不覆盖）。
- 本机（CachyOS + niri + AMD iGPU + NVIDIA dGPU，`DISPLAY=:0`）策略输出：不强制 X11、设置 DMA-BUF workaround。这与已经验证能画出 UI 的手动启动方式一致。
- 未能在本机跑完整 `cargo test --lib`：`boring-sys2` 需要 `cmake`，未安装。决策表已抽到无依赖模块，可用上面的 `rustc --test` 单独跑。

## 相关

- #260 Fedora + NVIDIA 空白窗
- #262 Debian 透明框
- #3278 Wayland 快捷方式/环境变量