### PR TITLE
fix: write account and config files atomically (tmp + fsync + rename)

### DIFF
--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -636,28 +636,12 @@ fn load_account_index_in_dir(data_dir: &PathBuf) -> Result<AccountIndex, String>
 /// Save account index to a specific directory (internal helper)
 fn save_account_index_in_dir(data_dir: &PathBuf, index: &AccountIndex) -> Result<(), String> {
     let index_path = data_dir.join(ACCOUNTS_INDEX);
-    // Use unique temp file name per write to avoid collision
-    let temp_filename = format!("{}.tmp.{}", ACCOUNTS_INDEX, Uuid::new_v4());
-    let temp_path = data_dir.join(&temp_filename);
 
     let content = serde_json::to_string_pretty(index)
         .map_err(|e| format!("failed_to_serialize_account_index: {}", e))?;
 
-    // Write to temporary file
-    if let Err(e) = fs::write(&temp_path, content) {
-        // Clean up temp file on failure
-        let _ = fs::remove_file(&temp_path);
-        return Err(format!("failed_to_write_temp_index_file: {}", e));
-    }
-
-    // Atomic rename with platform-specific handling
-    if let Err(e) = atomic_replace_file(&temp_path, &index_path) {
-        // Clean up temp file on failure
-        let _ = fs::remove_file(&temp_path);
-        return Err(format!("failed_to_replace_index_file: {}", e));
-    }
-
-    Ok(())
+    crate::utils::fs::write_atomic(&index_path, content.as_bytes())
+        .map_err(|e| format!("failed_to_save_account_index: {}", e))
 }
 
 /// Rebuild AccountIndex by scanning accounts/*.json files in specific directory
