### PR TITLE
chore(docker): add json-file log rotation to compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ cd docker
 # 2. 启动服务
 docker compose up -d
 ```
+> **日志轮转**: Compose 默认将 JSON 日志限制为单文件 `100m`、保留 `3` 个文件，避免日志无限增长。
 > **访问地址**: `http://localhost:8045` (管理后台) | `http://localhost:8045/v1` (API Base)
 > **系统要求**:
 > - **内存**: 建议 **1GB** (最小 256MB)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -224,6 +224,7 @@ cd docker
 # 2. Start the service
 docker compose up -d
 ```
+> **Log rotation**: Compose limits JSON logs to `100m` per file and keeps `3` files by default to prevent unbounded growth.
 > **Access URL**: `http://localhost:8045` (Admin Console) | `http://localhost:8045/v1` (API Base)
 > **System Requirements**:
 > - **RAM**: **1GB** recommended (minimum 256MB).

--- a/docker/docker-compose.backend.yml
+++ b/docker/docker-compose.backend.yml
@@ -4,3 +4,8 @@ services:
       dockerfile: docker/Dockerfile.backend
       args:
         FRONTEND_IMAGE: antigravity-manager:latest
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "3"

--- a/docker/docker-compose.localdist.yml
+++ b/docker/docker-compose.localdist.yml
@@ -3,3 +3,8 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.backend.localdist
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "3"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,3 +15,8 @@ services:
       - API_KEY=${API_KEY:-test}  # [重要] 請設置您的安全密鑰，若不設置則在日誌中查看隨機密鑰
       - ABV_BIND_LOCAL_ONLY=${ABV_BIND_LOCAL_ONLY:-true}  # 僅綁定 127.0.0.1
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "3"


### PR DESCRIPTION
## Summary

The Docker Compose configurations did not set a size or file-count limit for Docker's default `json-file` logs, allowing logs to grow without bound and fill small disks.

## Change

Add the following default logging policy to each Compose variant:

- `json-file` driver
- `max-size: "100m"`
- `max-file: "3"`

The defaults cap each service's retained logs at approximately 300 MB while preserving recent history for troubleshooting.

The Chinese and English Docker Compose examples also document the default rotation behavior.

## Compatibility

Compose configuration and documentation only; application behavior is unchanged.