### PR TITLE
fix(ui): highlight enabled toggles in dark mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,6 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Override dark background utilities so enabled switches remain distinct. */
+.dark input.toggle[type="checkbox"]:checked {
+  background-color: var(--app-toggle-active, #3b82f6);
+  border-color: var(--app-toggle-active, #3b82f6);
+}
+
+.dark input.toggle[type="checkbox"]:checked::before {
+  background-color: #ffffff;
+}
+
+.dark input.toggle.toggle-success { --app-toggle-active: #16a34a; }
+.dark input.toggle.toggle-warning { --app-toggle-active: #d97706; }
+.dark input.toggle.toggle-error { --app-toggle-active: #dc2626; }
+
 /* 禁止过度滚动和橡皮筋效果 */
 html,
 body {


### PR DESCRIPTION
In dark mode, gray background utilities override the checked background of service switches, so enabled and disabled settings look almost identical. Give checked switches a blue track and white thumb, while preserving the success/warning/error colors. All overrides are scoped to `.dark`; light-mode styling and toggle behavior are unchanged.

Validation: production frontend build and Windows release build passed (existing warnings); the installed app starts and `/health` returns `ok`. The dark-mode appearance was checked in the Windows app and confirmed by the reporter. `git diff --check` passed.

**Before**

![Before: enabled auto-start and authorization switches have gray backgrounds](https://raw.githubusercontent.com/Avlaak/Antigravity-Manager/96450f0ba59e8351857ab131cc5305acd20e193a/before.png)

**After**

![After: enabled switches have blue backgrounds; disabled LAN access remains gray](https://github.com/user-attachments/assets/bf4d38b7-b3b1-45f5-802f-0b9546f105ee)

Screenshots are cropped to service settings, excluding credentials.
