### PR TITLE
fix(brew): migrate deprecated flight hooks

### DIFF
--- a/Casks/antigravity-tools.rb
+++ b/Casks/antigravity-tools.rb
@@ -13,11 +13,10 @@ cask "antigravity-tools" do
 
     app "Antigravity Tools.app"
 
-    postflight do
-      system_command "xattr",
-                     args:         ["-rd", "com.apple.quarantine", "#{appdir}/Antigravity Tools.app"],
-                     sudo:         false,
-                     must_succeed: false
+    postflight_steps do
+      run "/usr/bin/xattr",
+          args:         ["-rd", "com.apple.quarantine", "{{appdir}}/Antigravity Tools.app"],
+          must_succeed: false
     end
 
     zap trash: [
@@ -34,10 +33,8 @@ cask "antigravity-tools" do
     arch arm: "aarch64", intel: "amd64"
 
     url "https://github.com/lbjlaq/Antigravity-Manager/releases/download/v#{version}/Antigravity.Tools_#{version}_#{arch}.AppImage"
-    binary "Antigravity.Tools_#{version}_#{arch}.AppImage", target: "antigravity-tools"
-
-    preflight do
-      system_command "/bin/chmod", args: ["+x", "#{staged_path}/Antigravity.Tools_#{version}_#{arch}.AppImage"]
+    binary "Antigravity.Tools_#{version}_#{arch}.AppImage", target: "antigravity-tools"    preflight_steps do
+      set_permissions "Antigravity.Tools_{{version}}_{{arch}}.AppImage", "0755"
     end
   end
 end

--- a/Casks/antigravity-tools.rb
+++ b/Casks/antigravity-tools.rb
@@ -25,15 +25,15 @@ cask "antigravity-tools" do
       "~/Library/Preferences/com.lbjlaq.antigravity-tools.plist",
       "~/Library/Saved Application State/com.lbjlaq.antigravity-tools.savedState",
     ]
-
-
   end
 
   on_linux do
     arch arm: "aarch64", intel: "amd64"
 
     url "https://github.com/lbjlaq/Antigravity-Manager/releases/download/v#{version}/Antigravity.Tools_#{version}_#{arch}.AppImage"
-    binary "Antigravity.Tools_#{version}_#{arch}.AppImage", target: "antigravity-tools"    preflight_steps do
+    binary "Antigravity.Tools_#{version}_#{arch}.AppImage", target: "antigravity-tools"
+
+    preflight_steps do
       set_permissions "Antigravity.Tools_{{version}}_{{arch}}.AppImage", "0755"
     end
   end


### PR DESCRIPTION
## Summary

Migrate the Homebrew Cask's legacy `postflight` and `preflight` blocks to the structured `postflight_steps` and `preflight_steps` APIs.

Recent Homebrew versions emit deprecation warnings for the legacy flight hooks.

## Changes

* macOS: migrate the quarantine cleanup to `postflight_steps` using `run`
* Linux: migrate the AppImage executable permission setup to `preflight_steps` using `set_permissions`
* use Homebrew runtime tokens such as `{{appdir}}`, `{{version}}`, and `{{arch}}`

The intended installation behavior is preserved; this change only updates the Cask to the current Homebrew structured flight-step DSL.

## Validation

* Checked against the current Homebrew Cask `*flight_steps` documentation
* `brew style` was attempted locally, but Homebrew's Bundler dependency bootstrap timed out before the check completed
