### PR TITLE
feat(opencode): sync APIKEY.FUN credentials and models

### DIFF
--- a/docs/testing/opencode_sync_verification_checklist.md
+++ b/docs/testing/opencode_sync_verification_checklist.md
@@ -165,6 +165,37 @@ ls -la ~/.config/opencode/*.bak
 
 ---
 
+## APIKEY.FUN → OpenCode
+
+- [ ] On APIKEY.FUN, query a key's models and click **OpenCode**. Verify
+  `provider.apikey-fun` uses `@ai-sdk/openai-compatible`, the current key and
+  BaseURL, and the queried model IDs. Existing providers must remain unchanged.
+- [ ] Repeat with a saved BaseURL ending in `/v1/`; the stored URL must end in
+  exactly `/v1`, without a duplicate suffix.
+- [ ] Edit the key after querying, or switch keys while a query is in flight.
+  Models fetched with another key or URL must not be exported for the current key.
+- [ ] Verify the button is disabled while querying or syncing and for a blank key.
+- [ ] Sync a nonempty model list twice: unavailable models are removed, while
+  custom limits/options on surviving unknown models are preserved. Omitting models
+  (including a query that returned no models) preserves the existing model list.
+- [ ] With an existing `opencode.jsonc` containing comments, trailing commas,
+  Unicode instructions/paths, and another provider, sync and verify those values
+  survive. The original file must be preserved in the `.antigravity-manager.bak`
+  backup; subsequent syncs must not overwrite that backup.
+- [ ] With an invalid JSON/JSONC config, verify sync reports an error and leaves
+  the original file unchanged.
+- [ ] Verify both desktop invocation and the authenticated web endpoint
+  `POST /api/proxy/opencode/openai-sync`. In web/server deployments, the config is
+  written on the server running Antigravity Manager.
+- [ ] Restart OpenCode, select an `apikey-fun/…` model, and send a short request.
+
+Automated backend coverage:
+
+```bash
+cd src-tauri
+cargo test --lib opencode_sync
+```
+
 ## Test Environment
 
 - **OS**: 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -692,6 +692,7 @@ pub fn run() {
             proxy::opencode_sync::get_opencode_sync_status,
             proxy::opencode_sync::get_canonical_families,
             proxy::opencode_sync::execute_opencode_sync,
+            proxy::opencode_sync::execute_opencode_openai_sync,
             proxy::opencode_sync::execute_opencode_restore,
             proxy::opencode_sync::get_opencode_config_content,
             proxy::opencode_sync::execute_opencode_clear,

--- a/src-tauri/src/proxy/opencode_sync.rs
+++ b/src-tauri/src/proxy/opencode_sync.rs
@@ -23,6 +23,8 @@ const BACKUP_SUFFIX: &str = ".antigravity-manager.bak";
 const OLD_BACKUP_SUFFIX: &str = ".antigravity.bak";
 
 const ANTIGRAVITY_PROVIDER_ID: &str = "antigravity-manager";
+const APIKEY_FUN_PROVIDER_ID: &str = "apikey-fun";
+const OPENAI_COMPATIBLE_NPM: &str = "@ai-sdk/openai-compatible";
 
 /// Variant type for model variants
 #[derive(Debug, Clone, Copy)]
@@ -345,7 +347,7 @@ fn get_config_paths() -> Option<(PathBuf, PathBuf, PathBuf)> {
 /// handled separately by [`strip_jsonc_trailing_commas`].
 fn strip_jsonc_comments(input: &str) -> String {
     let bytes = input.as_bytes();
-    let mut out = String::with_capacity(input.len());
+    let mut out = Vec::with_capacity(input.len());
     let mut i = 0;
     let mut in_string = false;
 
@@ -353,10 +355,10 @@ fn strip_jsonc_comments(input: &str) -> String {
         let c = bytes[i];
 
         if in_string {
-            out.push(c as char);
+            out.push(c);
             if c == b'\\' && i + 1 < bytes.len() {
                 // Keep the escaped char verbatim (e.g. \", \\, \/).
-                out.push(bytes[i + 1] as char);
+                out.push(bytes[i + 1]);
                 i += 2;
                 continue;
             }
@@ -370,7 +372,7 @@ fn strip_jsonc_comments(input: &str) -> String {
         match c {
             b'"' => {
                 in_string = true;
-                out.push('"');
+                out.push(b'"');
                 i += 1;
             }
             b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
@@ -389,13 +391,14 @@ fn strip_jsonc_comments(input: &str) -> String {
                 i = (i + 2).min(bytes.len());
             }
             _ => {
-                out.push(c as char);
+                out.push(c);
                 i += 1;
             }
         }
     }
 
-    out
+    // Only ASCII syntax is removed; all UTF-8 string bytes remain intact.
+    String::from_utf8(out).expect("JSONC normalization preserves UTF-8")
 }
 
 /// Remove trailing commas (a `,` followed, after optional whitespace, by a closing
@@ -404,7 +407,7 @@ fn strip_jsonc_comments(input: &str) -> String {
 /// never touched.
 fn strip_jsonc_trailing_commas(input: &str) -> String {
     let bytes = input.as_bytes();
-    let mut out = String::with_capacity(input.len());
+    let mut out = Vec::with_capacity(input.len());
     let mut i = 0;
     let mut in_string = false;
 
@@ -412,9 +415,9 @@ fn strip_jsonc_trailing_commas(input: &str) -> String {
         let c = bytes[i];
 
         if in_string {
-            out.push(c as char);
+            out.push(c);
             if c == b'\\' && i + 1 < bytes.len() {
-                out.push(bytes[i + 1] as char);
+                out.push(bytes[i + 1]);
                 i += 2;
                 continue;
             }
@@ -427,7 +430,7 @@ fn strip_jsonc_trailing_commas(input: &str) -> String {
 
         if c == b'"' {
             in_string = true;
-            out.push('"');
+            out.push(b'"');
             i += 1;
             continue;
         }
@@ -452,17 +455,18 @@ fn strip_jsonc_trailing_commas(input: &str) -> String {
                 // Skip the comma (don't push it); leave the whitespace to be pushed normally.
                 i += 1;
             } else {
-                out.push(',');
+                out.push(b',');
                 i += 1;
             }
             continue;
         }
 
-        out.push(c as char);
+        out.push(c);
         i += 1;
     }
 
-    out
+    // Only ASCII syntax is removed; all UTF-8 string bytes remain intact.
+    String::from_utf8(out).expect("JSONC normalization preserves UTF-8")
 }
 
 /// Read and parse an OpenCode config file, tolerating JSONC comments and trailing commas.
@@ -1080,7 +1084,10 @@ fn build_variants_object(variant_type: Option<VariantType>) -> Option<Value> {
                 "low".to_string(),
                 build_gemini3_effort_variant(VariantTier::Low),
             );
-            variants.insert("medium".to_string(), serde_json::json!({ "disabled": true }));
+            variants.insert(
+                "medium".to_string(),
+                serde_json::json!({ "disabled": true }),
+            );
             variants.insert(
                 "high".to_string(),
                 build_gemini3_effort_variant(VariantTier::High),
@@ -1218,10 +1225,69 @@ fn build_fallback_model_json(model_id: &str, display_name: Option<&str>) -> Valu
     Value::Object(entry)
 }
 
+/// Bare model id without a `vendor/` prefix (`anthropic/claude-sonnet-4-6` -> `claude-sonnet-4-6`).
+fn strip_model_vendor_prefix(model_id: &str) -> &str {
+    model_id.rsplit('/').next().unwrap_or(model_id)
+}
+
+fn is_short_version_token(s: &str) -> bool {
+    let len = s.len();
+    (1..=2).contains(&len) && s.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Join adjacent 1–2 digit version tokens with dots (`4-6` -> `4.6`).
+fn merge_hyphenated_version_tokens(model_id: &str) -> String {
+    let parts: Vec<&str> = model_id.split('-').filter(|s| !s.is_empty()).collect();
+    let mut out: Vec<String> = Vec::with_capacity(parts.len());
+    let mut i = 0;
+    while i < parts.len() {
+        if i + 1 < parts.len()
+            && is_short_version_token(parts[i])
+            && is_short_version_token(parts[i + 1])
+        {
+            out.push(format!("{}.{}", parts[i], parts[i + 1]));
+            i += 2;
+        } else {
+            out.push(parts[i].to_string());
+            i += 1;
+        }
+    }
+    out.join("-")
+}
+
+/// IDs to try against the catalog: original, vendor-stripped, dotted/dashed version variants.
+fn catalog_lookup_ids(model_id: &str) -> Vec<String> {
+    let bare = strip_model_vendor_prefix(model_id.trim());
+    let mut ids = Vec::new();
+    let mut push = |id: String| {
+        if !id.is_empty() && !ids.iter().any(|existing| existing == &id) {
+            ids.push(id);
+        }
+    };
+    push(model_id.trim().to_string());
+    push(bare.to_string());
+    push(bare.replace('.', "-"));
+    push(merge_hyphenated_version_tokens(bare));
+    ids
+}
+
+fn lookup_catalog_model<'a>(
+    catalog: &HashMap<&str, &'a ModelDef>,
+    model_id: &str,
+) -> Option<&'a ModelDef> {
+    for candidate in catalog_lookup_ids(model_id) {
+        if let Some(model) = catalog.get(candidate.as_str()) {
+            return Some(*model);
+        }
+    }
+    None
+}
+
 /// Derive a readable name from a model id, preserving version dots
-/// (e.g. "gemini-3.5-flash-low" -> "Gemini 3.5 Flash Low").
+/// (e.g. "gemini-3.5-flash-low" -> "Gemini 3.5 Flash Low",
+/// "claude-sonnet-4-6" -> "Claude Sonnet 4.6").
 fn humanize_model_id(model_id: &str) -> String {
-    model_id
+    merge_hyphenated_version_tokens(strip_model_vendor_prefix(model_id))
         .split('-')
         .filter(|s| !s.is_empty())
         .map(|s| {
@@ -1422,6 +1488,91 @@ pub fn sync_opencode_config(
     if sync_accounts {
         sync_accounts_file(&ag_accounts_path)?;
     }
+
+    Ok(())
+}
+
+/// Provider ids become JSON keys in opencode.json and are accepted over the admin
+/// HTTP API, so restrict them to a safe charset.
+fn validate_provider_id(provider_id: &str) -> Result<(), String> {
+    if provider_id.is_empty() {
+        return Err("OpenCode provider id is required".to_string());
+    }
+    if !provider_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(format!(
+            "Invalid OpenCode provider id '{}': only letters, digits, '-' and '_' are allowed",
+            provider_id
+        ));
+    }
+    Ok(())
+}
+
+pub fn sync_opencode_openai_provider(
+    provider_id: &str,
+    provider_name: &str,
+    proxy_url: &str,
+    api_key: &str,
+    models_to_sync: Option<Vec<ModelInput>>,
+) -> Result<(), String> {
+    let provider_id = provider_id.trim();
+    validate_provider_id(provider_id)?;
+
+    let Some((config_path, _, _)) = get_config_paths() else {
+        return Err("Failed to get OpenCode config directory".to_string());
+    };
+
+    sync_openai_provider_to_path(
+        &config_path,
+        provider_id,
+        provider_name,
+        proxy_url,
+        api_key,
+        models_to_sync.as_deref(),
+    )
+}
+
+fn sync_openai_provider_to_path(
+    config_path: &PathBuf,
+    provider_id: &str,
+    provider_name: &str,
+    proxy_url: &str,
+    api_key: &str,
+    models_to_sync: Option<&[ModelInput]>,
+) -> Result<(), String> {
+    // A read/parse failure must never turn a user's existing config into {}.
+    let mut config = match fs::read_to_string(config_path) {
+        Ok(content) => parse_jsonc(&content)
+            .filter(Value::is_object)
+            .ok_or_else(|| {
+                "OpenCode config must be a valid JSON/JSONC object; file left unchanged".to_string()
+            })?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => serde_json::json!({}),
+        Err(error) => return Err(format!("Failed to read OpenCode config: {}", error)),
+    };
+
+    if let Some(parent) = config_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {}", e))?;
+    }
+
+    create_backup(config_path)?;
+
+    config = apply_openai_compatible_provider_sync(
+        config,
+        provider_id,
+        provider_name,
+        proxy_url,
+        api_key,
+        models_to_sync,
+    );
+
+    let tmp_path = config_path.with_extension("tmp");
+    fs::write(&tmp_path, serde_json::to_string_pretty(&config).unwrap())
+        .map_err(|e| format!("Failed to write temp file: {}", e))?;
+    fs::rename(&tmp_path, config_path)
+        .map_err(|e| format!("Failed to rename config file: {}", e))?;
 
     Ok(())
 }
@@ -1671,6 +1822,116 @@ fn apply_sync_to_config(
             merge_provider_options(ag_provider, &normalized_url, api_key);
             migrate_gemini_alias_models(ag_provider);
             merge_catalog_models(ag_provider, models_to_sync);
+        }
+    }
+
+    config
+}
+
+/// Replace the provider's model list with the given inputs. The list mirrors the
+/// models actually exposed by the upstream key, so models absent from the input are
+/// dropped (unlike the Antigravity sync which merges). Known catalog ids still get
+/// full catalog metadata, and user-defined fields on surviving models are preserved.
+fn replace_provider_models(provider: &mut Value, model_inputs: Option<&[ModelInput]>) {
+    if provider.get("models").is_none() {
+        provider["models"] = serde_json::json!({});
+    }
+
+    // An absent or empty list means "keep whatever is there" — e.g. the user synced
+    // before querying models, or called the HTTP API with no models field.
+    let Some(inputs) = model_inputs else {
+        return;
+    };
+    if inputs.is_empty() {
+        return;
+    }
+
+    let catalog = build_model_catalog();
+    let catalog_map: HashMap<&str, &ModelDef> = catalog.iter().map(|m| (m.id, m)).collect();
+    let existing_models: serde_json::Map<String, Value> = provider
+        .get("models")
+        .and_then(|m| m.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut models = serde_json::Map::new();
+    for input in inputs {
+        let model_id = input.id.trim();
+        if model_id.is_empty() {
+            continue;
+        }
+        let entry = match lookup_catalog_model(&catalog_map, model_id) {
+            Some(model_def) => {
+                let catalog_model = build_model_json(model_def);
+                match existing_models.get(model_id) {
+                    Some(existing) if existing.is_object() => {
+                        let mut merged = existing.as_object().unwrap().clone();
+                        if let Some(catalog_obj) = catalog_model.as_object() {
+                            for (key, value) in catalog_obj {
+                                merged.insert(key.clone(), value.clone());
+                            }
+                        }
+                        Value::Object(merged)
+                    }
+                    _ => catalog_model,
+                }
+            }
+            None => {
+                // Unknown upstream models often have manually configured limits,
+                // tool support, or options that cannot be recovered from the catalog.
+                let mut entry = existing_models
+                    .get(model_id)
+                    .and_then(Value::as_object)
+                    .cloned()
+                    .unwrap_or_default();
+                if let Value::Object(defaults) =
+                    build_fallback_model_json(model_id, input.name.as_deref())
+                {
+                    for (key, value) in defaults {
+                        entry.entry(key).or_insert(value);
+                    }
+                }
+                Value::Object(entry)
+            }
+        };
+        models.insert(model_id.to_string(), entry);
+    }
+    provider["models"] = Value::Object(models);
+}
+
+fn apply_openai_compatible_provider_sync(
+    mut config: Value,
+    provider_id: &str,
+    provider_name: &str,
+    proxy_url: &str,
+    api_key: &str,
+    models_to_sync: Option<&[ModelInput]>,
+) -> Value {
+    if !config.is_object() {
+        config = serde_json::json!({});
+    }
+
+    if config.get("$schema").is_none() {
+        config["$schema"] = Value::String("https://opencode.ai/config.json".to_string());
+    }
+
+    let normalized_url = normalize_opencode_base_url(proxy_url);
+    let display_name = if provider_name.trim().is_empty() {
+        "APIKEY.FUN"
+    } else {
+        provider_name.trim()
+    };
+
+    ensure_object(&mut config, "provider");
+
+    if let Some(provider) = config.get_mut("provider").and_then(|p| p.as_object_mut()) {
+        ensure_provider_object(provider, provider_id);
+        if let Some(target) = provider.get_mut(provider_id) {
+            ensure_provider_string_field(target, "npm", OPENAI_COMPATIBLE_NPM);
+            ensure_provider_string_field(target, "name", display_name);
+            ensure_object(target, "options");
+            merge_provider_options(target, &normalized_url, api_key);
+            replace_provider_models(target, models_to_sync);
         }
     }
 
@@ -2352,6 +2613,338 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_openai_compatible_sync_creates_apikey_fun_provider() {
+        let config = serde_json::json!({
+            "provider": {
+                ANTIGRAVITY_PROVIDER_ID: {
+                    "npm": "@ai-sdk/anthropic",
+                    "name": "Antigravity Manager",
+                    "options": { "apiKey": "ag-key" }
+                }
+            }
+        });
+        let models_to_sync = [
+            minput("gpt-5.5"),
+            minput_named("claude-sonnet-4-6", "Claude Sonnet 4.6"),
+        ];
+
+        let result = apply_openai_compatible_provider_sync(
+            config,
+            APIKEY_FUN_PROVIDER_ID,
+            "APIKEY.FUN",
+            "https://api.apikey.fun",
+            "fun-key",
+            Some(&models_to_sync),
+        );
+
+        let provider = result.get("provider").unwrap();
+        assert!(
+            provider.get(ANTIGRAVITY_PROVIDER_ID).is_some(),
+            "antigravity-manager provider should be preserved"
+        );
+        let fun = provider.get(APIKEY_FUN_PROVIDER_ID).unwrap();
+        assert_eq!(fun.get("npm").unwrap(), OPENAI_COMPATIBLE_NPM);
+        assert_eq!(fun.get("name").unwrap(), "APIKEY.FUN");
+        assert_eq!(
+            fun.get("options").unwrap().get("baseURL").unwrap(),
+            "https://api.apikey.fun/v1"
+        );
+        assert_eq!(
+            fun.get("options").unwrap().get("apiKey").unwrap(),
+            "fun-key"
+        );
+
+        let models = fun.get("models").unwrap().as_object().unwrap();
+        assert_eq!(models.len(), 2);
+        assert_eq!(
+            models.get("gpt-5.5").unwrap().get("name").unwrap(),
+            "Gpt 5.5"
+        );
+
+        // claude-sonnet-4-6 is in the catalog: full metadata, dotted display name.
+        let claude = models.get("claude-sonnet-4-6").unwrap();
+        assert_eq!(claude.get("name").unwrap(), "Claude Sonnet 4.6");
+        assert_eq!(claude["limit"]["context"], 200_000);
+        assert_eq!(claude["limit"]["output"], 64_000);
+        assert!(claude.get("modalities").is_some());
+    }
+
+    #[test]
+    fn test_openai_compatible_sync_replaces_models() {
+        let config = serde_json::json!({
+            "provider": {
+                APIKEY_FUN_PROVIDER_ID: {
+                    "models": {
+                        "old-model": { "name": "Old Model" }
+                    }
+                }
+            }
+        });
+
+        let result = apply_openai_compatible_provider_sync(
+            config,
+            APIKEY_FUN_PROVIDER_ID,
+            "APIKEY.FUN",
+            "https://api.apikey.fun/v1",
+            "fun-key",
+            Some(&[minput("gpt-5.5")]),
+        );
+
+        let models = result["provider"][APIKEY_FUN_PROVIDER_ID]["models"]
+            .as_object()
+            .unwrap();
+        assert!(models.contains_key("gpt-5.5"));
+        assert!(!models.contains_key("old-model"));
+    }
+
+    #[test]
+    fn test_openai_compatible_sync_empty_models_keeps_existing() {
+        let config = serde_json::json!({
+            "provider": {
+                APIKEY_FUN_PROVIDER_ID: {
+                    "models": {
+                        "gpt-4o": { "name": "GPT-4o", "custom": true }
+                    }
+                }
+            }
+        });
+
+        let result = apply_openai_compatible_provider_sync(
+            config,
+            APIKEY_FUN_PROVIDER_ID,
+            "APIKEY.FUN",
+            "https://api.apikey.fun/v1",
+            "fun-key",
+            Some(&[]),
+        );
+
+        let models = result["provider"][APIKEY_FUN_PROVIDER_ID]["models"]
+            .as_object()
+            .unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models.get("gpt-4o").unwrap().get("name").unwrap(), "GPT-4o");
+        assert_eq!(
+            models.get("gpt-4o").unwrap().get("custom").unwrap(),
+            &Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn test_provider_id_validation() {
+        assert!(validate_provider_id("apikey-fun").is_ok());
+        assert!(validate_provider_id("My_Provider2").is_ok());
+        assert!(validate_provider_id("").is_err());
+        assert!(validate_provider_id("  ").is_err());
+        assert!(validate_provider_id("bad/id").is_err());
+        assert!(validate_provider_id("bad id").is_err());
+    }
+
+    #[test]
+    fn test_openai_sync_preserves_unknown_model_settings() {
+        let existing = serde_json::json!({
+            "name": "My GPT",
+            "limit": { "context": 128_000, "output": 16_384 },
+            "options": { "reasoningEffort": "high" },
+            "tool_call": true
+        });
+        let result = apply_openai_compatible_provider_sync(
+            serde_json::json!({ "provider": { APIKEY_FUN_PROVIDER_ID: {
+                "models": { "gpt-5.5": existing.clone() }
+            }}}),
+            APIKEY_FUN_PROVIDER_ID,
+            "APIKEY.FUN",
+            "https://api.apikey.fun/v1/",
+            "fun-key",
+            Some(&[minput("gpt-5.5")]),
+        );
+        assert_eq!(
+            result["provider"][APIKEY_FUN_PROVIDER_ID]["models"]["gpt-5.5"],
+            existing
+        );
+        assert_eq!(
+            result["provider"][APIKEY_FUN_PROVIDER_ID]["options"]["baseURL"],
+            "https://api.apikey.fun/v1"
+        );
+    }
+
+    #[test]
+    fn test_openai_sync_repairs_non_object_options() {
+        for options in [
+            Value::Null,
+            serde_json::json!([]),
+            serde_json::json!("invalid"),
+        ] {
+            let result = apply_openai_compatible_provider_sync(
+                serde_json::json!({ "provider": { APIKEY_FUN_PROVIDER_ID: { "options": options }}}),
+                APIKEY_FUN_PROVIDER_ID,
+                "APIKEY.FUN",
+                "https://api.apikey.fun",
+                "fun-key",
+                None,
+            );
+            assert_eq!(
+                result["provider"][APIKEY_FUN_PROVIDER_ID]["options"]["apiKey"],
+                "fun-key"
+            );
+        }
+    }
+
+    #[test]
+    fn test_openai_sync_leaves_invalid_config_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(OPENCODE_CONFIG_FILE_JSONC);
+        for content in ["{ broken", "[]", "null", ""] {
+            fs::write(&path, content).unwrap();
+            let result = sync_openai_provider_to_path(
+                &path,
+                APIKEY_FUN_PROVIDER_ID,
+                "APIKEY.FUN",
+                "https://api.apikey.fun",
+                "fun-key",
+                None,
+            );
+            assert!(result.is_err(), "must reject invalid config: {content}");
+            assert_eq!(fs::read_to_string(&path).unwrap(), content);
+            assert!(!path.with_extension("tmp").exists());
+            assert!(!tmp
+                .path()
+                .join(format!("{OPENCODE_CONFIG_FILE_JSONC}{BACKUP_SUFFIX}"))
+                .exists());
+        }
+        // A read error must also propagate instead of replacing the config.
+        fs::remove_file(&path).unwrap();
+        fs::create_dir(&path).unwrap();
+        assert!(sync_openai_provider_to_path(
+            &path,
+            APIKEY_FUN_PROVIDER_ID,
+            "APIKEY.FUN",
+            "https://api.apikey.fun",
+            "fun-key",
+            None,
+        )
+        .is_err());
+        assert!(path.is_dir());
+    }
+
+    #[test]
+    fn test_openai_sync_preserves_jsonc_unicode_and_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(OPENCODE_CONFIG_FILE_JSONC);
+        let content = r#"{
+            // User settings must survive syncing another provider.
+            "instructions": ["инструкции.md", "日本語.md", "🚀.md",],
+            "provider": {"custom": {"name": "Мой провайдер",},},
+        }"#;
+        fs::write(&path, content).unwrap();
+        sync_openai_provider_to_path(
+            &path,
+            APIKEY_FUN_PROVIDER_ID,
+            "APIKEY.FUN",
+            "https://api.apikey.fun/v1/",
+            "fun-key",
+            Some(&[minput("gpt-5.5")]),
+        )
+        .unwrap();
+        let config: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            config["instructions"],
+            serde_json::json!(["инструкции.md", "日本語.md", "🚀.md"])
+        );
+        assert_eq!(config["provider"]["custom"]["name"], "Мой провайдер");
+        assert_eq!(
+            config["provider"][APIKEY_FUN_PROVIDER_ID]["options"]["baseURL"],
+            "https://api.apikey.fun/v1"
+        );
+        let backup = tmp
+            .path()
+            .join(format!("{OPENCODE_CONFIG_FILE_JSONC}{BACKUP_SUFFIX}"));
+        assert_eq!(fs::read_to_string(&backup).unwrap(), content);
+        sync_openai_provider_to_path(
+            &path,
+            APIKEY_FUN_PROVIDER_ID,
+            "APIKEY.FUN",
+            "https://api.apikey.fun/v1",
+            "next-key",
+            None,
+        )
+        .unwrap();
+        assert_eq!(fs::read_to_string(&backup).unwrap(), content);
+    }
+
+    #[test]
+    fn test_openai_sync_creates_missing_config_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("new").join(OPENCODE_CONFIG_FILE);
+        sync_openai_provider_to_path(
+            &path,
+            APIKEY_FUN_PROVIDER_ID,
+            "APIKEY.FUN",
+            "https://api.apikey.fun",
+            "fun-key",
+            None,
+        )
+        .unwrap();
+        let config = parse_config_file(&path).unwrap();
+        assert_eq!(
+            config["provider"][APIKEY_FUN_PROVIDER_ID]["options"]["apiKey"],
+            "fun-key"
+        );
+    }
+
+    #[test]
+    fn test_humanize_joins_hyphenated_version() {
+        assert_eq!(humanize_model_id("claude-sonnet-4-6"), "Claude Sonnet 4.6");
+        assert_eq!(
+            humanize_model_id("claude-sonnet-4-6-thinking"),
+            "Claude Sonnet 4.6 Thinking"
+        );
+        assert_eq!(
+            humanize_model_id("gemini-3.5-flash-low"),
+            "Gemini 3.5 Flash Low"
+        );
+        assert_eq!(
+            humanize_model_id("anthropic/claude-opus-4-6"),
+            "Claude Opus 4.6"
+        );
+        assert_eq!(humanize_model_id("grok-4.20-0309"), "Grok 4.20 0309");
+    }
+
+    #[test]
+    fn test_openai_compatible_sync_matches_dotted_and_prefixed_ids() {
+        let result = apply_openai_compatible_provider_sync(
+            serde_json::json!({}),
+            APIKEY_FUN_PROVIDER_ID,
+            "APIKEY.FUN",
+            "https://api.apikey.fun/v1",
+            "fun-key",
+            Some(&[
+                minput("claude-sonnet-4.6"),
+                minput("anthropic/claude-opus-4-6"),
+            ]),
+        );
+        let models = result["provider"][APIKEY_FUN_PROVIDER_ID]["models"]
+            .as_object()
+            .unwrap();
+        assert_eq!(
+            models
+                .get("claude-sonnet-4.6")
+                .unwrap()
+                .get("name")
+                .unwrap(),
+            "Claude Sonnet 4.6"
+        );
+        assert_eq!(
+            models
+                .get("anthropic/claude-opus-4-6")
+                .unwrap()
+                .get("name")
+                .unwrap(),
+            "Claude Opus 4.6"
+        );
+        assert_eq!(models["claude-sonnet-4.6"]["limit"]["context"], 200_000);
+    }
+
     // Tests for apply_clear_to_config
 
     #[test]
@@ -3000,6 +3593,33 @@ pub async fn execute_opencode_sync(
 ) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         sync_opencode_config(&proxy_url, &api_key, sync_accounts.unwrap_or(false), models)
+    })
+    .await
+    .unwrap_or_else(|_| Err("Failed to execute sync".to_string()))
+}
+
+#[tauri::command]
+pub async fn execute_opencode_openai_sync(
+    proxy_url: String,
+    api_key: String,
+    provider_id: Option<String>,
+    provider_name: Option<String>,
+    models: Option<Vec<ModelInput>>,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        sync_opencode_openai_provider(
+            provider_id
+                .as_deref()
+                .filter(|id| !id.trim().is_empty())
+                .unwrap_or(APIKEY_FUN_PROVIDER_ID),
+            provider_name
+                .as_deref()
+                .filter(|name| !name.trim().is_empty())
+                .unwrap_or("APIKEY.FUN"),
+            &proxy_url,
+            &api_key,
+            models,
+        )
     })
     .await
     .unwrap_or_else(|_| Err("Failed to execute sync".to_string()))

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -754,6 +754,10 @@ impl AxumServer {
             )
             .route("/proxy/opencode/sync", post(admin_execute_opencode_sync))
             .route(
+                "/proxy/opencode/openai-sync",
+                post(admin_execute_opencode_openai_sync),
+            )
+            .route(
                 "/proxy/opencode/restore",
                 post(admin_execute_opencode_restore),
             )
@@ -3891,6 +3895,38 @@ async fn admin_execute_opencode_sync(
         payload.proxy_url,
         payload.api_key,
         Some(payload.sync_accounts),
+        payload.models,
+    )
+    .await
+    .map(|_| StatusCode::OK)
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse { error: e }),
+        )
+    })
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OpencodeOpenaiSyncRequest {
+    proxy_url: String,
+    api_key: String,
+    #[serde(default)]
+    provider_id: Option<String>,
+    #[serde(default)]
+    provider_name: Option<String>,
+    models: Option<Vec<crate::proxy::opencode_sync::ModelInput>>,
+}
+
+async fn admin_execute_opencode_openai_sync(
+    Json(payload): Json<OpencodeOpenaiSyncRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    crate::proxy::opencode_sync::execute_opencode_openai_sync(
+        payload.proxy_url,
+        payload.api_key,
+        payload.provider_id,
+        payload.provider_name,
         payload.models,
     )
     .await

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1225,7 +1225,8 @@
       "quickConfig": "One-Click Local Dev Setup",
       "syncDesc": "Sync to official standard configuration",
       "codexTooltip": "Sync API Key & BaseURL to Antigravity Codex",
-      "claudeTooltip": "Sync API Key & BaseURL to Claude Code"
+      "claudeTooltip": "Sync API Key & BaseURL to Claude Code",
+      "opencodeTooltip": "Sync API Key, BaseURL and models to OpenCode"
     },
     "models": {
       "title": "Available Models",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1453,7 +1453,8 @@
       "quickConfig": "One-Click Local Dev Setup",
       "syncDesc": "Sync to official standard configuration",
       "codexTooltip": "Sync API Key & BaseURL to Codex / ChatGPT CLI",
-      "claudeTooltip": "Sync API Key & BaseURL to Claude Code"
+      "claudeTooltip": "Sync API Key & BaseURL to Claude Code",
+      "opencodeTooltip": "Sync API Key, BaseURL and models to OpenCode"
     },
     "models": {
       "title": "Available Models",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1451,7 +1451,8 @@
       "quickConfig": "Configuración local en un clic",
       "syncDesc": "Sincronizar con la configuración estándar oficial",
       "codexTooltip": "Sync API Key & BaseURL to Antigravity Codex",
-      "claudeTooltip": "Sincronizar API Key y BaseURL con Claude Code"
+      "claudeTooltip": "Sincronizar API Key y BaseURL con Claude Code",
+      "opencodeTooltip": "Sincronizar API Key, BaseURL y modelos con OpenCode"
     },
     "models": {
       "title": "Modelos disponibles",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1451,7 +1451,8 @@
       "quickConfig": "ワンクリック開発環境設定",
       "syncDesc": "公式標準設定に同期",
       "codexTooltip": "Codexに同期",
-      "claudeTooltip": "Claude Codeに同期"
+      "claudeTooltip": "Claude Codeに同期",
+      "opencodeTooltip": "API Key、BaseURL、モデルを OpenCode に同期"
     },
     "models": {
       "title": "利用可能なモデル",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1451,7 +1451,8 @@
       "quickConfig": "원클릭 로컬 개발 설정",
       "syncDesc": "공식 표준 설정으로 동기화",
       "codexTooltip": "API Key와 BaseURL을 Antigravity Codex에 동기화",
-      "claudeTooltip": "API Key와 BaseURL을 Claude Code에 동기화"
+      "claudeTooltip": "API Key와 BaseURL을 Claude Code에 동기화",
+      "opencodeTooltip": "API Key, BaseURL, 모델을 OpenCode에 동기화"
     },
     "models": {
       "title": "사용 가능한 모델",

--- a/src/locales/my.json
+++ b/src/locales/my.json
@@ -1123,7 +1123,8 @@
       "quickConfig": "One-Click Local Dev Setup",
       "syncDesc": "Sync to official standard configuration",
       "codexTooltip": "Sync API Key & BaseURL to Antigravity Codex",
-      "claudeTooltip": "Sync API Key & BaseURL to Claude Code"
+      "claudeTooltip": "Sync API Key & BaseURL to Claude Code",
+      "opencodeTooltip": "Sync API Key, BaseURL and models to OpenCode"
     },
     "models": {
       "title": "Available Models",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1520,7 +1520,8 @@
       "quickConfig": "One-Click Local Dev Setup",
       "syncDesc": "Sync to official standard configuration",
       "codexTooltip": "Sync API Key & BaseURL to Antigravity Codex",
-      "claudeTooltip": "Sync API Key & BaseURL to Claude Code"
+      "claudeTooltip": "Sync API Key & BaseURL to Claude Code",
+      "opencodeTooltip": "Sincronizar API Key, BaseURL e modelos com o OpenCode"
     },
     "models": {
       "title": "Available Models",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1451,7 +1451,8 @@
       "quickConfig": "One-Click Local Dev Setup",
       "syncDesc": "Sync to official standard configuration",
       "codexTooltip": "Sync API Key & BaseURL to Antigravity Codex",
-      "claudeTooltip": "Sync API Key & BaseURL to Claude Code"
+      "claudeTooltip": "Sync API Key & BaseURL to Claude Code",
+      "opencodeTooltip": "Синхронизировать API Key, BaseURL и модели в OpenCode"
     },
     "models": {
       "title": "Available Models",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1186,7 +1186,8 @@
       "quickConfig": "One-Click Local Dev Setup",
       "syncDesc": "Sync to official standard configuration",
       "codexTooltip": "Sync API Key & BaseURL to Antigravity Codex",
-      "claudeTooltip": "Sync API Key & BaseURL to Claude Code"
+      "claudeTooltip": "Sync API Key & BaseURL to Claude Code",
+      "opencodeTooltip": "API Key, BaseURL ve modelleri OpenCode ile senkronize et"
     },
     "models": {
       "title": "Available Models",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1235,7 +1235,8 @@
       "quickConfig": "One-Click Local Dev Setup",
       "syncDesc": "Sync to official standard configuration",
       "codexTooltip": "Sync API Key & BaseURL to Antigravity Codex",
-      "claudeTooltip": "Sync API Key & BaseURL to Claude Code"
+      "claudeTooltip": "Sync API Key & BaseURL to Claude Code",
+      "opencodeTooltip": "Đồng bộ API Key, BaseURL và models sang OpenCode"
     },
     "models": {
       "title": "Available Models",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -1256,7 +1256,8 @@
       "quickConfig": "一鍵配置本地開發環境",
       "syncDesc": "同步至官方標準配置",
       "codexTooltip": "將 API Key 同步至 Antigravity Codex",
-      "claudeTooltip": "將 API Key 同步至 Claude Code"
+      "claudeTooltip": "將 API Key 同步至 Claude Code",
+      "opencodeTooltip": "將 API Key、BaseURL 與模型同步至 OpenCode"
     },
     "models": {
       "title": "可用模型",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1418,7 +1418,8 @@
       "quickConfig": "一键配置本地开发环境",
       "syncDesc": "同步至官方标准配置",
       "codexTooltip": "将 API Key 与 BaseURL 同步至 Codex / ChatGPT CLI",
-      "claudeTooltip": "将 API Key 与 BaseURL 同步至 Claude Code"
+      "claudeTooltip": "将 API Key 与 BaseURL 同步至 Claude Code",
+      "opencodeTooltip": "将 API Key、BaseURL 和模型同步至 OpenCode"
     },
     "models": {
       "title": "可用模型",

--- a/src/pages/ApiKeyFun.tsx
+++ b/src/pages/ApiKeyFun.tsx
@@ -21,6 +21,7 @@ import {
     TrendingUp,
     Zap,
     Code,
+    CodeXml,
     Wand2
 } from 'lucide-react';
 import { motion } from 'framer-motion';
@@ -77,6 +78,8 @@ export const ApiKeyFun: React.FC = () => {
     const [querying, setQuerying] = useState(false);
     const [usage, setUsage] = useState<UsageSummary | null>(null);
     const [models, setModels] = useState<string[]>([]);
+    const [modelsSource, setModelsSource] = useState<{ key: string; endpoint: string } | null>(null);
+    const [syncingOpenCode, setSyncingOpenCode] = useState(false);
     const [queryError, setQueryError] = useState<string | null>(null);
     const [modelsError, setModelsError] = useState<string | null>(null);
     
@@ -119,6 +122,7 @@ export const ApiKeyFun: React.FC = () => {
         setQueryError(null);
         setUsage(null);
         setModels([]);
+        setModelsSource(null);
 
         try {
             // 1. Fetch available models
@@ -143,6 +147,7 @@ export const ApiKeyFun: React.FC = () => {
                 setModelsError(t('apiKeyFun.errors.fetchFailed', { defaultValue: '获取失败: {{err}}', err: err.message || String(err) }));
             }
             setModels(fetchedModels);
+            setModelsSource({ key, endpoint });
 
             // 2. Fetch balance (Try sub2api /usage first, then New API billing)
             let usageSummary: UsageSummary | null = null;
@@ -318,6 +323,37 @@ export const ApiKeyFun: React.FC = () => {
             showToast(t('apiKeyFun.syncSuccess', { defaultValue: 'Successfully synced to {{app}}', app }), 'success');
         } catch (error: any) {
             showToast(t('apiKeyFun.syncError', { defaultValue: 'Failed to sync: {{error}}', error: error.toString() }), 'error');
+        }
+    };
+
+    const handleSyncOpenCode = async () => {
+        if (!apiKey.trim() || !baseUrl.trim() || syncingOpenCode || querying) return;
+        const rawKey = apiKey.trim();
+        // The backend normalizes /v1; appending it here duplicates it for /v1/ URLs.
+        const proxyUrl = baseUrl.trim().replace(/\/+$/, '');
+        // Inputs can change before their model query finishes. Never export models
+        // obtained with another key or endpoint (including late query responses).
+        const currentModels = modelsSource?.key === rawKey && modelsSource.endpoint === proxyUrl
+            ? models : [];
+        const modelInputs = currentModels
+            .map((id) => id.trim())
+            .filter(Boolean)
+            .map((id) => ({ id }));
+
+        setSyncingOpenCode(true);
+        try {
+            await request('execute_opencode_openai_sync', {
+                proxyUrl,
+                apiKey: rawKey,
+                providerId: 'apikey-fun',
+                providerName: 'APIKEY.FUN',
+                models: modelInputs.length > 0 ? modelInputs : undefined
+            });
+            showToast(t('apiKeyFun.syncSuccess', { defaultValue: 'Successfully synced to {{app}}', app: 'OpenCode' }), 'success');
+        } catch (error: any) {
+            showToast(t('apiKeyFun.syncError', { defaultValue: 'Failed to sync: {{error}}', error: error.toString() }), 'error');
+        } finally {
+            setSyncingOpenCode(false);
         }
     };
 
@@ -714,6 +750,7 @@ export const ApiKeyFun: React.FC = () => {
                                                     onClick={() => handleSyncCli('Codex')}
                                                     className="flex-1 sm:flex-none btn btn-sm px-5 font-medium rounded-full bg-blue-500 hover:bg-blue-600 text-white border-none shadow-md shadow-blue-500/20 transition-all group"
                                                     disabled={!apiKey}
+                                                    title={t('apiKeyFun.cli.codexTooltip', { defaultValue: 'Sync API Key & BaseURL to Codex / ChatGPT CLI' })}
                                                 >
                                                     <Code size={14} className="mr-1.5 opacity-90 group-hover:scale-110 group-hover:opacity-100 transition-all" />
                                                     Codex
@@ -724,11 +761,21 @@ export const ApiKeyFun: React.FC = () => {
                                                     onClick={() => handleSyncCli('Claude')}
                                                     className="flex-1 sm:flex-none btn btn-sm px-5 font-medium rounded-full bg-purple-500 hover:bg-purple-600 text-white border-none shadow-md shadow-purple-500/20 transition-all group"
                                                     disabled={!apiKey}
+                                                    title={t('apiKeyFun.cli.claudeTooltip', { defaultValue: 'Sync API Key & BaseURL to Claude Code' })}
                                                 >
                                                     <Cpu size={14} className="mr-1.5 opacity-90 group-hover:scale-110 group-hover:opacity-100 transition-all" />
                                                     Claude
                                                 </button>
                                             )}
+                                            <button
+                                                onClick={handleSyncOpenCode}
+                                                className="flex-1 sm:flex-none btn btn-sm px-5 font-medium rounded-full bg-teal-500 hover:bg-teal-600 text-white border-none shadow-md shadow-teal-500/20 transition-all group"
+                                                disabled={!apiKey.trim() || !baseUrl.trim() || querying || syncingOpenCode}
+                                                title={t('apiKeyFun.cli.opencodeTooltip', { defaultValue: 'Sync API Key, BaseURL and models to OpenCode' })}
+                                            >
+                                                <CodeXml size={14} className="mr-1.5 opacity-90 group-hover:scale-110 group-hover:opacity-100 transition-all" />
+                                                OpenCode
+                                            </button>
                                         </div>
                                     );
                                 })()}

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -70,6 +70,7 @@ const COMMAND_MAPPING: Record<string, { url: string; method: 'GET' | 'POST' | 'D
   // OpenCode Sync
   'get_opencode_sync_status': { url: '/api/proxy/opencode/status', method: 'POST' },
   'execute_opencode_sync': { url: '/api/proxy/opencode/sync', method: 'POST' },
+  'execute_opencode_openai_sync': { url: '/api/proxy/opencode/openai-sync', method: 'POST' },
   'execute_opencode_restore': { url: '/api/proxy/opencode/restore', method: 'POST' },
   'execute_opencode_clear': { url: '/api/proxy/opencode/clear', method: 'POST' },
   'get_opencode_config_content': { url: '/api/proxy/opencode/config', method: 'POST' },


### PR DESCRIPTION
<img width="941" height="293" alt="image" src="https://github.com/user-attachments/assets/6f624119-9e5d-44b3-b7b5-e7962ed8fca6" />

Adds an OpenCode button to the APIKEY.FUN page to sync the current API key, BaseURL, and queried models into a separate `apikey-fun` provider using `@ai-sdk/openai-compatible`. The command is available through both Tauri and the authenticated web API, with tooltips in all 13 locales.

The sync preserves other providers, backs up the active JSON/JSONC config, enriches recognized model IDs from the existing catalog, and replaces the provider's model list when a nonempty list is supplied. Missing or empty model lists preserve the existing list. Vendor-prefixed and dotted/dashed model IDs keep their upstream IDs while receiving matching catalog metadata.

Review fixes included:

- Normalize the URL only in the backend, so a saved endpoint ending in `/v1/` does not become `/v1/v1`.
- Associate queried models with their key and endpoint, preventing edited keys or late query responses from exporting another key's model list. Disable sync while querying/syncing and for blank inputs.
- Abort on unreadable, invalid, or non-object configs before writing or creating a backup. Preserve UTF-8 bytes when parsing JSONC so Unicode instructions and file paths survive.
- Preserve manual settings on surviving models outside the catalog, and repair malformed provider options before writing credentials.

Validation:

- `npm run build` passed (TypeScript and production bundle).
- `cargo clippy --all-targets --all-features --locked --offline` passed with warnings.
- `cargo test --lib opencode_sync --locked --offline`: 59 passed, 2 failed. All 11 added tests passed. The same two failures reproduce on a clean copy of upstream `85fb4fe6` (48 passed, 2 failed): `canonical_families_expose_the_complete_public_dto` and `catalog_preserves_non_gemini3_variant_json_snapshot`.
- `rustfmt --edition 2021 --check src-tauri/src/proxy/opencode_sync.rs` and `git diff --check` passed. Repository-wide `cargo fmt -- --check` already fails on upstream in 28 files; this PR does not reformat unrelated files.
- An isolated harness exercised the actual page handlers with mocked requests: matching models, edited keys, late responses, trailing slashes, blank keys, and pending query/sync guards. Locale JSON and tooltip keys validated.
- Added backend filesystem regression tests and an APIKEY.FUN section to the manual verification checklist. Live provider requests were not repeated during this review.
