### PR TITLE
fix(proxy): scope sessionId per conversation and auto-bump on upstream 1M token accumulation

### DIFF
--- a/src-tauri/src/proxy/common/session.rs
+++ b/src-tauri/src/proxy/common/session.rs
@@ -12,6 +12,57 @@ pub fn derive_session_id(account_id: &str) -> String {
     hash.to_string()
 }
 
+// [FIX session-1M] Upstream accumulates conversation input server-side per sessionId.
+// A session that drives many tool loops can push the accumulated input past 1M tokens,
+// after which EVERY request with the same sessionId fails with
+// 400 "The input token count exceeds the maximum number of tokens allowed 1048576"
+// until the upstream session expires. Bumping the sessionId generation forces the
+// upstream to start a fresh session, transparently recovering the conversation.
+
+/// Monotonic generation counter per (account_id, conversation fingerprint).
+static SESSION_BUMPS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<String, u64>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+fn bump_key(account_id: &str, fingerprint: &str) -> String {
+    format!("{}::{}", account_id, fingerprint)
+}
+
+/// Current sessionId generation for (account, conversation). Starts at 0.
+pub fn current_bump(account_id: &str, fingerprint: &str) -> u64 {
+    if let Ok(map) = SESSION_BUMPS.lock() {
+        map.get(&bump_key(account_id, fingerprint)).copied().unwrap_or(0)
+    } else {
+        0
+    }
+}
+
+/// Advance the sessionId generation for (account, conversation) and return the new value.
+pub fn bump_session(account_id: &str, fingerprint: &str) -> u64 {
+    if let Ok(mut map) = SESSION_BUMPS.lock() {
+        let counter = map.entry(bump_key(account_id, fingerprint)).or_insert(0);
+        *counter += 1;
+        tracing::warn!(
+            "[Session] Bumped sessionId generation to {} for account {} fingerprint {}",
+            counter,
+            &account_id[..account_id.len().min(8)],
+            &fingerprint[..fingerprint.len().min(16)]
+        );
+        *counter
+    } else {
+        0
+    }
+}
+
+/// Derive the upstream sessionId for (account, conversation fingerprint, generation).
+/// Stable within one conversation generation (keeps upstream server-side cache hits),
+/// but distinct across conversations and after a bump.
+pub fn derive_session_scoped(account_id: &str, fingerprint: &str, generation: u64) -> String {
+    if fingerprint.is_empty() && generation == 0 {
+        return derive_session_id(account_id);
+    }
+    derive_session_id(&format!("{}|{}|{}", account_id, fingerprint, generation))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -21,5 +72,46 @@ mod tests {
         let x = derive_session_id("my_account@gmail.com");
         let y = derive_session_id("my_account@gmail.com");
         assert_eq!(x, y);
+    }
+
+    #[test]
+    fn test_bump_isolated_per_account_and_fingerprint() {
+        let a1 = current_bump("acc1", "fp1");
+        let a2 = current_bump("acc2", "fp1");
+        let a3 = current_bump("acc1", "fp2");
+        assert_eq!(a1, 0);
+        assert_eq!(a2, 0);
+        assert_eq!(a3, 0);
+
+        assert_eq!(bump_session("acc1", "fp1"), 1);
+        assert_eq!(current_bump("acc1", "fp1"), 1);
+        // other keys untouched
+        assert_eq!(current_bump("acc2", "fp1"), 0);
+        assert_eq!(current_bump("acc1", "fp2"), 0);
+
+        assert_eq!(bump_session("acc1", "fp1"), 2);
+        assert_eq!(current_bump("acc1", "fp1"), 2);
+    }
+
+    #[test]
+    fn test_derive_session_scoped() {
+        // Generation 0 with empty fingerprint keeps legacy behavior
+        assert_eq!(derive_session_scoped("acc", "", 0), derive_session_id("acc"));
+        // Same inputs -> stable
+        assert_eq!(
+            derive_session_scoped("acc", "fp", 0),
+            derive_session_scoped("acc", "fp", 0)
+        );
+        // Different fingerprint or generation -> distinct sessions
+        assert_ne!(
+            derive_session_scoped("acc", "fp1", 0),
+            derive_session_scoped("acc", "fp2", 0)
+        );
+        assert_ne!(
+            derive_session_scoped("acc", "fp", 0),
+            derive_session_scoped("acc", "fp", 1)
+        );
+        // Still a valid signed-integer string (official client format)
+        assert!(derive_session_scoped("acc", "fp", 1).parse::<i64>().is_ok());
     }
 }

--- a/src-tauri/src/proxy/handlers/openai.rs
+++ b/src-tauri/src/proxy/handlers/openai.rs
@@ -2720,6 +2720,19 @@ pub async fn handle_chat_completions(
             continue; // 重试
         }
 
