### PR TITLE
feat: retention policy for proxy request logs

### DIFF
--- a/src-tauri/src/modules/proxy_db.rs
+++ b/src-tauri/src/modules/proxy_db.rs
@@ -1,3 +1,4 @@
+use crate::proxy::config::LogRetentionConfig;
 use crate::proxy::monitor::ProxyRequestLog;
 use rusqlite::{params, Connection};
 use std::path::PathBuf;
@@ -80,6 +81,57 @@ pub fn init_db() -> Result<(), String> {
     .map_err(|e| e.to_string())?;
 
     Ok(())
+}
+
+pub fn apply_retention(policy: &LogRetentionConfig) -> Result<(usize, usize), String> {
+    let conn = connect_db()?;
+    apply_retention_with_connection(&conn, policy)
+}
+
+fn apply_retention_with_connection(
+    conn: &Connection,
+    policy: &LogRetentionConfig,
+) -> Result<(usize, usize), String> {
+    let now = chrono::Utc::now().timestamp_millis();
+    let body_cutoff = now - (policy.max_body_age_hours as i64 * 3600 * 1000);
+    let age_cutoff = now - (policy.max_age_days as i64 * 24 * 3600 * 1000);
+    let bodies_cleared = conn.execute(
+        "UPDATE request_logs SET request_body = NULL, response_body = NULL WHERE timestamp < ?1 AND (request_body IS NOT NULL OR response_body IS NOT NULL)",
+        [body_cutoff],
+    ).map_err(|e| e.to_string())?;
+    let mut rows_deleted = conn
+        .execute(
+            "DELETE FROM request_logs WHERE timestamp < ?1",
+            [age_cutoff],
+        )
+        .map_err(|e| e.to_string())?;
+    if policy.max_rows > 0 {
+        rows_deleted += conn.execute(
+            "DELETE FROM request_logs WHERE id NOT IN (SELECT id FROM request_logs ORDER BY timestamp DESC LIMIT ?1)",
+            [policy.max_rows],
+        ).map_err(|e| e.to_string())?;
+    }
+    let auto_vacuum: i64 = conn
+        .pragma_query_value(None, "auto_vacuum", |row| row.get(0))
+        .map_err(|e| e.to_string())?;
+    if auto_vacuum == 0 {
+        let db_size = get_proxy_db_path()
+            .ok()
+            .and_then(|path| std::fs::metadata(path).ok())
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        if db_size < 1024 * 1024 * 1024 {
+            conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL; VACUUM;")
+                .map_err(|e| e.to_string())?;
+        } else {
+            tracing::warn!(
+                "Skipping auto_vacuum migration for proxy logs database larger than 1 GiB"
+            );
+        }
+    }
+    conn.execute_batch("PRAGMA incremental_vacuum;")
+        .map_err(|e| e.to_string())?;
+    Ok((bodies_cleared, rows_deleted))
 }
 
 pub fn save_log(log: &ProxyRequestLog) -> Result<(), String> {
@@ -226,6 +278,60 @@ pub fn get_log_detail(log_id: &str) -> Result<ProxyRequestLog, String> {
         })
     })
     .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod retention_tests {
+    use super::apply_retention_with_connection;
+    use crate::proxy::config::LogRetentionConfig;
+    use rusqlite::Connection;
+
+    #[test]
+    fn clears_old_bodies_and_limits_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE request_logs (id TEXT PRIMARY KEY, timestamp INTEGER, request_body TEXT, response_body TEXT)").unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        conn.execute(
+            "INSERT INTO request_logs VALUES ('retained-with-old-body', ?1, 'request', 'response')",
+            [now - 25 * 3600 * 1000],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO request_logs VALUES ('new-1', ?1, NULL, NULL)",
+            [now - 30 * 3600 * 1000],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO request_logs VALUES ('deleted-1', ?1, NULL, NULL)",
+            [now - 35 * 3600 * 1000],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO request_logs VALUES ('deleted-2', ?1, NULL, NULL)",
+            [now - 40 * 3600 * 1000],
+        )
+        .unwrap();
+        let policy = LogRetentionConfig {
+            max_body_age_hours: 24,
+            max_age_days: 30,
+            max_rows: 2,
+        };
+        let (cleared, deleted) = apply_retention_with_connection(&conn, &policy).unwrap();
+        assert_eq!(cleared, 1);
+        assert_eq!(deleted, 2);
+        let body: Option<String> = conn
+            .query_row(
+                "SELECT request_body FROM request_logs WHERE id = 'retained-with-old-body'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(body, None);
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM request_logs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2);
+    }
 }
 
 /// Cleanup old logs (keep last N days)

