### PR TITLE
fix: always include usage in message_start event

### DIFF
--- a/src-tauri/src/proxy/mappers/claude/streaming.rs
+++ b/src-tauri/src/proxy/mappers/claude/streaming.rs
@@ -321,6 +321,11 @@ impl StreamingState {
 
         if let Some(u) = usage {
             message["usage"] = json!(u);
+        } else {
+            message["usage"] = json!({
+                "input_tokens": 0,
+                "output_tokens": 0
+            });
         }
 
         let result = self.emit(


### PR DESCRIPTION
Fixes #2028

## Problem

`emit_message_start` in `src-tauri/src/proxy/mappers/claude/streaming.rs` only sets `message["usage"]` when the first upstream chunk carries `usageMetadata`. For models whose first chunk has no usage metadata (e.g. `gpt-oss-120b-medium`), the emitted `message_start` event contains no `usage` field at all.

Strict Anthropic-protocol clients such as OpenCode (`@ai-sdk/anthropic`) reject the stream:

```
Type validation failed: Value: {"type":"message_start","message":{...no usage...}}.
Error message: [{"expected":"object","code":"invalid_type","path":["message","usage"],"message":"Invalid input: expected object, received undefined"}]
```

## Fix

When upstream usage metadata is not yet known, emit a zero-value `usage` object (`{"input_tokens": 0, "output_tokens": 0}`) in `message_start` so the field is always present. Later `message_delta` events still carry the real cumulative totals, so token accounting is unaffected.

## Verification

- `cargo check` passes (no new warnings from this change)
- Reproduced the original error against v4.6.6 with OpenCode + `gpt-oss-120b-medium`; with this change the `message_start` event always contains `usage`, and OpenCode completes the stream normally.

Tested on macOS with Antigravity Tools v4.6.6 proxy (`/v1/messages`, Anthropic protocol).