### PR TITLE
fix(proxy): multi-turn 400 on non-suffixed Claude models (thinking.signature: Field required)

### DIFF
--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -2632,6 +2632,13 @@ pub async fn handle_chat_completions(
                 email
             );
 
+            // [FIX #3400] 真正禁用 thinking 重试: 此前的处理只是追加修复提示词,
+            // 请求仍携带 thinking + 缺失签名的 assistant 历史, 重试必然再次 400
+            // (例如 "messages.N.content.0.thinking.signature: Field required")。
+            // transform_openai_request 在每次重试时都会重新调用, 清掉 thinking
+            // 即可让 mapper 不再注入 thinkingConfig / 占位 thinking 块。
+            openai_req.thinking = None;
+
             // 追加修复提示词到最后一条用户消息
             if let Some(last_msg) = openai_req.messages.last_mut() {
                 if last_msg.role == "user" {

--- a/src-tauri/src/proxy/mappers/openai/request.rs
+++ b/src-tauri/src/proxy/mappers/openai/request.rs
@@ -254,7 +254,18 @@ pub fn transform_openai_request(
             || mapped_model_lower.contains("-flash-")
             || mapped_model_lower.contains("-flash-agent"))
         && !mapped_model_lower.contains("claude");
-    let is_claude_thinking = mapped_model_lower.ends_with("-thinking");
+    // [FIX #3400] Claude Sonnet 4.6 / Opus 等新版 Claude 模型不带 "-thinking" 后缀，
+    // 但 Variant 层 (handlers/openai.rs) 会为它们注入 thinking enabled，上游同样强制 thinking。
+    // 仅凭后缀判定会让下方的历史兼容防御对这些模型完全失效，导致多轮对话 400
+    // "messages.N.content.0.thinking.signature: Field required"。
+    let claude_thinking_requested = mapped_model_lower.contains("claude")
+        && request
+            .thinking
+            .as_ref()
+            .map(|t| t.thinking_type.as_deref() == Some("enabled"))
+            .unwrap_or(false);
+    let is_claude_thinking =
+        mapped_model_lower.ends_with("-thinking") || claude_thinking_requested;
     let is_thinking_model = is_gemini_3_thinking || is_claude_thinking || is_gemini_flash_thinking;
 
     // [NEW] 检查用户是否在请求中显式启用 thinking
@@ -282,15 +293,19 @@ pub fn transform_openai_request(
     // [NEW] 决定是否开启 Thinking 功能:
     // 1. 模型名包含 -thinking 时自动开启
     // 2. 用户在请求中显式设置 thinking.type = "enabled" 时开启
-    // 如果是 Claude 思考模型且历史不兼容且没有可用签名来占位, 则禁用 Thinking 以防 400
     let mut actual_include_thinking = is_thinking_model || user_enabled_thinking;
 
     // [REFACTORED] 使用 SignatureCache 获取 Session 级别的签名
     let session_thought_sig =
         crate::proxy::SignatureCache::global().get_session_signature(&session_id);
 
-    if is_claude_thinking && has_incompatible_assistant_history && session_thought_sig.is_none() {
-        tracing::warn!("[OpenAI-Thinking] Incompatible assistant history detected for Claude thinking model without session signature. Disabling thinking for this request to avoid 400 error. (sid: {})", session_id);
+    // 如果是 Claude 思考模型且历史不兼容, 则禁用 Thinking 以防 400
+    // [FIX #3400] 移除 session_thought_sig.is_none() 条件: 会话签名只用于 functionCall part
+    // (Gemini 格式), 不会附加到为兼容历史而注入的占位 thinking 块上; 而 Claude 上游
+    // (Anthropic/Vertex) 没有 Gemini 的 sentinel 机制, 占位块缺 signature 必然 400。
+    // 缓存命中时跳过防御反而会让首轮成功后的所有多轮请求持续 400。
+    if is_claude_thinking && has_incompatible_assistant_history {
+        tracing::warn!("[OpenAI-Thinking] Incompatible assistant history detected for Claude thinking model. Disabling thinking for this request to avoid 400 error. (sid: {})", session_id);
         actual_include_thinking = false;
     }
 
@@ -1813,6 +1828,75 @@ mod tests {
         assert_eq!(
             tool_part["thoughtSignature"].as_str(),
             Some("skip_thought_signature_validator")
+        );
+    }
+
+    #[test]
+    fn test_issue_3400_claude_sonnet_incompatible_history_disables_thinking() {
+        // [FIX #3400] claude-sonnet-4-6 不带 "-thinking" 后缀，但 Variant 层会为它注入
+        // thinking enabled，上游同样强制 thinking。当 assistant 历史缺失 reasoning_content
+        // 时（如 AstrBot / SillyTavern 只回传文本），必须禁用 thinking，否则占位 thought part
+        // 缺 signature 会导致上游 400 "messages.N.content.0.thinking.signature: Field required"。
+        let req = OpenAIRequest {
+            model: "claude-sonnet-4-6".to_string(),
+            // 模拟 Variant 层注入的 thinking (handlers/openai.rs)
+            thinking: Some(ThinkingConfig {
+                thinking_type: Some("enabled".to_string()),
+                budget_tokens: Some(1024),
+                effort: None,
+            }),
+            messages: vec![
+                OpenAIMessage {
+                    role: "user".to_string(),
+                    refusal: None,
+                    content: Some(OpenAIContent::String("hi".to_string())),
+                    reasoning_content: None,
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                OpenAIMessage {
+                    role: "assistant".to_string(),
+                    refusal: None,
+                    content: Some(OpenAIContent::String("hello".to_string())),
+                    reasoning_content: None, // 历史不带思考内容 → 不兼容
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                OpenAIMessage {
+                    role: "user".to_string(),
+                    refusal: None,
+                    content: Some(OpenAIContent::String("reply ok".to_string())),
+                    reasoning_content: None,
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let (result, _sid, _msg_count, _) =
+            transform_openai_request(&req, "test-proj", "claude-sonnet-4-6", None);
+
+        // 1. thinking 必须被禁用: 不得下发 thinkingConfig
+        let gen_config = &result["request"]["generationConfig"];
+        assert!(
+            gen_config.get("thinkingConfig").is_none(),
+            "thinking must be disabled for claude-sonnet-4-6 with incompatible assistant history, got: {gen_config}"
+        );
+
+        // 2. model 角色历史消息不得包含占位 thought part
+        let contents = result["request"]["contents"].as_array().expect("contents");
+        let model_msg = contents
+            .iter()
+            .find(|c| c["role"] == "model")
+            .expect("model message");
+        let parts = model_msg["parts"].as_array().expect("parts");
+        assert!(
+            parts.iter().all(|p| p.get("thought") != Some(&json!(true))),
+            "model history must not contain injected thought placeholders, got: {parts:?}"
         );
     }
 


### PR DESCRIPTION
## Problem

Using non-`-thinking`-suffixed Claude models (e.g. `claude-sonnet-4-6`) via the OpenAI-compatible endpoint (`/v1/chat/completions`), **every multi-turn conversation fails with 400**:

```
messages.1.content.0.thinking.signature: Field required
```

Single-turn requests work fine. This affects every OpenAI-compatible client that only replays plain-text history (AstrBot, SillyTavern, etc.).

## Root cause (reproduced from live logs)

1. The Variant layer (`handlers/openai.rs`) unconditionally injects `thinking: enabled` (budget=1024) for `claude-sonnet-4-6`; log: `[OpenAI-Thinking] User explicitly enabled thinking with budget: Some(1024)`. Upstream forces thinking for these models;
2. On follow-up turns the assistant history lacks `reasoning_content`, so the mapper injects a placeholder thought part;
3. Per `[FIX #1575]` the placeholder must never carry a real signature, and Claude has no Gemini-style `skip_thought_signature_validator` sentinel, so the placeholder block has no signature;
4. Upstream Anthropic/Vertex validates that thinking blocks in assistant messages carry a signature, hence the 400;
5. The existing defense (`is_claude_thinking && has_incompatible_assistant_history && session_thought_sig.is_none()`) never fires, for two reasons:
   - `is_claude_thinking` only matches the `-thinking` suffix, which `claude-sonnet-4-6` lacks;
   - After the first successful turn the session signature cache is populated, so `is_none()` is false. The session signature is only attached to functionCall parts (Gemini format) and never to the placeholder thinking block, so with a cache hit the defense is skipped and every follow-up turn of the session keeps failing with 400;
6. The 400-retry branch only appends a repair prompt without actually disabling thinking, so the retry deterministically hits the same 400 (logs show attempt 1/2 and 2/2 both failing).

## Fix

- `mappers/openai/request.rs`:
  - Treat any Claude model with thinking enabled (regardless of source) as a Claude thinking model so the existing incompatible-history defense actually fires;
  - Drop the `session_thought_sig.is_none()` condition from that defense.
- `handlers/openai.rs`: on signature-related 400 retries, set `openai_req.thinking = None` so the retry really runs without thinking (`transform_openai_request` is re-invoked on every retry).

After the fix, multi-turn requests no longer send `thinkingConfig` and no longer inject placeholder thought parts, so upstream skips the signature validation and conversations work again. Behavior for normal single-turn / tool-free flows is unchanged.

## Tests

- Adds regression test `test_issue_3400_claude_sonnet_incompatible_history_disables_thinking` (asserts no `thinkingConfig` is sent and no placeholder thought part is injected into model history), passing locally;
- `cargo test --lib request:: -- --test-threads=1` produces exactly the same failure list as the main baseline (main already has 5 pre-existing failures related to global config state, unrelated to this PR), no regressions.