### PR TITLE
fix(responses): separate routing and signature identities and persist non-stream history

### DIFF
--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -8,8 +8,8 @@ use serde_json::{json, Value};
 use tracing::{debug, error, info}; // Import Engine trait for encode method
 
 use crate::proxy::mappers::openai::{
-    transform_openai_request, transform_openai_response, OpenAIContent, OpenAIContentBlock,
-    OpenAIMessage, OpenAIRequest, OpenAIResponse,
+    transform_openai_request, transform_openai_request_with_session, transform_openai_response,
+    OpenAIContent, OpenAIContentBlock, OpenAIMessage, OpenAIRequest, OpenAIResponse,
 };
 // use crate::proxy::upstream::client::UpstreamClient; // 通过 state 获取
 use crate::proxy::debug_logger;
@@ -954,6 +954,7 @@ mod stream_peek_tests {
     use super::response_has_inline_image_data;
     use super::responses_input_item_type;
     use super::responses_message_parts;
+    use super::responses_routing_session_id;
     use super::rewrite_terminal_assistant_prefill;
     use super::save_session_unless_response_cancelled;
     use super::stream_chunk_has_error_event;
@@ -964,6 +965,35 @@ mod stream_peek_tests {
     use super::{MAX_INPUT_IMAGES, MAX_INPUT_IMAGE_BYTES, MAX_TOTAL_INPUT_IMAGE_BYTES};
     use crate::proxy::mappers::openai::{transform_openai_request, OpenAIRequest};
     use serde_json::{json, Value};
+
+    #[test]
+    fn responses_routing_identity_follows_the_response_chain() {
+        let first = responses_routing_session_id(None, None, None, "resp-root-a");
+        let second = responses_routing_session_id(None, None, None, "resp-root-b");
+        assert_eq!(first, "resp-root-a");
+        assert_eq!(second, "resp-root-b");
+        assert_ne!(first, second);
+
+        let continued =
+            responses_routing_session_id(None, Some("resp-parent"), Some(&first), "resp-child");
+        let branch =
+            responses_routing_session_id(None, Some("resp-parent"), Some(&first), "resp-branch");
+        assert_eq!(continued, first);
+        assert_eq!(branch, first);
+        assert_eq!(
+            responses_routing_session_id(
+                Some("client-session"),
+                Some("resp-parent"),
+                Some(&first),
+                "resp-child"
+            ),
+            "client-session"
+        );
+        assert_eq!(
+            responses_routing_session_id(None, Some("resp-missing"), None, "resp-child"),
+            "resp-missing"
+        );
+    }
 
     #[test]
     fn responses_created_with_null_error_is_not_an_error_event() {
@@ -1222,6 +1252,7 @@ data: {"type":"response.failed","response":{"status":"failed","error":{"code":"u
                 Vec::new(),
                 String::new(),
                 "gemini-pro-agent".to_string(),
+                "routing-cancelled".to_string(),
             )
             .await;
         }));
@@ -1661,6 +1692,20 @@ fn codex_ledger_from_body(
     }
 
     (ledger, markers)
+}
+
+fn responses_routing_session_id(
+    explicit_session_id: Option<&str>,
+    previous_response_id: Option<&str>,
+    stored_routing_session_id: Option<&str>,
+    response_id: &str,
+) -> String {
+    explicit_session_id
+        .filter(|id| !id.is_empty())
+        .or(stored_routing_session_id.filter(|id| !id.is_empty()))
+        .or(previous_response_id.filter(|id| !id.is_empty()))
+        .unwrap_or(response_id)
+        .to_string()
 }
 
 fn strip_codex_step_markers(content: &str) -> String {
@@ -2822,6 +2867,7 @@ pub async fn handle_completions(
     let debug_cfg = state.debug_logging.read().await.clone();
     let original_body =
         debug_logger::is_enabled(&debug_cfg).then(|| debug_value_without_inline_data(&body));
+    let is_responses_api = uri.path() == "/v1/responses";
     let is_codex_style = body.get("input").is_some() || body.get("instructions").is_some();
 
     // [MULTI-TURN] 支持 previous_response_id 链式历史恢复
@@ -2831,10 +2877,16 @@ pub async fn handle_completions(
         .get("previous_response_id")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
+    let explicit_session_id = body
+        .get("session_id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string);
     let response_id_for_save = format!("resp-{}", uuid::Uuid::new_v4());
     let http_tool_call_cache: std::collections::HashMap<String, serde_json::Value> =
         std::collections::HashMap::new();
     let mut session_parent = None;
+    let mut stored_routing_session_id = None;
     let mut session_delta_input = Vec::new();
     if is_codex_style {
         let mut existing_input = body
@@ -2852,6 +2904,7 @@ pub async fn handle_completions(
             if let Some((session, parent)) =
                 crate::proxy::http_session_store::get_session_with_parent(prev_id).await
             {
+                stored_routing_session_id = Some(parent.routing_session_id().to_string());
                 let prepared = crate::proxy::http_session_store::prepare_session_input(
                     session.input_items,
                     existing_input,
@@ -2891,6 +2944,13 @@ pub async fn handle_completions(
             return (StatusCode::BAD_REQUEST, message).into_response();
         }
     }
+    let routing_session_id = responses_routing_session_id(
+        explicit_session_id.as_deref(),
+        previous_response_id.as_deref(),
+        stored_routing_session_id.as_deref(),
+        &response_id_for_save,
+    );
+    let signature_read_key = previous_response_id.clone();
 
     let mut bounded_session_input = None;
 
@@ -3417,14 +3477,25 @@ pub async fn handle_completions(
     }
 
     // [NEW v4.2.0] Context Management & Reasoning Replay
-    let session_id_str = SessionManager::extract_openai_session_id(&openai_req);
+    let session_id_str = if is_responses_api {
+        routing_session_id.clone()
+    } else {
+        SessionManager::extract_openai_session_id(&openai_req)
+    };
+    let signature_session_id_str = if is_responses_api {
+        previous_response_id
+            .clone()
+            .unwrap_or_else(|| response_id_for_save.clone())
+    } else {
+        session_id_str.clone()
+    };
 
     let client_tool_names =
         crate::proxy::mappers::openai::request::extract_client_tool_names(&openai_req.tools);
 
     crate::proxy::mappers::context_manager::ContextManager::restore_openai_reasoning_content(
         &mut openai_req.messages,
-        &session_id_str,
+        &signature_session_id_str,
     );
 
     let experimental_cfg = state.experimental.read().await;
@@ -3565,7 +3636,7 @@ pub async fn handle_completions(
                 &openai_req,
                 &trace_id,
                 &token_manager_clone,
-                &session_id_str,
+                &signature_session_id_str,
             )
             .await
             {
@@ -3679,7 +3750,7 @@ pub async fn handle_completions(
 
         // 3. 提取 SessionId (复用)
         // [New] 使用 TokenManager 内部逻辑提取 session_id，支持粘性调度
-        let session_id_str = SessionManager::extract_openai_session_id(&openai_req);
+        let session_id_str = session_id_str.clone();
         let session_id = Some(session_id_str.as_str());
 
         let (access_token, project_id, email, account_id, _wait_ms) =
@@ -3716,12 +3787,23 @@ pub async fn handle_completions(
         info!("✓ Using account: {} (type: {})", email, config.request_type);
 
         let proxy_token = token_manager.get_token_by_id(&account_id);
-        let (gemini_body, session_id, message_count, _prefix_hash) = transform_openai_request(
-            &openai_req,
-            &project_id,
-            &mapped_model,
-            proxy_token.as_ref(),
-        );
+        let (gemini_body, session_id, message_count, _prefix_hash) = if is_responses_api {
+            transform_openai_request_with_session(
+                &openai_req,
+                &project_id,
+                &mapped_model,
+                proxy_token.as_ref(),
+                &routing_session_id,
+                signature_read_key.as_deref(),
+            )
+        } else {
+            transform_openai_request(
+                &openai_req,
+                &project_id,
+                &mapped_model,
+                proxy_token.as_ref(),
+            )
+        };
         let gemini_body_for_debug = debug_logger::is_enabled(&debug_cfg)
             .then(|| debug_value_without_inline_data(&gemini_body));
         if debug_logger::is_enabled(&debug_cfg) {
@@ -3862,7 +3944,7 @@ pub async fn handle_completions(
                         create_codex_sse_stream(
                             gemini_stream,
                             openai_req.model.clone(),
-                            session_id,
+                            response_id_for_save.clone(),
                             message_count,
                             assistant_turn_index,
                             response_id_for_save.clone(),
@@ -3976,6 +4058,7 @@ pub async fn handle_completions(
                                         outputs,
                                         save_instructions,
                                         save_model,
+                                        routing_session_id,
                                     ),
                                 )
                                 .await;
@@ -4000,7 +4083,11 @@ pub async fn handle_completions(
                     let mut openai_stream = create_openai_sse_stream(
                         gemini_stream,
                         openai_req.model.clone(),
-                        session_id,
+                        if is_responses_api {
+                            response_id_for_save.clone()
+                        } else {
+                            session_id
+                        },
                         message_count,
                         Some(client_tool_names.clone()),
                     );
@@ -4086,7 +4173,26 @@ pub async fn handle_completions(
                             let is_responses_api = uri.path() == "/v1/responses";
 
                             if is_responses_api {
-                                let resp = convert_chat_response_to_responses(&chat_resp);
+                                let mut resp = convert_chat_response_to_responses(&chat_resp);
+                                resp["id"] = json!(response_id_for_save.clone());
+                                let outputs = resp
+                                    .get("output")
+                                    .and_then(Value::as_array)
+                                    .cloned()
+                                    .unwrap_or_default()
+                                    .into_iter()
+                                    .filter_map(into_history_without_inline_media)
+                                    .collect();
+                                crate::proxy::http_session_store::save_session_delta(
+                                    response_id_for_save.clone(),
+                                    session_parent,
+                                    session_save_input,
+                                    outputs,
+                                    session_save_instructions,
+                                    openai_req.model.clone(),
+                                    routing_session_id.clone(),
+                                )
+                                .await;
                                 if debug_logger::is_enabled(&debug_cfg) {
                                     let payload = json!({
                                         "kind": "exchange_summary",

--- a/src-tauri/src/proxy/http_session_store.rs
+++ b/src-tauri/src/proxy/http_session_store.rs
@@ -30,10 +30,17 @@ struct SessionNode {
     response_output: Vec<Value>,
     instructions: String,
     model: String,
+    routing_session_id: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct SessionParent(Arc<SessionNode>);
+
+impl SessionParent {
+    pub fn routing_session_id(&self) -> &str {
+        &self.0.routing_session_id
+    }
+}
 
 struct StoredSession {
     node: Arc<SessionNode>,
@@ -74,6 +81,7 @@ impl HttpSessionStore {
             Vec::new(),
             entry.instructions,
             entry.model,
+            None,
         );
     }
 
@@ -85,7 +93,9 @@ impl HttpSessionStore {
         response_output: Vec<Value>,
         instructions: String,
         model: String,
+        routing_session_id: Option<String>,
     ) {
+        let routing_session_id = routing_session_id.unwrap_or_else(|| response_id.clone());
         self.sessions.insert(
             response_id,
             StoredSession {
@@ -95,6 +105,7 @@ impl HttpSessionStore {
                     response_output,
                     instructions,
                     model,
+                    routing_session_id,
                 }),
                 last_accessed: Instant::now(),
             },
@@ -164,6 +175,7 @@ pub async fn save_session_delta(
     response_output: Vec<Value>,
     instructions: String,
     model: String,
+    routing_session_id: String,
 ) {
     store().lock().await.insert_delta(
         response_id,
@@ -172,6 +184,7 @@ pub async fn save_session_delta(
         response_output,
         instructions,
         model,
+        Some(routing_session_id),
     );
 }
 
@@ -463,6 +476,7 @@ mod tests {
             vec![json!({"id": "out-second", "content": "answer"})],
             "be concise".to_string(),
             "gemini-3.7-flash-high".to_string(),
+            Some("routing-root".to_string()),
         );
 
         let (previous, _) = store.get("resp-2").expect("child");
@@ -487,6 +501,7 @@ mod tests {
             Vec::new(),
             String::new(),
             String::new(),
+            Some("routing-root".to_string()),
         );
         store.insert_delta(
             "resp-b".to_string(),
@@ -495,11 +510,20 @@ mod tests {
             Vec::new(),
             String::new(),
             String::new(),
+            Some("routing-root".to_string()),
         );
 
         let parent_a = store.sessions["resp-a"].node.parent.as_ref().unwrap();
         let parent_b = store.sessions["resp-b"].node.parent.as_ref().unwrap();
         assert!(Arc::ptr_eq(parent_a, parent_b));
+        assert_eq!(
+            store.sessions["resp-a"].node.routing_session_id,
+            "routing-root"
+        );
+        assert_eq!(
+            store.sessions["resp-b"].node.routing_session_id,
+            "routing-root"
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy/mappers/openai/context_blocks.rs
+++ b/src-tauri/src/proxy/mappers/openai/context_blocks.rs
@@ -23,13 +23,12 @@ pub fn build_official_style_system_instruction(
     global_prompt: Option<&str>,
     request_type: &str,
     mapped_model: &str,
-    session_id: &str,
 ) -> String {
     let mut sections = ContextSections::default();
 
     sections.user_information.push(format!(
-        "Request type: {}\nMapped model: {}\nSession ID: {}",
-        request_type, mapped_model, session_id
+        "Request type: {}\nMapped model: {}",
+        request_type, mapped_model
     ));
 
     if let Some(prompt) = global_prompt.map(str::trim).filter(|s| !s.is_empty()) {

--- a/src-tauri/src/proxy/mappers/openai/request.rs
+++ b/src-tauri/src/proxy/mappers/openai/request.rs
@@ -186,6 +186,26 @@ pub fn transform_openai_request(
     mapped_model: &str,
     token: Option<&ProxyToken>,
 ) -> (Value, String, usize, String) {
+    let session_id =
+        crate::proxy::session_manager::SessionManager::extract_openai_session_id(request);
+    transform_openai_request_with_session(
+        request,
+        project_id,
+        mapped_model,
+        token,
+        &session_id,
+        Some(&session_id),
+    )
+}
+
+pub fn transform_openai_request_with_session(
+    request: &OpenAIRequest,
+    project_id: &str,
+    mapped_model: &str,
+    token: Option<&ProxyToken>,
+    routing_session_id: &str,
+    signature_read_key: Option<&str>,
+) -> (Value, String, usize, String) {
     let remember_cwd =
         |text: &str| crate::proxy::adapters::apply_patch_preflight::remember_cwd_from_text(text);
     let found_cwd = request.instructions.as_deref().is_some_and(remember_cwd);
@@ -213,8 +233,7 @@ pub fn transform_openai_request(
         }
     }
 
-    let session_id =
-        crate::proxy::session_manager::SessionManager::extract_openai_session_id(request);
+    let session_id = routing_session_id.to_string();
     let message_count = request.messages.len();
     // 将 OpenAI 工具转为 Value 数组以便探测
     let tools_val = request
@@ -290,8 +309,8 @@ pub fn transform_openai_request(
     let mut actual_include_thinking = is_thinking_model || user_enabled_thinking;
 
     // [REFACTORED] 使用 SignatureCache 获取 Session 级别的签名
-    let session_thought_sig =
-        crate::proxy::SignatureCache::global().get_session_signature(&session_id);
+    let session_thought_sig = signature_read_key
+        .and_then(|key| crate::proxy::SignatureCache::global().get_session_signature(key));
 
     if is_claude_thinking && has_incompatible_assistant_history {
         tracing::warn!("[OpenAI-Thinking] Incompatible assistant history detected for Claude thinking model (missing reasoning_content). Disabling thinking for this request to avoid 400 signature error. (sid: {})", session_id);
@@ -1248,7 +1267,6 @@ pub fn transform_openai_request(
             global_prompt,
             &config.request_type,
             mapped_model,
-            &session_id,
         );
 
     // [FIX] Inject explicit tool mapping instructions for Gemini to read SKILL.md
@@ -1414,6 +1432,84 @@ fn enforce_uppercase_types(value: &mut Value) {
 mod tests {
     use super::*;
     use crate::proxy::mappers::openai::models::*;
+
+    #[test]
+    fn responses_session_identity_is_not_written_into_system_instruction() {
+        let req: OpenAIRequest = serde_json::from_value(json!({
+            "model": "gemini-3.7-flash-high",
+            "messages": [{"role": "user", "content": "same first message"}]
+        }))
+        .unwrap();
+
+        let (body, session_id, _, _) = transform_openai_request_with_session(
+            &req,
+            "test-project",
+            "gemini-3.7-flash-high",
+            None,
+            "resp-routing-root",
+            None,
+        );
+        let system_instruction = body["request"]["systemInstruction"].to_string();
+
+        assert_eq!(session_id, "resp-routing-root");
+        assert!(system_instruction.contains("Request type:"));
+        assert!(system_instruction.contains("Mapped model:"));
+        assert!(!system_instruction.contains("Session ID:"));
+        assert!(!system_instruction.contains("resp-routing-root"));
+    }
+
+    #[test]
+    fn responses_reads_the_parent_signature_instead_of_the_routing_identity() {
+        let previous_response_id = format!("resp-parent-{}", uuid::Uuid::new_v4());
+        let routing_session_id = format!("resp-root-{}", uuid::Uuid::new_v4());
+        let signature = "parent-signature-".repeat(8);
+        crate::proxy::SignatureCache::global().cache_session_signature(
+            &previous_response_id,
+            signature.clone(),
+            1,
+        );
+        let request = OpenAIRequest {
+            model: "gemini-3.7-flash-high".to_string(),
+            messages: vec![OpenAIMessage {
+                role: "assistant".to_string(),
+                content: None,
+                reasoning_content: None,
+                tool_calls: Some(vec![ToolCall {
+                    id: "call-parent".to_string(),
+                    r#type: "function".to_string(),
+                    function: Some(ToolFunction {
+                        name: "test_tool".to_string(),
+                        arguments: "{}".to_string(),
+                    }),
+                    status: None,
+                    call_id: None,
+                    operation: None,
+                }]),
+                tool_call_id: None,
+                name: None,
+                refusal: None,
+            }],
+            ..Default::default()
+        };
+
+        let (body, returned_session_id, _, _) = transform_openai_request_with_session(
+            &request,
+            "test-project",
+            "gemini-3.7-flash-high",
+            None,
+            &routing_session_id,
+            Some(&previous_response_id),
+        );
+        let tool_part = body["request"]["contents"][0]["parts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|part| part.get("functionCall").is_some())
+            .unwrap();
+
+        assert_eq!(returned_session_id, routing_session_id);
+        assert_eq!(tool_part["thoughtSignature"], signature);
+    }
 
     #[test]
     #[test]

--- a/src-tauri/src/proxy/mappers/openai/streaming.rs
+++ b/src-tauri/src/proxy/mappers/openai/streaming.rs
@@ -1282,6 +1282,7 @@ mod tests {
                 outputs,
                 String::new(),
                 "gemini-pro-agent".to_string(),
+                "routing-test-session".to_string(),
             )
             .await;
             ack_tx.send(()).expect("acknowledge session save");
@@ -1318,6 +1319,25 @@ mod tests {
 
         assert!(saw_completed);
         assert!(raw.contains(&format!("\"id\":\"{response_id}\"")));
+    }
+
+    #[test]
+    fn response_branches_store_signatures_under_their_own_response_ids() {
+        let branch_a = format!("resp-signature-a-{}", uuid::Uuid::new_v4());
+        let branch_b = format!("resp-signature-b-{}", uuid::Uuid::new_v4());
+        let signature_a = "a".repeat(64);
+        let signature_b = "b".repeat(64);
+        store_thought_signature(&signature_a, &branch_a, 1);
+        store_thought_signature(&signature_b, &branch_b, 1);
+
+        assert_eq!(
+            crate::proxy::SignatureCache::global().get_session_signature(&branch_a),
+            Some(signature_a)
+        );
+        assert_eq!(
+            crate::proxy::SignatureCache::global().get_session_signature(&branch_b),
+            Some(signature_b)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

HTTP Responses currently derives routing again from normalized messages and shares that identity with session signatures. Successful non-streaming responses are not persisted. Carry routing through stored response nodes, read signatures from the selected parent, write them under the current response ID, and save non-streaming history before returning that same ID. Follow-up to #3356 and #3366.

## Changes

- `handlers/openai.rs`: resolve routing identity, pass separate signature keys, persist non-stream output, and update stream/save call sites.
- `http_session_store.rs`: retain routing metadata in parent-linked nodes without changing history merge rules.
- `mappers/openai/request.rs`: introduce an explicit routing/signature mapper entrypoint while retaining the legacy wrapper.
- `mappers/openai/context_blocks.rs`: remove internal session identity from generated system text.
- `mappers/openai/streaming.rs`: update the save test and cover response-specific signature keys.

## Tests

- Isolated branch: syntax parsing and `git diff --check` passed. Not a full `cargo fmt --check` or type-check result.
- Existing migrated tests are included; they have not completed execution. Non-streaming HTTP persistence and live account-affinity behavior lack direct executed coverage.
- Combined migration: prior release build and deployed health/WebUI checks passed. No new build or deployment was performed for this branch.

## Compatibility

The legacy mapper wrapper retains its inferred routing/signature key behavior. Responses uses explicit parent/current keys. Shared OpenAI prompts lose only the internally injected Session ID section line. Existing history deduplication, inline-media removal and video support remain. Unknown-parent fallback does not reconstruct missing history. The implementation covers HTTP Responses; it makes no new WebSocket guarantee. It does not claim to fix all signature failures or all shared cache behavior.

Closes #3402