+        // [FIX session-1M] 上游按 sessionId 在服务端累计会话输入,长工具循环会把累计推过 1M,
+        // 之后该 sessionId 的所有请求都 400 "input token count exceeds ... 1048576"。
+        // 给 (账号, 对话) 的 sessionId 升代并立即重试:新 sessionId = 上游全新会话,对话无感恢复。
+        if status_code == 400 && error_text.contains("exceeds the maximum number of tokens") {
+            let fingerprint = SessionManager::extract_openai_session_id(&openai_req);
+            let generation = crate::proxy::common::session::bump_session(&account_id, &fingerprint);
+            tracing::warn!(
+                "[OpenAI] Upstream session token accumulation exceeded 1M on account {}. sessionId bumped to generation {}, retrying with a fresh upstream session.",
+                email, generation
+            );
+            continue; // 重试:下一轮 transform 时读取新代数,派生全新 sessionId
+        }
+
         // 404 等由于模型配置或路径错误的 HTTP 异常，直接报错，不进行无效轮换
         error!(
             "OpenAI Upstream non-retryable error {} on account {}: {}",

--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -697,9 +697,11 @@ pub fn transform_claude_request_in(
     }
 
     // [ADDED v4.1.24] 注入稳定 sessionId 对齐官方规范
+    // [FIX session-1M] 混入对话指纹与代数,不同对话隔离服务端会话,1M 累计报错后 bump 自愈
     if let Some(account_id) = account_id {
+        let generation = crate::proxy::common::session::current_bump(account_id, &session_id);
         inner_request["sessionId"] =
-            json!(crate::proxy::common::session::derive_session_id(account_id));
+            json!(crate::proxy::common::session::derive_session_scoped(account_id, &session_id, generation));
     }
 
     // 生成 requestId

--- a/src-tauri/src/proxy/mappers/gemini/wrapper.rs
+++ b/src-tauri/src/proxy/mappers/gemini/wrapper.rs
@@ -797,9 +797,15 @@ pub fn wrap_request_v2(
     }
 
     // [ADDED v4.1.24] 注入基于账号的稳定 sessionId
+    // [FIX session-1M] 混入对话指纹与代数,不同对话隔离服务端会话,1M 累计报错后 bump 自愈
     if let Some(account_id_str) = account_id {
-        inner_request["sessionId"] = json!(crate::proxy::common::session::derive_session_id(
-            account_id_str
+        let fingerprint = session_id.unwrap_or("default");
+        let generation =
+            crate::proxy::common::session::current_bump(account_id_str, fingerprint);
+        inner_request["sessionId"] = json!(crate::proxy::common::session::derive_session_scoped(
+            account_id_str,
+            fingerprint,
+            generation
         ));
     }
 

--- a/src-tauri/src/proxy/mappers/openai/request.rs
+++ b/src-tauri/src/proxy/mappers/openai/request.rs
@@ -1363,9 +1363,17 @@ pub fn transform_openai_request_with_session(
     }
 
     // [ADDED v4.1.24] 注入稳定 sessionId 对齐官方规范
+    // [FIX session-1M] sessionId 混入对话指纹与代数:
+    //   - 同一对话内保持稳定(保留上游服务端会话缓存收益)
+    //   - 不同对话使用不同 sessionId,避免共享同一服务端累计会话
+    //   - 检测到上游 1M 累计报错后 bump 代数,新 sessionId = 全新上游会话,对话无感恢复
     if let Some(t) = token {
-        inner_request["sessionId"] = json!(crate::proxy::common::session::derive_session_id(
-            &t.account_id
+        let generation =
+            crate::proxy::common::session::current_bump(&t.account_id, &session_id);
+        inner_request["sessionId"] = json!(crate::proxy::common::session::derive_session_scoped(
+            &t.account_id,
+            &session_id,
+            generation
         ));
     }
 


### PR DESCRIPTION
## 问题

同一账号的**所有对话共享同一个上游 sessionId**(`sessionId = FNV1a(账号邮箱)`,v4.1.24 引入)。Antigravity 上游会**按 sessionId 在服务端累计会话输入**,因此长工具循环会话(如 RikkaHub/Claude Code/OpenCode 等带 MCP 工具的客户端)会把服务端累计推过 1M,之后该账号**所有请求**持续返回:

```
400 INVALID_ARGUMENT: The input token count exceeds the maximum number of tokens allowed 1048576.
```

直到上游 session 过期或调度器轮换到其他账号。这也解释了 #3325 报告的"60K/200K/600K 不固定触发"(取决于会话轮次内容量)以及 #3411 中"每轮注入 20KB 签名,长对话上下文爆炸"的现象。

## 证据(#3411 中已详述)

- 同一 131KB 请求体(客户端实际仅 ~31K tokens):
  - 被污染账号:400 `1048576`(重启容器后依然 400)
  - 其他账号:200 成功
- 被污染账号一次成功响应中 `usage.prompt_tokens=172845`,而客户端仅发送 22KB —— 服务端会话累计的实锤
- `[FIX #3325]` 的历史裁剪只能减缓增长,无法阻止单会话内累计突破 1M

## 修复

1. **sessionId 按对话隔离**(OpenAI / Claude / Gemini 三个入口统一):
   `sessionId = FNV1a(account_id | 对话指纹 | 代数)`
   - 同一对话内稳定 → 保留上游服务端会话缓存收益
   - 不同对话互不共享服务端会话 → 单会话爆炸不再殃及全账号
2. **1M 自愈**:OpenAI 重试循环检测到 `exceeds the maximum number of tokens` 时,对该 (账号, 对话) 的 sessionId 升代并立即重试 —— 新 sessionId = 上游全新会话,对话无感恢复(复用现有"签名失效重试"的模式,同会话不换账号、不消耗额外配额)

## 测试

- 新增单元测试:bump 计数按 (账号, 指纹) 隔离;`derive_session_scoped` 同输入稳定、跨对话/跨代数不同、输出保持官方的大负整数格式
- 本地部署实测:被 1M 污染的账号,其原 400 请求在新逻辑下正常完成对话
- 全量 `cargo test --lib`:553 passed(35 个失败为 main 分支基线自带,与本 PR 无关,均为 thinking budget 断言)

Fixes #3411, refs #3325