### PR TITLE
fix: reduce signature cache log noise at info level

### DIFF
--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -1282,7 +1282,7 @@ fn build_contents(
                                 // Try session-based signature cache at specific msg_index first (Layer 3)
                                 crate::proxy::SignatureCache::global().get_session_signature_at(session_id, msg_index)
                                     .map(|s| {
-                                        tracing::info!(
+                                        tracing::debug!(
                                             "[Claude-Request] Recovered signature from SESSION cache at turn {} (session: {}, len: {})",
                                             msg_index, session_id, s.len()
                                         );
@@ -1293,7 +1293,7 @@ fn build_contents(
                                 // Fallback to latest session signature
                                 crate::proxy::SignatureCache::global().get_session_signature(session_id)
                                     .map(|s| {
-                                        tracing::info!(
+                                        tracing::debug!(
                                             "[Claude-Request] Recovered latest signature from SESSION cache (session: {}, len: {})",
                                             session_id, s.len()
                                         );

--- a/src-tauri/src/proxy/mappers/claude/thinking_utils.rs
+++ b/src-tauri/src/proxy/mappers/claude/thinking_utils.rs
@@ -211,14 +211,14 @@ pub fn filter_invalid_thinking_blocks_with_family(
                             // This happens after a server restart when memory is cleared.
                             // If we pass this unverified signature to the upstream, it will likely return 400 "Invalid signature".
                             // It is safer to strip the signature and let the upstream regenerate it.
-                            info!("[Thinking-Sanitizer] Dropping unverified signature (cache miss after restart)");
+                            debug!("[Thinking-Sanitizer] Dropping unverified signature (cache miss after restart)");
                             stripped_count += 1;
                             return false;
                         }
                     } else if get_signature_family(sig).is_none() && !sig.is_empty() {
                         // Even if no target family is specified, we still want to filter out signatures
                         // that we can't verify (unless they are empty, which indicates a fresh start).
-                        info!("[Thinking-Sanitizer] Dropping unverified signature (no target family)");
+                        debug!("[Thinking-Sanitizer] Dropping unverified signature (no target family)");
                         stripped_count += 1;
                         return false;
                     }


### PR DESCRIPTION
## Summary

Busy Claude Code clients can emit repeated signature-cache and sanitizer messages for the same request, producing hundreds of lines per request and roughly ~1 GB/day of Docker logs.

## Root cause

The messages are emitted inside per-tool-message and per-content-block loops while signatures are recovered or rejected, so the same session signature can be logged repeatedly at `info` level.

## Change

- Demote session-cache recovery messages to `debug!`.
- Demote unverified-signature sanitizer messages to `debug!`.

## Compatibility

Logging level only; request transformation and signature validation behavior are unchanged.

## Validation

`cargo fmt -- --check` was attempted; the repository currently has pre-existing formatting differences. `cargo check` was attempted and is blocked by the local missing NASM assembler required by `boring-sys2`.