### PR TITLE
fix(proxy): resolve 429 failover loops, model circuit breaker bypass, and quota protection normalization

### DIFF
--- a/src-tauri/src/proxy/handlers/claude.rs
+++ b/src-tauri/src/proxy/handlers/claude.rs
@@ -1631,6 +1631,14 @@ pub async fn handle_messages(
                     Some(&request_with_mapped.model),
                 )
                 .await;
+
+            // [FIX] 遭遇 429 限流或服务端过载时，立即解绑会话，防止下一轮尝试或后续请求死锁在故障账号上
+            if status_code == 429 || status_code == 529 {
+                if let Some(sid) = session_id {
+                    token_manager.clear_session_binding(sid);
+                    debug!("[{}] Unbound session {} from account {} due to status {}", trace_id, sid, email, status_code);
+                }
+            }
         }
 
         // 4. 处理 400 错误 (Thinking 签名失效 或 块顺序错误)

--- a/src-tauri/src/proxy/handlers/common.rs
+++ b/src-tauri/src/proxy/handlers/common.rs
@@ -105,6 +105,17 @@ pub fn determine_retry_strategy(
     retried_without_thinking: bool,
 ) -> RetryStrategy {
     if status_code == 429 {
+        let lower = error_text.to_lowercase();
+        let is_hard_quota_exhausted = lower.contains("resource_exhausted")
+            || lower.contains("quota_exhausted")
+            || lower.contains("exceeded your current quota")
+            || lower.contains("insufficient_quota");
+
+        // [FIX] 硬配额耗尽必须立即轮换账号，绝不走 Grace Retry
+        if is_hard_quota_exhausted {
+            return RetryStrategy::FixedDelay(Duration::from_millis(50));
+        }
+
         return match crate::proxy::upstream::retry::parse_legacy_retry_delay(error_text) {
             Some(delay_ms) if delay_ms > 0 && delay_ms <= 2000 => {
                 let actual_delay = delay_ms.saturating_add(100);
@@ -156,6 +167,16 @@ fn determine_retry_strategy_inner(
 
         // 429 限流错误
         429 => {
+            let is_hard_quota_exhausted = lower.contains("resource_exhausted")
+                || lower.contains("quota_exhausted")
+                || lower.contains("exceeded your current quota")
+                || lower.contains("insufficient_quota");
+
+            // [FIX] 硬配额耗尽必须立即轮换账号，绝不走 Grace Retry
+            if is_hard_quota_exhausted {
+                return RetryStrategy::FixedDelay(Duration::from_millis(50));
+            }
+
             // 优先使用服务端返回的 Retry-After / quotaResetDelay
             if let Some(parsed_delay) = crate::proxy::upstream::retry::parse_retry_delay_with_source(
                 error_text,

--- a/src-tauri/src/proxy/handlers/gemini.rs
+++ b/src-tauri/src/proxy/handlers/gemini.rs
@@ -751,6 +751,12 @@ pub async fn handle_generate(
             }
         }
 
+        // [FIX] 429 时立即解绑当前会话，确保换号重试与后续请求不会死锁在受限账号上
+        if status_code == 429 || status_code == 529 {
+            token_manager.clear_session_binding(&session_id);
+            tracing::debug!("[Gemini] Unbound session {} from account {} due to status {}", session_id, email, status_code);
+        }
+
         // 确定重试策略
         let strategy = retry_state.determine_strategy(
             &account_id,

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -829,8 +829,12 @@ impl TokenManager {
         let mut changed = false;
 
         for std_id in &config.monitored_models {
+            // [FIX] 归一化监控模型为标准 ID（例如用户在 UI 选了 gemini-3.7-flash，对齐到 gemini-3-flash）
+            let lookup_key = crate::proxy::common::model_mapping::normalize_to_standard_id(std_id)
+                .unwrap_or_else(|| std_id.clone());
+
             // 获取该组的最高百分比，如果账号没该组型号则视为 100%
-            let max_pct = group_max_percentage.get(std_id).cloned().unwrap_or(100);
+            let max_pct = group_max_percentage.get(&lookup_key).cloned().unwrap_or(100);
 
             if max_pct < threshold {
                 // 只有组内所有模型都不行，才触发全组保护
@@ -841,7 +845,7 @@ impl TokenManager {
                         account_path,
                         max_pct,
                         threshold,
-                        std_id,
+                        &lookup_key,
                     )
                     .await
                     .unwrap_or(false)
@@ -855,12 +859,12 @@ impl TokenManager {
                     .and_then(|v| v.as_array());
 
                 let is_protected = protected_models.map_or(false, |arr| {
-                    arr.iter().any(|m| m.as_str() == Some(std_id as &str))
+                    arr.iter().any(|m| m.as_str() == Some(lookup_key.as_str()))
                 });
 
                 if is_protected {
                     if self
-                        .restore_quota_protection(account_json, &account_id, account_path, std_id)
+                        .restore_quota_protection(account_json, &account_id, account_path, &lookup_key)
                         .await
                         .unwrap_or(false)
                     {
@@ -1175,9 +1179,11 @@ impl TokenManager {
             }
 
             for std_id in &config.monitored_models {
-                let max_pct = group_max_percentage.get(std_id).cloned().unwrap_or(100);
-                if max_pct < threshold {
-                    protected_list.push(serde_json::Value::String(std_id.clone()));
+                let lookup_key = crate::proxy::common::model_mapping::normalize_to_standard_id(std_id)
+                    .unwrap_or_else(|| std_id.clone());
+                let max_pct = group_max_percentage.get(&lookup_key).cloned().unwrap_or(100);
+                if max_pct < threshold && !protected_list.iter().any(|v| v.as_str() == Some(lookup_key.as_str())) {
+                    protected_list.push(serde_json::Value::String(lookup_key));
                 }
             }
         }
@@ -1892,14 +1898,14 @@ impl TokenManager {
                         let key = self
                             .email_to_account_id(&bound_token.email)
                             .unwrap_or_else(|| bound_token.account_id.clone());
-                        // [FIX] Pass None for specific model wait time if not applicable
-                        let reset_sec = self.rate_limit_tracker.get_remaining_wait(&key, None);
+                        // [FIX] 传入目标模型标准化 ID，检查该模型是否已被熔断器精准锁定
+                        let reset_sec = self.rate_limit_tracker.get_remaining_wait(&key, Some(&normalized_target));
                         if reset_sec > 0 {
                             // 【修复 Issue #284】立即解绑并切换账号，不再阻塞等待
                             // 原因：阻塞等待会导致并发请求时客户端 socket 超时 (UND_ERR_SOCKET)
                             tracing::debug!(
-                                "Sticky Session: Bound account {} is rate-limited ({}s), unbinding and switching.",
-                                bound_token.email, reset_sec
+                                "Sticky Session: Bound account {} is rate-limited for {} ({}s), unbinding and switching.",
+                                bound_token.email, normalized_target, reset_sec
                             );
                             self.session_accounts.remove(sid);
                         } else if !attempted.contains(&bound_id)
@@ -1913,6 +1919,10 @@ impl TokenManager {
                             && bound_token.protected_models.contains(&normalized_target)
                         {
                             tracing::debug!("Sticky Session: Bound account {} is quota-protected for model {} [{}], unbinding and switching.", bound_token.email, normalized_target, target_model);
+                            self.session_accounts.remove(sid);
+                        } else if attempted.contains(&bound_id) {
+                            // [FIX] 绑定的账号在当前轮次请求中已尝试失败，立即解绑避免死锁
+                            tracing::debug!("Sticky Session: Bound account {} already attempted in current request, unbinding", bound_token.email);
                             self.session_accounts.remove(sid);
                         }
                     } else {


### PR DESCRIPTION
## Summary
This PR addresses three interconnected reliability issues in Antigravity-Manager's proxy scheduling, circuit breaker, and quota protection subsystems:

1. **Model-Level Circuit Breaker Bypass in Sticky Sessions**:
   - In `token_manager.rs`, sticky session check called `rate_limit_tracker.get_remaining_wait(&key, None)` with `None` (global account lock).
   - Because quota exhaustion (`QuotaExhausted` / `RESOURCE_EXHAUSTED`) locks accounts using a composite key (`account_id:model_id`), querying with `None` returned `0` seconds.
   - Consequently, sticky sessions failed to detect that the bound account was locked for the requested model, repeatedly reusing the rate-limited account.
   - Fixed by querying with `Some(&normalized_target)`.

2. **429 Failover Dead Loop in Balance & CacheFirst Modes**:
   - Upstream `429 RESOURCE_EXHAUSTED` was triggering `GraceRetry` in `common.rs`, causing `should_rotate_account` to return `false` and preventing account rotation.
   - Handlers (`claude.rs` and `gemini.rs`) did not unbind sessions upon receiving 429/529.
   - Furthermore, `token_manager.rs` did not clean up `session_accounts` when the bound account had already failed in the current request turn (`attempted.contains(&bound_id)`).
   - Fixed by bypassing Grace Retry on hard quota limits, and explicitly unbinding sessions on 429/529 as well as when an account has already been attempted in the current turn.

3. **Quota Protection Model Normalization Mismatch**:
   - The settings UI allowed selecting specific models (e.g. `gemini-3.7-flash`, `gemini-3.1-pro`), storing them directly in `gui_config.json`.
   - However, backend quota evaluations group models strictly under Standard IDs (`gemini-3-flash`, `gemini-3-pro-high`, `claude`). Looking up specific keys resulted in defaulting to 100% quota, silently disabling protection.
   - Fixed by normalizing configured keys with `normalize_to_standard_id` in `token_manager.rs` before quota evaluation and restoration.

## Detailed Changes
- `src-tauri/src/proxy/token_manager.rs`:
  - Query target model in `get_remaining_wait` instead of `None` in sticky session validation.
  - Remove from `session_accounts` immediately if bound account was already attempted in current request loop.
  - Normalize `monitored_models` to standard ID before checking `group_max_percentage` and setting `protected_models`.
- `src-tauri/src/proxy/handlers/claude.rs`: Immediately unbind session on 429/529.
- `src-tauri/src/proxy/handlers/gemini.rs`: Immediately unbind session on 429/529.
- `src-tauri/src/proxy/handlers/common.rs`: Bypass Grace Retry on `resource_exhausted` / `quota_exhausted` to force instant account rotation.

## Verification
- Verified that model-specific circuit breaker locks now properly trigger unbinding and failover in sticky sessions.
- Verified that upstream 429 with `RESOURCE_EXHAUSTED` rotates accounts immediately without trapping requests in Grace Retry loops.
- Verified that UI selection of specific model variants (e.g. G3.7 Flash) correctly aligns with the `gemini-3-flash` quota protection bucket.