### PR TITLE
fix(i18n): detect the system language on first launch

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sys-locale",
  "sysinfo",
  "tauri",
  "tauri-build",
@@ -4918,6 +4919,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 base64 = "0.22"
 sysinfo = "0.31"
+sys-locale = "0.3.2"
 tokio = { version = "1", features = ["full"] }
 url = "2.5.7"
 tauri-plugin-dialog = "2.6.0"

--- a/src-tauri/src/models/config.rs
+++ b/src-tauri/src/models/config.rs
@@ -173,7 +173,7 @@ impl Default for CircuitBreakerConfig {
 impl AppConfig {
     pub fn new() -> Self {
         Self {
-            language: "zh".to_string(),
+            language: crate::modules::i18n::default_language(),
             theme: "system".to_string(),
             auto_refresh: true,
             refresh_interval: 15,
@@ -199,5 +199,21 @@ impl AppConfig {
 impl Default for AppConfig {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppConfig;
+
+    #[test]
+    fn saved_language_is_preserved_when_loading_config() {
+        let mut config = AppConfig::new();
+        for language in ["en", "zh", "zh-TW", "ru"] {
+            config.language = language.to_string();
+            let saved = serde_json::to_string(&config).unwrap();
+            let restored: AppConfig = serde_json::from_str(&saved).unwrap();
+            assert_eq!(restored.language, language);
+        }
     }
 }

--- a/src-tauri/src/modules/i18n.rs
+++ b/src-tauri/src/modules/i18n.rs
@@ -1,6 +1,48 @@
 use serde_json::Value;
 use std::collections::HashMap;
 
+/// Choose the first supported OS language when creating a new configuration.
+/// Saved configurations keep their explicit language selection.
+pub fn default_language() -> String {
+    language_from_locales(sys_locale::get_locales()).to_string()
+}
+
+fn language_from_locales(locales: impl IntoIterator<Item = impl AsRef<str>>) -> &'static str {
+    locales
+        .into_iter()
+        .find_map(|locale| supported_language(locale.as_ref()))
+        .unwrap_or("en")
+}
+
+/// Normalize OS locale tags to the identifiers shared by the UI and tray menu.
+fn supported_language(locale: &str) -> Option<&'static str> {
+    let locale = locale
+        .split(['.', '@'])
+        .next()?
+        .replace('_', "-")
+        .to_ascii_lowercase();
+    let mut subtags = locale.split('-');
+    match subtags.next()? {
+        "zh" => Some(match subtags.next() {
+            // An explicit script takes precedence over the region (zh-Hans-TW).
+            Some("hant" | "tw" | "hk" | "mo") => "zh-TW",
+            _ => "zh",
+        }),
+        "en" => Some("en"),
+        "ja" => Some("ja"),
+        "tr" => Some("tr"),
+        "vi" => Some("vi"),
+        "pt" => Some("pt"),
+        "ru" => Some("ru"),
+        "ko" => Some("ko"),
+        "ar" => Some("ar"),
+        "es" => Some("es"),
+        // The existing Malay translation uses the application's legacy "my" key.
+        "ms" => Some("my"),
+        _ => None,
+    }
+}
+
 /// Tray text structure
 #[derive(Debug, Clone)]
 pub struct TrayTexts {
@@ -92,5 +134,74 @@ pub fn get_tray_texts(lang: &str) -> TrayTexts {
             .get("forbidden")
             .cloned()
             .unwrap_or_else(|| "Account Forbidden".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_tray_texts, language_from_locales};
+
+    #[test]
+    fn detects_supported_languages_from_os_locale_tags() {
+        for (locale, expected) in [
+            ("en-US", "en"),
+            ("en-GB", "en"),
+            ("ru-RU", "ru"),
+            ("ja-JP", "ja"),
+            ("tr-TR", "tr"),
+            ("vi-VN", "vi"),
+            ("pt-BR", "pt"),
+            ("pt-PT", "pt"),
+            ("ko-KR", "ko"),
+            ("ar-SA", "ar"),
+            ("es-MX", "es"),
+            ("ms-MY", "my"),
+            ("RU_ru.UTF-8", "ru"),
+            ("es_ES@euro", "es"),
+        ] {
+            assert_eq!(language_from_locales([locale]), expected, "{locale}");
+        }
+    }
+
+    #[test]
+    fn distinguishes_chinese_scripts_and_regions() {
+        for (locale, expected) in [
+            ("zh", "zh"),
+            ("zh-CN", "zh"),
+            ("zh-SG", "zh"),
+            ("zh-Hans", "zh"),
+            ("zh-Hans-TW", "zh"),
+            ("zh-TW", "zh-TW"),
+            ("zh-HK", "zh-TW"),
+            ("zh-MO", "zh-TW"),
+            ("zh-Hant", "zh-TW"),
+            ("zh-Hant-CN", "zh-TW"),
+        ] {
+            assert_eq!(language_from_locales([locale]), expected, "{locale}");
+        }
+    }
+
+    #[test]
+    fn honors_preference_order_and_skips_unsupported_languages() {
+        assert_eq!(language_from_locales(["de-DE", "ru-RU", "en-US"]), "ru");
+        assert_eq!(language_from_locales(["en-GB", "zh-CN"]), "en");
+        assert_eq!(language_from_locales(["zh-TW", "en-US"]), "zh-TW");
+    }
+
+    #[test]
+    fn falls_back_to_english_without_a_supported_locale() {
+        assert_eq!(language_from_locales(Vec::<String>::new()), "en");
+        for locale in ["", "C", "POSIX", "C.UTF-8", "de-DE", "my-MM"] {
+            assert_eq!(language_from_locales([locale]), "en", "{locale}");
+        }
+    }
+
+    #[test]
+    fn tray_uses_the_detected_language() {
+        let language = language_from_locales(["ru-RU"]);
+        let texts = get_tray_texts(language);
+        let russian: serde_json::Value =
+            serde_json::from_str(include_str!("../../../src/locales/ru.json")).unwrap();
+        assert_eq!(texts.quit, russian["tray"]["quit"].as_str().unwrap());
     }
 }


### PR DESCRIPTION
Fresh installs persist `language: "zh"` in `AppConfig::new()`. Once `App.tsx` loads that configuration, it overrides the frontend language detector with Chinese, including on English and Russian systems.

Initialize the language from the first supported OS preference using [`sys-locale`](https://docs.rs/sys-locale/0.3.2/sys_locale/), which supports macOS, Windows and Linux. Normalize regional tags to the existing UI/tray identifiers, distinguish simplified and traditional Chinese, and use English if no supported preference is available.

This is a one-time default for new configurations. Saved language choices remain authoritative. For headless deployments, the initial shared configuration uses the server host's locale.

Validation on macOS Apple Silicon:
- All five locale/tray regression tests passed, covering supported languages, preference order, regional/script variants and fallback.
- The saved-language round-trip regression test passed.
- A direct native smoke check returned OS locales `["ru-RU"]` and initial app language `ru`.
- `npm ci --legacy-peer-deps --no-audit --no-fund` and `npm run build` passed.
- `cargo clippy --locked --all-targets --all-features` and `cargo check --locked` passed with existing project warnings.
- `rustfmt --edition 2021 --check` passed for both changed Rust files; `git diff --check` passed.

The repository-wide `cargo fmt -- --check` reports existing formatting differences in untouched files. Native Windows/Linux execution has not been tested locally.
