### PR TITLE
fix(proxy): ensure user turn precedes function call in OpenAI-to-Gemini mapping

### DIFF
--- a/src-tauri/src/proxy/mappers/openai/request.rs
+++ b/src-tauri/src/proxy/mappers/openai/request.rs
@@ -780,6 +780,11 @@ pub fn transform_openai_request(
                 }
             }
 
+            // Ensure user role message is not dropped if parts is empty, preserving role rotation
+            if role == "user" && parts.is_empty() {
+                parts.push(json!({ "text": " " }));
+            }
+
             json!({ "role": role, "parts": parts })
         })
         .filter(|msg| !msg["parts"].as_array().map(|a| a.is_empty()).unwrap_or(true))
@@ -809,7 +814,26 @@ pub fn transform_openai_request(
         }
         merged_contents.push(msg);
     }
-    let contents = merged_contents;
+    let mut contents = merged_contents;
+
+    // Gemini requires conversations to start with a user turn, and functionCall turns
+    // must immediately follow a user turn or a functionResponse turn.
+    // If the conversation starts with a model turn (e.g. autonomous agent loops starting with tool calls),
+    // inject a lightweight user primer to prevent 400 INVALID_ARGUMENT error.
+    if contents.is_empty() {
+        contents.push(json!({
+            "role": "user",
+            "parts": [{ "text": "Continue" }]
+        }));
+    } else if contents.first().and_then(|f| f.get("role")).and_then(|r| r.as_str()) == Some("model") {
+        contents.insert(
+            0,
+            json!({
+                "role": "user",
+                "parts": [{ "text": "Continue the task." }]
+            }),
+        );
+    }
 
     // 3. 构建请求体
 
@@ -1811,7 +1835,11 @@ mod tests {
         // Extract the tool call part from contents (under request.contents)
         let contents = result["request"]["contents"].as_array().unwrap();
         // Identify the part with functionCall
-        let parts = contents[0]["parts"].as_array().unwrap();
+        let model_msg = contents
+            .iter()
+            .find(|c| c["role"] == "model")
+            .expect("Should find model role message");
+        let parts = model_msg["parts"].as_array().unwrap();
         let tool_part = parts
             .iter()
             .find(|p: &&serde_json::Value| p.get("functionCall").is_some())
@@ -2067,4 +2095,59 @@ mod tests {
         let has_thought_part = parts.iter().any(|p| p.get("thought") == Some(&serde_json::json!(true)));
         assert!(!has_thought_part, "Should not inject placeholder thinking block into assistant message for Claude");
     }
+
+    #[test]
+    fn test_hermes_autonomous_first_assistant_tool_call_injected_user_primer() {
+        // Ensure conversation starting with assistant tool calls (common in Hermes / autonomous agents)
+        // has a user primer injected at index 0 so Google Gemini does not reject with:
+        // "Please ensure that function call turn comes immediately after a user turn or after a function response turn."
+        let raw_json = json!({
+            "model": "gemini-3.8-flash-high",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are Don Santo, an autonomous agent."
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_123",
+                            "type": "function",
+                            "function": {
+                                "name": "terminal",
+                                "arguments": "{\"command\": \"ls\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_123",
+                    "name": "terminal",
+                    "content": "output of ls"
+                }
+            ]
+        });
+
+        let request: OpenAIRequest = serde_json::from_value(raw_json).unwrap();
+        let (res_val, _sid, _msg_count, _) = transform_openai_request(&request, "test-v", "gemini-3.8-flash-high", None);
+        let contents = res_val["request"]["contents"].as_array().expect("contents must be an array");
+
+        // First turn MUST be user
+        assert_eq!(contents[0]["role"], "user");
+        assert!(contents[0]["parts"][0]["text"].as_str().is_some());
+
+        // Second turn MUST be model with functionCall
+        assert_eq!(contents[1]["role"], "model");
+        let has_func_call = contents[1]["parts"].as_array().unwrap().iter().any(|p| p.get("functionCall").is_some());
+        assert!(has_func_call);
+
+        // Third turn MUST be user with functionResponse
+        assert_eq!(contents[2]["role"], "user");
+        let has_func_resp = contents[2]["parts"].as_array().unwrap().iter().any(|p| p.get("functionResponse").is_some());
+        assert!(has_func_resp);
+    }
 }
+


### PR DESCRIPTION
### Problem
When clients such as autonomous agents (e.g., Hermes Agent, background subworker loops) send an OpenAI-compatible `/v1/chat/completions` request where the conversation starts with an assistant turn invoking tool calls immediately after the system message (without an initial user greeting turn):

1. The proxy mapper extracts `role: "system"` into `systemInstruction`.
2. The remaining `contents` sent to Google Gemini upstream starts with `role: "model"` containing a `functionCall`.
3. Google Gemini API strictly requires that every `functionCall` turn MUST immediately follow either a `user` turn or a `functionResponse` turn.
4. Consequently, Google Gemini upstream rejects the request with HTTP 400:
```json
{
  "error": {
    "code": 400,
    "message": "Please ensure that function call turn comes immediately after a user turn or after a function response turn.",
    "status": "INVALID_ARGUMENT"
  }
}
```

Additionally, if a client sends a user message with empty text content, filtering out empty parts could drop the user turn entirely and disrupt the turn rotation required by upstream Gemini.

### Solution
1. In `transform_openai_request` (`src-tauri/src/proxy/mappers/openai/request.rs`):
   - Ensure `role == "user"` messages with empty parts receive a whitespace text block (`" "`) rather than being dropped.
   - If `contents` begins with `role: "model"` (or is empty), inject a lightweight user turn primer (`"Continue the task."`) at index 0 so that function call turns always succeed a valid user turn.
2. Updated `test_vertex_ai_sentinel_injection` to locate the model turn dynamically.
3. Added unit test `test_hermes_autonomous_first_assistant_tool_call_injected_user_primer` to guarantee correct turn order and verify functionCall compatibility.