### PR TITLE
fix(responses): honor store:false for HTTP session and tool-call retention

### DIFF
--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -966,6 +966,14 @@ mod stream_peek_tests {
     use serde_json::{json, Value};
 
     #[test]
+    fn responses_store_defaults_to_enabled_and_honors_explicit_false() {
+        assert!(super::responses_store_enabled(&json!({})));
+        assert!(super::responses_store_enabled(&json!({"store": true})));
+        assert!(super::responses_store_enabled(&json!({"store": null})));
+        assert!(!super::responses_store_enabled(&json!({"store": false})));
+    }
+
+    #[test]
     fn responses_created_with_null_error_is_not_an_error_event() {
         let chunk = br#"event: response.created
 data: {"type":"response.created","response":{"status":"in_progress","error":null}}
@@ -2808,6 +2816,10 @@ fn web_tools_guidance_message() -> Value {
 
 // --- END Codex GUIDANCE PROMPTS ---
 
+fn responses_store_enabled(body: &Value) -> bool {
+    body.get("store").and_then(Value::as_bool) != Some(false)
+}
+
 /// 处理 Legacy Completions API (/v1/completions)
 /// 将 Prompt 转换为 Chat Message 格式，复用 handle_chat_completions
 pub async fn handle_completions(
@@ -2823,6 +2835,7 @@ pub async fn handle_completions(
     let original_body =
         debug_logger::is_enabled(&debug_cfg).then(|| debug_value_without_inline_data(&body));
     let is_codex_style = body.get("input").is_some() || body.get("instructions").is_some();
+    let store_response = responses_store_enabled(&body);
 
     // [MULTI-TURN] 支持 previous_response_id 链式历史恢复
     // 当客户端通过 HTTP POST /v1/responses 传入 previous_response_id 时，
@@ -2852,13 +2865,14 @@ pub async fn handle_completions(
             if let Some((session, parent)) =
                 crate::proxy::http_session_store::get_session_with_parent(prev_id).await
             {
-                let prepared = crate::proxy::http_session_store::prepare_session_input(
+                let prepared = crate::proxy::http_session_store::prepare_session_input_with_storage(
                     session.input_items,
                     existing_input,
                     &http_tool_call_cache,
+                    store_response,
                 );
                 session_delta_input = prepared.delta;
-                if !prepared.reset_parent {
+                if store_response && !prepared.reset_parent {
                     session_parent = Some(parent);
                 }
                 if let Some(obj) = body.as_object_mut() {
@@ -2876,11 +2890,15 @@ pub async fn handle_completions(
                 );
                 prepared.merged
             } else {
-                session_delta_input = existing_input.clone();
+                if store_response {
+                    session_delta_input = existing_input.clone();
+                }
                 existing_input
             }
         } else {
-            session_delta_input = existing_input.clone();
+            if store_response {
+                session_delta_input = existing_input.clone();
+            }
             existing_input
         };
 
@@ -2910,13 +2928,13 @@ pub async fn handle_completions(
                 _ => None,
             })
             .unwrap_or_default();
-        bounded_session_input = Some(
+        bounded_session_input = store_response.then(|| {
             session_delta_input
                 .drain(..)
                 .filter_map(into_history_without_inline_media)
                 .filter(|item| !item.is_null())
-                .collect(),
-        );
+                .collect()
+        });
 
         let mut messages = Vec::new();
 
@@ -3387,7 +3405,14 @@ pub async fn handle_completions(
                 _ => None,
             })
             .unwrap_or_default();
-        (input, instructions)
+        (
+            input,
+            if store_response {
+                instructions
+            } else {
+                String::new()
+            },
+        )
     } else {
         (Vec::new(), String::new())
     };
@@ -3857,8 +3882,13 @@ pub async fn handle_completions(
                     let mut session_completion_rx = None;
                     let mut openai_stream = if is_codex_style {
                         use crate::proxy::mappers::openai::streaming::create_codex_sse_stream;
-                        let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
-                        session_completion_rx = Some(completion_rx);
+                        let completion_tx = if store_response {
+                            let (tx, rx) = tokio::sync::oneshot::channel();
+                            session_completion_rx = Some(rx);
+                            Some(tx)
+                        } else {
+                            None
+                        };
                         create_codex_sse_stream(
                             gemini_stream,
                             openai_req.model.clone(),
@@ -3866,7 +3896,8 @@ pub async fn handle_completions(
                             message_count,
                             assistant_turn_index,
                             response_id_for_save.clone(),
-                            Some(completion_tx),
+                            completion_tx,
+                            store_response,
                         )
                     } else {
                         use crate::proxy::mappers::openai::streaming::create_legacy_sse_stream;

--- a/src-tauri/src/proxy/http_session_store.rs
+++ b/src-tauri/src/proxy/http_session_store.rs
@@ -187,6 +187,16 @@ pub fn prepare_session_input(
     new_input: Vec<Value>,
     tool_call_cache: &HashMap<String, Value>,
 ) -> PreparedSessionInput {
+    prepare_session_input_with_storage(history, new_input, tool_call_cache, true)
+}
+
+/// Restore the complete model input while optionally retaining a delta for storage.
+pub fn prepare_session_input_with_storage(
+    history: Vec<Value>,
+    new_input: Vec<Value>,
+    tool_call_cache: &HashMap<String, Value>,
+    retain_delta: bool,
+) -> PreparedSessionInput {
     let reset_parent = new_input.iter().any(|item| {
         matches!(
             item.get("type").and_then(Value::as_str),
@@ -229,9 +239,16 @@ pub fn prepare_session_input(
             .all(|(h, n)| items_semantically_equal(h, n));
 
     // Semantic suffix find: find last item of history in new_input
-    let semantic_suffix_idx = if !history.is_empty() && !reset_parent && !exact_replay && replayed_through.is_none() && !semantic_prefix_match {
+    let semantic_suffix_idx = if !history.is_empty()
+        && !reset_parent
+        && !exact_replay
+        && replayed_through.is_none()
+        && !semantic_prefix_match
+    {
         let last_h = &history[history.len() - 1];
-        new_input.iter().rposition(|n| items_semantically_equal(last_h, n))
+        new_input
+            .iter()
+            .rposition(|n| items_semantically_equal(last_h, n))
     } else {
         None
     };
@@ -268,17 +285,22 @@ pub fn prepare_session_input(
     };
 
     let delta = merge_history_with_new_input(Vec::new(), &[], delta_source, tool_call_cache);
-    let merged = if reset_parent || history.is_empty() {
+    let stored_delta = if retain_delta {
         delta.clone()
+    } else {
+        Vec::new()
+    };
+    let merged = if reset_parent || history.is_empty() {
+        delta
     } else if use_new_input_as_merged {
         merge_history_with_new_input(Vec::new(), &[], new_input, tool_call_cache)
     } else {
-        merge_history_with_new_input(history, &[], delta.clone(), tool_call_cache)
+        merge_history_with_new_input(history, &[], delta, tool_call_cache)
     };
 
     PreparedSessionInput {
         merged,
-        delta,
+        delta: stored_delta,
         reset_parent,
     }
 }
@@ -444,6 +466,42 @@ mod tests {
             model: "gemini-3.7-flash-high".to_string(),
             last_accessed: Instant::now(),
         }
+    }
+
+    #[test]
+    fn responses_store_false_restores_full_input_without_retaining_delta() {
+        let history = vec![
+            json!({"id": "old", "role": "user", "content": "x".repeat(32768)}),
+            json!({"id": "answer", "role": "assistant", "content": "prior answer"}),
+        ];
+        let next = json!({"id": "new", "role": "user", "content": "y".repeat(32768)});
+        let mut full_input = history.clone();
+        full_input.push(next.clone());
+        for replay in [vec![next], full_input.clone()] {
+            let prepared =
+                prepare_session_input_with_storage(history.clone(), replay, &HashMap::new(), false);
+            assert!(prepared.delta.is_empty());
+            assert_eq!(prepared.merged, full_input);
+        }
+        let prepared =
+            prepare_session_input_with_storage(Vec::new(), history.clone(), &HashMap::new(), false);
+        assert!(prepared.delta.is_empty());
+        assert_eq!(prepared.merged, history);
+    }
+
+    #[test]
+    fn responses_store_false_full_tool_replay_needs_no_global_cache() {
+        let call_id = format!("uncached-{}", uuid::Uuid::new_v4());
+        let input = vec![
+            json!({"id":"call-item", "type":"function_call", "call_id":call_id, "name":"shell_command", "arguments":"{\"command\":\"pwd\"}"}),
+            json!({"type":"function_call_output", "call_id":call_id, "output":"/synthetic/workspace"}),
+            json!({"role":"user", "content":"continue"}),
+        ];
+        assert!(get_cached_tool_call(&call_id).is_none());
+        let prepared =
+            prepare_session_input_with_storage(Vec::new(), input.clone(), &HashMap::new(), false);
+        assert!(prepared.delta.is_empty());
+        assert_eq!(prepared.merged, input);
     }
 
     #[test]

--- a/src-tauri/src/proxy/mappers/openai/streaming.rs
+++ b/src-tauri/src/proxy/mappers/openai/streaming.rs
@@ -556,6 +556,7 @@ pub fn create_codex_sse_stream<S, E>(
     completion_tx: Option<
         tokio::sync::oneshot::Sender<(Vec<Value>, tokio::sync::oneshot::Sender<()>)>,
     >,
+    cache_tool_calls: bool,
 ) -> Pin<Box<dyn Stream<Item = Result<Bytes, String>> + Send>>
 where
     S: Stream<Item = Result<Bytes, E>> + Send + ?Sized + 'static,
@@ -921,7 +922,9 @@ where
                                                                 yield Ok::<Bytes, String>(codex_sse_frame(&done_ev));
 
                                                                 let tc_val = item_obj.clone();
-                                                                crate::proxy::handlers::openai::insert_cached_tool_call(call_id.clone(), tc_val.clone());
+                                                                if cache_tool_calls {
+                                                                    crate::proxy::handlers::openai::insert_cached_tool_call(call_id.clone(), tc_val.clone());
+                                                                }
                                                                 if is_custom_tool && (actual_name == "apply_patch" || actual_name == "apply_patch_v2") {
                                                                     crate::proxy::adapters::apply_patch_trace::emit(
                                                                         &crate::proxy::adapters::apply_patch_trace::ApplyPatchTrace {
@@ -1238,6 +1241,13 @@ mod tests {
     use serde_json::json;
 
     async fn collect_codex_stream(chunks: Vec<Value>) -> (String, Vec<Value>) {
+        collect_codex_stream_with_cache(chunks, true).await
+    }
+
+    async fn collect_codex_stream_with_cache(
+        chunks: Vec<Value>,
+        cache_tool_calls: bool,
+    ) -> (String, Vec<Value>) {
         let items: Vec<Result<Bytes, String>> = chunks
             .into_iter()
             .map(|chunk| Ok(Bytes::from(format!("data: {chunk}\n\n"))))
@@ -1250,6 +1260,7 @@ mod tests {
             0,
             "resp-test-codex-session".to_string(),
             None,
+            cache_tool_calls,
         );
 
         let mut raw = String::new();
@@ -1262,6 +1273,38 @@ mod tests {
             .filter_map(|data| serde_json::from_str::<Value>(data).ok())
             .collect();
         (raw, events)
+    }
+
+    #[tokio::test]
+    async fn responses_store_false_emits_complete_tool_call_without_caching_it() {
+        let (_, events) = collect_codex_stream_with_cache(vec![json!({
+            "response": {"candidates": [{
+                "finishReason": "STOP",
+                "content": {"parts": [{"functionCall": {"name":"shell_command", "args":{"command":"pwd"}}}]}
+            }]}
+        })], false).await;
+        let completed = events
+            .iter()
+            .find(|event| event["type"] == "response.completed")
+            .expect("completed response");
+        let call = completed["response"]["output"]
+            .as_array()
+            .expect("output")
+            .iter()
+            .find(|item| item["type"] == "function_call")
+            .expect("function call");
+        let call_id = call["call_id"].as_str().expect("call id");
+        assert_eq!(call["name"], "shell_command");
+        assert_eq!(
+            serde_json::from_str::<Value>(call["arguments"].as_str().expect("arguments"))
+                .expect("JSON arguments"),
+            json!({"command":"pwd"})
+        );
+        assert!(crate::proxy::handlers::openai::get_cached_tool_call(call_id).is_none());
+        assert!(events
+            .iter()
+            .any(|event| event["type"] == "response.output_item.done"
+                && event["item"]["call_id"] == call_id));
     }
 
     #[tokio::test]
@@ -1294,6 +1337,7 @@ mod tests {
             0,
             response_id.clone(),
             Some(completion_tx),
+            true,
         );
 
         let mut raw = String::new();


### PR DESCRIPTION
## Summary

Honor explicit boolean `store:false` in the HTTP Responses path so full-replay requests do not retain another session snapshot and completed-tool-call cache copy after they finish.

The fix is independently based on upstream `main` at `efc3827b3fa560c7191943307006725191b14c7d`. It changes three Rust files and does not include the request-ID, routing/signature, or tiered-model patches from #3404, #3405, and #3406.

## Changes

- `handlers/openai.rs`: inspect `store` before retaining input/instruction snapshots and parent references. When false, do not create a completion channel or background session-save task. Pass the same policy to the HTTP Codex SSE adapter.
- `http_session_store.rs`: add `prepare_session_input_with_storage(..., retain_delta)`. Materialize the same complete input, but avoid cloning and returning an additional retained delta when disabled. Keep the existing wrapper with storage enabled for unchanged callers.
- `mappers/openai/streaming.rs`: gate writes to the global tool-call cache while still emitting complete tool-call arguments, item-completion events, and response output. Existing stateful stream callers keep caching enabled.

## Compatibility and scope

- Only explicit boolean false disables storage; omitted, true, and the existing handling of null retain prior behavior.
- A known `previous_response_id` may still supply full history for the current request, even when the new response is not stored.
- Stateless clients must replay complete tool calls and tool outputs. Tool-output-only replay cannot rely on global-cache entries created by a previous `store:false` response.
- No new context truncation, summarization, image-policy change, WebSocket change, allocator tuning, hard cache budget, or TTL change.
- Current upstream does not persist the successful non-streaming HTTP response in this path; this PR preserves that behavior rather than importing the separate non-stream persistence feature from #3405. If #3405 is combined with this PR, its newly added non-stream `save_session_delta` call must also be guarded by `store_response`. The deployed combined implementation already uses that guard. This PR does not claim to fix missing-parent fallback or all stateful memory growth.

## Regression coverage

Four focused tests are included:

- `responses_store_defaults_to_enabled_and_honors_explicit_false`
- `responses_store_false_restores_full_input_without_retaining_delta`
- `responses_store_false_full_tool_replay_needs_no_global_cache`
- `responses_store_false_emits_complete_tool_call_without_caching_it`

Validation commands for the isolated branch (from `src-tauri`):

```sh
cargo test --release --locked --lib responses_store
cargo test --release --locked --lib proxy::http_session_store::tests
cargo test --release --locked --lib proxy::mappers::openai::streaming::tests
cargo test --release --locked --lib cancelled_response_drops_pending_session_save
cargo build --release --locked --bin antigravity-tools
```

All five commands passed on the isolated branch in the Debian 12 / Rust 1.98.0 builder on 2026-09-07, including the four new regressions, existing session/stream suites, cancellation regression, and release binary build. Modified-file rustfmt checks and `git diff --check` also passed. Existing compiler warnings remain; this is not a claim that the full project test suite or CI is green.

The independently built image also preserved the complete official v4.6.8 WebUI (28-file relative-path/size manifest matched). This validation image was not deployed to the running services.

### Initial upstream CI status

The [macOS Rust-check job](https://github.com/lbjlaq/Antigravity-Manager/actions/runs/34132759402/job/101776580110) failed at the repository-wide `cargo fmt -- --check` step before Clippy or compilation. Its formatting diffs name 22 files, all unchanged by this PR compared with its upstream base (for example, `modules/account.rs`, `proxy/mappers/openai/models.rs`, and `proxy/mappers/openai/request.rs`). None is one of this PR's three changed files, which pass the targeted rustfmt check. These pre-existing formatting issues are not folded into this memory fix. Other CI jobs were still running at the initial check; the Debian validation above is a separate result.

## Existing real HTTP evidence

The associated issue documents the complete setup and limitations. On the combined locally patched v4.6.8 deployment, 30 sequential `store:false` full-replay requests (approximately 718k-723k input tokens/request) increased backend RSS by **184.4 MiB before** versus **21.6 MiB after** this repair. All 30 requests per version passed content/tool-replay checks. Across functional, large-context, and default/true continuation checks, **100 real HTTP requests passed**.

Those measurements compare combined deployments, not pristine upstream images or this isolated PR in production. The baseline process was warm and the repaired one recreated; both ran the same functional warmup. Samples are request-end RSS, not in-request peaks. No 24-hour result is claimed. The fix reduces retained historical copies without discarding the current request's context.

Closes #3407