--- a/src-tauri/src/proxy/config.rs
+++ b/src-tauri/src/proxy/config.rs
@@ -626,6 +626,9 @@ pub struct ProxyConfig {
     #[serde(default)]
     pub enable_logging: bool,
 
+    #[serde(default)]
+    pub log_retention: LogRetentionConfig,
+
     /// 调试日志配置 (保存完整链路)
     #[serde(default)]
     pub debug_logging: DebugLoggingConfig,
@@ -693,6 +696,37 @@ pub struct ProxyConfig {
     pub proxy_pool: ProxyPoolConfig,
 }
 
+/// Request log retention policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogRetentionConfig {
+    #[serde(default = "default_max_body_age_hours")]
+    pub max_body_age_hours: u64,
+    #[serde(default = "default_max_age_days")]
+    pub max_age_days: u64,
+    #[serde(default = "default_max_rows")]
+    pub max_rows: u64,
+}
+
+fn default_max_body_age_hours() -> u64 {
+    24
+}
+fn default_max_age_days() -> u64 {
+    30
+}
+fn default_max_rows() -> u64 {
+    100_000
+}
+
+impl Default for LogRetentionConfig {
+    fn default() -> Self {
+        Self {
+            max_body_age_hours: 24,
+            max_age_days: 30,
+            max_rows: 100_000,
+        }
+    }
+}
+
 /// 上游代理配置
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UpstreamProxyConfig {
@@ -715,6 +749,7 @@ impl Default for ProxyConfig {
             custom_mapping: std::collections::HashMap::new(),
             request_timeout: default_request_timeout(),
             enable_logging: true, // 默认开启，支持 token 统计功能
+            log_retention: LogRetentionConfig::default(),
             debug_logging: DebugLoggingConfig::default(),
             upstream_proxy: UpstreamProxyConfig::default(),
             only_raw_quota_models: false,

--- a/src-tauri/src/proxy/monitor.rs
+++ b/src-tauri/src/proxy/monitor.rs
@@ -48,19 +48,51 @@ impl ProxyMonitor {
             tracing::error!("Failed to initialize proxy DB: {}", e);
         }
 
-        // Auto cleanup old logs (keep last 30 days)
-        tokio::task::spawn_blocking(
-            move || match crate::modules::proxy_db::cleanup_old_logs(30) {
-                Ok(deleted) => {
-                    if deleted > 0 {
-                        tracing::info!("Auto cleanup: removed {} old logs (>30 days)", deleted);
+        let retention = crate::modules::config::load_app_config()
+            .map(|config| config.proxy.log_retention)
+            .unwrap_or_default();
+        tokio::task::spawn_blocking(move || {
+            match crate::modules::proxy_db::apply_retention(&retention) {
+                Ok((cleared, deleted)) => {
+                    if cleared > 0 || deleted > 0 {
+                        tracing::info!(
+                            "Proxy log retention: cleared {} bodies, deleted {} rows",
+                            cleared,
+                            deleted
+                        );
                     }
                 }
                 Err(e) => {
                     tracing::error!("Failed to cleanup old logs: {}", e);
                 }
-            },
-        );
+            }
+        });
+
+        tokio::spawn(async {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(3600));
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                let retention = crate::modules::config::load_app_config()
+                    .map(|config| config.proxy.log_retention)
+                    .unwrap_or_default();
+                let result = tokio::task::spawn_blocking(move || {
+                    crate::modules::proxy_db::apply_retention(&retention)
+                })
+                .await;
+                match result {
+                    Ok(Ok((cleared, deleted))) => tracing::info!(
+                        "Proxy log retention: cleared {} bodies, deleted {} rows",
+                        cleared,
+                        deleted
+                    ),
+                    Ok(Err(error)) => {
+                        tracing::error!("Failed to apply proxy log retention: {}", error)
+                    }
+                    Err(error) => tracing::error!("Proxy log retention task failed: {}", error),
+                }
+            }
+        });
 
         Self {
             logs: RwLock::new(VecDeque::with_capacity(max_logs)),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -774,6 +774,10 @@
       "request_timeout_hint": "Default 120s, range 30-7200s. Restart service to apply changes.",
       "enable_logging": "Enable Request Logging",
       "enable_logging_hint": "Record history for debugging (Minor perf cost)",
+      "log_retention_title": "Request log retention",
+      "log_retention_body_hours": "Request body age (hours)",
+      "log_retention_age_days": "Log age (days)",
+      "log_retention_rows": "Maximum log rows",
       "upstream_proxy": {
         "title": "Global Upstream Proxy (Global Proxy)",
         "desc": "When enabled, all external requests (API Proxy, Token Refresh, Quota Check, Update Check) will be routed through this proxy.",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -767,6 +767,10 @@
       "request_timeout_hint": "默认 120 秒，范围 30-7200 秒。修改后需重启服务生效。",
       "enable_logging": "启用请求日志",
       "enable_logging_hint": "记录历史记录以便调试 (微小性能损耗)",
+      "log_retention_title": "请求日志保留",
+      "log_retention_body_hours": "请求体保留小时数",
+      "log_retention_age_days": "日志保留天数",
+      "log_retention_rows": "最大日志行数",
       "upstream_proxy": {
         "title": "全局上游代理 (Global Proxy)",
         "desc": "开启后，应用内所有外部请求（API 反代、Token 刷新、配额查询、更新检测）都将通过此代理。",

--- a/src/pages/ApiProxy.tsx
+++ b/src/pages/ApiProxy.tsx
@@ -1213,6 +1213,21 @@ print(response.choices[0].message.content)`;
                             </div>
 
 
+                            <div className="border-t border-gray-200 dark:border-base-300 pt-3 mt-3">
+                                <div className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">{t('proxy.config.log_retention_title')}</div>
+                                <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                                    {([['max_body_age_hours', 'log_retention_body_hours'], ['max_age_days', 'log_retention_age_days'], ['max_rows', 'log_retention_rows']] as const).map(([field, label]) => (
+                                        <label key={field} className="text-xs text-gray-600 dark:text-gray-400">
+                                            {t(`proxy.config.${label}`)}
+                                            <input type="number" min={1}
+                                                value={appConfig.proxy.log_retention?.[field] ?? (field === 'max_body_age_hours' ? 24 : field === 'max_age_days' ? 30 : 100000)}
+                                                onChange={(e) => updateProxyConfig({ log_retention: { ...(appConfig.proxy.log_retention || { max_body_age_hours: 24, max_age_days: 30, max_rows: 100000 }), [field]: Math.max(1, Number(e.target.value)) } })}
+                                                className="w-full mt-1 px-2.5 py-1.5 border border-gray-300 dark:border-base-200 rounded-lg bg-white dark:bg-base-200 text-xs" />
+                                        </label>
+                                    ))}
+                                </div>
+                            </div>
+
                             {/* 局域网访问 & 访问授权 - 合并到同一行 */}
                             <div className="border-t border-gray-200 dark:border-base-300 pt-3 mt-3">
                                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -14,6 +14,7 @@ export interface ProxyConfig {
     custom_mapping?: Record<string, string>;
     request_timeout: number;
     enable_logging: boolean;
+    log_retention?: LogRetentionConfig;
     debug_logging?: DebugLoggingConfig;
     upstream_proxy: UpstreamProxyConfig;
     zai?: ZaiConfig;
@@ -26,6 +27,18 @@ export interface ProxyConfig {
     image_thinking_mode?: 'enabled' | 'disabled'; // [NEW] 图像思维模式开关
     only_raw_quota_models?: boolean; // [NEW] 是否只暴露真实配额模型
     proxy_pool?: ProxyPoolConfig;
+}
+
+export interface LogRetentionConfig {
+    max_body_age_hours: number;
+    max_age_days: number;
+    max_rows: number;
+}
+
+export interface LogRetentionConfig {
+    max_body_age_hours: number;
+    max_age_days: number;
+    max_rows: number;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary  Busy CLI clients can write multiple GB of request bodies per day. This change bounds proxy request-log storage while preserving recent metadata for troubleshooting.  ## Changes  - Add `proxy.log_retention` defaults: 24-hour request/response body retention, 30-day row retention, and a 100,000-row cap. - Run retention once at startup and hourly thereafter. - Clear aged bodies, delete aged/over-limit rows, and run SQLite incremental vacuum. Small databases migrate to incremental auto-vacuum automatically; larger databases emit a warning instead of performing a startup VACUUM. - Add proxy settings inputs and zh/en translations.  ## Validation

- Added a unit test covering aged body clearing and row limits.
- `cargo test retention_tests --lib` (PASS)

```text
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 586 filtered out; finished in 0.01s
```

- `cargo check -p antigravity-tools` (PASS)

```text
Finished `dev` profile [unoptimized + debuginfo] (target(s) in 1.60s)
```