@@ -783,7 +767,7 @@ fn try_save_recovered_index(
         let timestamp = chrono::Utc::now().timestamp();
         let backup_name = format!("accounts.json.corrupt-{}-{}", timestamp, Uuid::new_v4());
         let backup_path = data_dir.join(&backup_name);
-        if let Err(e) = fs::write(&backup_path, content) {
+        if let Err(e) = crate::utils::fs::write_atomic(&backup_path, content) {
             crate::modules::logger::log_warn(&format!(
                 "Failed to backup corrupt index to {}: {}",
                 backup_name, e
@@ -824,57 +808,6 @@ pub fn save_account_index(index: &AccountIndex) -> Result<(), String> {
     save_account_index_in_dir(&data_dir, index)
 }
 
-/// Platform-specific atomic file replacement
-#[cfg(target_os = "windows")]
-fn atomic_replace_file(src: &PathBuf, dst: &PathBuf) -> Result<(), String> {
-    use std::os::windows::ffi::OsStrExt;
-
-    type Bool = i32;
-    type Dword = u32;
-
-    #[link(name = "Kernel32")]
-    extern "system" {
-        fn MoveFileExW(
-            lp_existing_file_name: *const u16,
-            lp_new_file_name: *const u16,
-            dw_flags: Dword,
-        ) -> Bool;
-    }
-
-    let src_wide: Vec<u16> = src
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect();
-    let dst_wide: Vec<u16> = dst
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect();
-
-    // MOVEFILE_REPLACE_EXISTING = 0x1
-    // MOVEFILE_WRITE_THROUGH = 0x8
-    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
-    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
-    let flags = MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH;
-
-    let result = unsafe { MoveFileExW(src_wide.as_ptr(), dst_wide.as_ptr(), flags) };
-    if result == 0 {
-        let err = std::io::Error::last_os_error();
-        // Clean up source file on failure
-        let _ = fs::remove_file(src);
-        return Err(format!("MoveFileExW failed: {}", err));
-    }
-
-    Ok(())
-}
-
-/// Non-Windows: use standard rename
-#[cfg(not(target_os = "windows"))]
-fn atomic_replace_file(src: &PathBuf, dst: &PathBuf) -> Result<(), String> {
-    fs::rename(src, dst).map_err(|e| format!("rename failed: {}", e))
-}
-
 /// Load account data
 pub fn load_account(account_id: &str) -> Result<Account, String> {
     let accounts_dir = get_accounts_dir()?;
@@ -887,28 +820,11 @@ fn save_account_at_path(account_path: &PathBuf, account: &Account) -> Result<(),
     let _lock = get_account_lock(&account.id);
     let _guard = _lock.lock().unwrap();
 
-    let parent_dir = account_path
-        .parent()
-        .map(|p| p.to_path_buf())
-        .ok_or_else(|| "invalid_account_path".to_string())?;
-
-    let temp_filename = format!("{}.tmp.{}", account.id, Uuid::new_v4());
-    let temp_path = parent_dir.join(&temp_filename);
-
     let content = serde_json::to_string_pretty(account)
         .map_err(|e| format!("failed_to_serialize_account_data: {}", e))?;
 
-    if let Err(e) = std::fs::write(&temp_path, content) {
-        let _ = std::fs::remove_file(&temp_path);
-        return Err(format!("failed_to_write_temp_account_file: {}", e));
-    }
-
-    if let Err(e) = atomic_replace_file(&temp_path, account_path) {
-        let _ = std::fs::remove_file(&temp_path);
-        return Err(format!("failed_to_replace_account_file: {}", e));
-    }
-
-    Ok(())
+    crate::utils::fs::write_atomic(account_path, content.as_bytes())
+        .map_err(|e| format!("failed_to_save_account_file: {}", e))
 }
 
 /// Save account data (thread-safe and atomic)

--- a/src-tauri/src/modules/config.rs
+++ b/src-tauri/src/modules/config.rs
@@ -98,7 +98,7 @@ pub fn load_app_config() -> Result<AppConfig, String> {
     Ok(config)
 }
 
-/// Save application configuration
+/// Save application configuration (atomic write)
 pub fn save_app_config(config: &AppConfig) -> Result<(), String> {
     let data_dir = get_data_dir()?;
     let config_path = data_dir.join(CONFIG_FILE);
@@ -106,5 +106,6 @@ pub fn save_app_config(config: &AppConfig) -> Result<(), String> {
     let content = serde_json::to_string_pretty(config)
         .map_err(|e| format!("failed_to_serialize_config: {}", e))?;
 
-    fs::write(&config_path, content).map_err(|e| format!("failed_to_save_config: {}", e))
+    crate::utils::fs::write_atomic(&config_path, content.as_bytes())
+        .map_err(|e| format!("failed_to_save_config: {}", e))
 }

--- a/src-tauri/src/proxy/token_manager.rs
+++ b/src-tauri/src/proxy/token_manager.rs
@@ -296,7 +296,7 @@ impl TokenManager {
                     // 跳过无效账号
                 }
                 Err(e) => {
-                    tracing::debug!("加载账号失败 {:?}: {}", path, e);
+                    tracing::warn!("加载账号失败 {:?}: {}", path, e);
                 }
             }
         }

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -1,0 +1,153 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+/// Platform-specific atomic file replacement
+#[cfg(target_os = "windows")]
+fn atomic_replace_file(src: &Path, dst: &Path) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt;
+
+    type Bool = i32;
+    type Dword = u32;
+
+    #[link(name = "Kernel32")]
+    extern "system" {
+        fn MoveFileExW(
+            lp_existing_file_name: *const u16,
+            lp_new_file_name: *const u16,
+            dw_flags: Dword,
+        ) -> Bool;
+    }
+
+    let src_wide: Vec<u16> = src
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let dst_wide: Vec<u16> = dst
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // MOVEFILE_REPLACE_EXISTING = 0x1
+    // MOVEFILE_WRITE_THROUGH = 0x8
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+    let flags = MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH;
+
+    let result = unsafe { MoveFileExW(src_wide.as_ptr(), dst_wide.as_ptr(), flags) };
+    if result == 0 {
+        let err = std::io::Error::last_os_error();
+        let _ = std::fs::remove_file(src);
+        return Err(format!("MoveFileExW failed: {}", err));
+    }
+
+    Ok(())
+}
+
+/// Non-Windows: use standard atomic rename
+#[cfg(not(target_os = "windows"))]
+fn atomic_replace_file(src: &Path, dst: &Path) -> Result<(), String> {
+    std::fs::rename(src, dst).map_err(|e| format!("rename failed: {}", e))
+}
+
+/// Atomically write bytes to a file at `target_path`.
+///
+/// Steps:
+/// 1. Create a unique temporary file in the same directory (`<file>.tmp.<uuid>`).
+/// 2. Write content and call `sync_all()` to flush buffers to physical disk.
+/// 3. Replace target file via atomic rename (`MoveFileExW` with `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH` on Windows, `fs::rename` on POSIX).
+/// 4. If any step fails, remove the temporary file.
+pub fn write_atomic<P: AsRef<Path>>(target_path: P, content: &[u8]) -> Result<(), String> {
+    let target = target_path.as_ref();
+    let parent_dir = target
+        .parent()
+        .ok_or_else(|| "Target path has no parent directory".to_string())?;
+
+    let file_name = target
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("file");
+    let temp_filename = format!("{}.tmp.{}", file_name, Uuid::new_v4());
+    let temp_path: PathBuf = parent_dir.join(temp_filename);
+
+    let mut file = File::create(&temp_path)
+        .map_err(|e| format!("Failed to create temporary file {:?}: {}", temp_path, e))?;
+
+    if let Err(e) = file.write_all(content) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(format!(
+            "Failed to write to temporary file {:?}: {}",
+            temp_path, e
+        ));
+    }
+
+    if let Err(e) = file.sync_all() {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(format!(
+            "Failed to fsync temporary file {:?}: {}",
+            temp_path, e
+        ));
+    }
+
+    // Explicitly drop file handle before rename to release Windows lock
+    drop(file);
+
+    if let Err(e) = atomic_replace_file(&temp_path, target) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(format!("Failed to atomically replace {:?}: {}", target, e));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_write_atomic_basic() {
+        let temp_dir = std::env::temp_dir().join(format!("test_atomic_{}", Uuid::new_v4()));
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let target_file = temp_dir.join("config.json");
+        let initial_data = b"{\"key\":\"initial_value\"}";
+        write_atomic(&target_file, initial_data).expect("First write should succeed");
+
+        assert_eq!(fs::read(&target_file).unwrap(), initial_data);
+
+        let updated_data = b"{\"key\":\"updated_value\"}";
+        write_atomic(&target_file, updated_data).expect("Overwrite should succeed");
+
+        assert_eq!(fs::read(&target_file).unwrap(), updated_data);
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_write_atomic_survives_partial_tmp() {
+        let temp_dir = std::env::temp_dir().join(format!("test_atomic_partial_{}", Uuid::new_v4()));
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let target_file = temp_dir.join("accounts.json");
+        let good_data = b"{\"valid\":true}";
+        write_atomic(&target_file, good_data).expect("Initial write should succeed");
+
+        // Simulate leftover half-written temp file from a simulated crash / power loss
+        let leftover_tmp = temp_dir.join("accounts.json.tmp.aborted");
+        fs::write(&leftover_tmp, b"{\"valid\":false, truncated...").unwrap();
+
+        // Target file should remain intact and valid
+        assert_eq!(fs::read(&target_file).unwrap(), good_data);
+
+        // Next write should succeed cleanly
+        let next_data = b"{\"valid\":true,\"generation\":2}";
+        write_atomic(&target_file, next_data).expect("Subsequent write should succeed");
+        assert_eq!(fs::read(&target_file).unwrap(), next_data);
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod command;
 pub mod crypto;
+pub mod fs;
 pub mod http;
 pub mod protobuf;


### PR DESCRIPTION
### Summary

This PR addresses potential account data loss and 0-byte corruption when the host system crashes, loses power, or encounters temporary disk full/exhaustion conditions.

### Details
1. **Centralized Atomic Write Utility (`src-tauri/src/utils/fs.rs`)**:
   - Implements `write_atomic` which creates a unique temporary file (`<file>.tmp.<uuid>`) in the same directory.
   - Flushes user-space buffers via `write_all` and forces OS physical sync via `sync_all` (`fsync`).
   - Atomically replaces the destination file using platform-appropriate APIs (`MoveFileExW` with `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH` on Windows, `fs::rename` on Unix/POSIX).
   - Cleans up temporary files if any error occurs during write or sync.

2. **Atomic Writes for Critical Files (`src-tauri/src/modules/account.rs`, `src-tauri/src/modules/config.rs`)**:
   - Replaced custom incomplete temp-file writes in `save_account_index_in_dir` and `save_account_at_path` with `write_atomic`, ensuring `sync_all` is guaranteed before renaming.
   - Replaced direct non-atomic `fs::write` in `gui_config.json` (`save_app_config`) and corrupt index backup (`try_save_recovered_index`).
   - Removed duplicated platform-specific rename routines in favor of the shared utility.

3. **Visibility for Loading Errors (`src-tauri/src/proxy/token_manager.rs`)**:
   - Promoted account loading parse failure logs from `debug` to `warn` level so silent data corruption can be detected in logs.
