### PR TITLE
fix(prompt): isolate global system prompt spacing, prevent duplicates, and ensure config sync

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -410,6 +410,20 @@ pub async fn save_config(
     // 通知托盘配置已更新
     let _ = app.emit("config://updated", ());
 
+    // 同步全局内存配置（无论反代服务当前是否处于运行状态）
+    crate::proxy::update_thinking_budget_config(config.proxy.thinking_budget.clone());
+    crate::proxy::update_global_system_prompt_config(config.proxy.global_system_prompt.clone());
+    crate::proxy::update_image_thinking_mode(config.proxy.image_thinking_mode.clone());
+    crate::proxy::config::update_global_compression_level(
+        config.proxy.experimental.compression_level.clone(),
+        config.proxy.experimental.enable_usage_scaling,
+    );
+    crate::proxy::config::update_global_thresholds(
+        config.proxy.experimental.context_compression_threshold_l1,
+        config.proxy.experimental.context_compression_threshold_l2,
+        config.proxy.experimental.context_compression_threshold_l3,
+    );
+
     // 热更新正在运行的服务
     let instance_lock = proxy_state.instance.read().await;
     if let Some(instance) = instance_lock.as_ref() {

--- a/src-tauri/src/proxy/mappers/claude/request.rs
+++ b/src-tauri/src/proxy/mappers/claude/request.rs
@@ -930,7 +930,7 @@ fn build_system_instruction(
     let antigravity_identity = "You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.\n\
     You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.\n\
     **Absolute paths only**\n\
-    **Proactiveness**";
+    **Proactiveness**\n\n";
 
     // [HYBRID] 检查用户是否已提供 Antigravity 身份
     let mut user_has_antigravity = false;
@@ -960,7 +960,8 @@ fn build_system_instruction(
     // [NEW] 注入全局系统提示词 (紧跟 Antigravity 身份之后)
     let global_prompt_config = crate::proxy::config::get_global_system_prompt();
     if global_prompt_config.enabled && !global_prompt_config.content.trim().is_empty() {
-        parts.push(json!({"text": global_prompt_config.content}));
+        let content = global_prompt_config.content.trim();
+        parts.push(json!({"text": format!("{}\n\n", content)}));
     }
 
     // 添加用户的系统提示词

--- a/src-tauri/src/proxy/mappers/gemini/wrapper.rs
+++ b/src-tauri/src/proxy/mappers/gemini/wrapper.rs
@@ -712,7 +712,7 @@ pub fn wrap_request_v2(
             "You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.\n\
             You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.\n\
             **Absolute paths only**\n\
-            **Proactiveness**"
+            **Proactiveness**\n\n"
         };
 
         // [HYBRID] 检查是否已有 systemInstruction
@@ -744,13 +744,22 @@ pub fn wrap_request_v2(
                     if global_prompt_config.enabled
                         && !global_prompt_config.content.trim().is_empty()
                     {
-                        // 插入位置：Antigravity 身份之后 (index 1)
-                        let insert_pos = if has_antigravity { 1 } else { 1 };
-                        if insert_pos <= parts_array.len() {
-                            parts_array
-                                .insert(insert_pos, json!({"text": global_prompt_config.content}));
-                        } else {
-                            parts_array.push(json!({"text": global_prompt_config.content}));
+                        let prompt_content = global_prompt_config.content.trim();
+                        let already_has_global = parts_array.iter().any(|p| {
+                            p.get("text")
+                                .and_then(|t| t.as_str())
+                                .map(|s| s.contains(prompt_content))
+                                .unwrap_or(false)
+                        });
+
+                        if !already_has_global {
+                            let formatted = format!("{}\n\n", prompt_content);
+                            let insert_pos = if has_antigravity { 1 } else { 1 };
+                            if insert_pos <= parts_array.len() {
+                                parts_array.insert(insert_pos, json!({"text": formatted}));
+                            } else {
+                                parts_array.push(json!({"text": formatted}));
+                            }
                         }
                     }
                 }
@@ -761,7 +770,7 @@ pub fn wrap_request_v2(
             // [NEW] 注入全局系统提示词
             let global_prompt_config = crate::proxy::config::get_global_system_prompt();
             if global_prompt_config.enabled && !global_prompt_config.content.trim().is_empty() {
-                parts.push(json!({"text": global_prompt_config.content}));
+                parts.push(json!({"text": format!("{}\n\n", global_prompt_config.content.trim())}));
             }
             inner_request["systemInstruction"] = json!({
                 "role": "user",


### PR DESCRIPTION
## Summary

This PR addresses formatting issues and edge-case behavior with the Global System Prompt and memory configuration synchronization:

1. **Prompt Isolation & Markdown Formatting**:
   - In `src-tauri/src/proxy/mappers/claude/request.rs` and `src-tauri/src/proxy/mappers/gemini/wrapper.rs`, added proper `\n\n` delimiters between the Antigravity identity prefix and the global system prompt.
   - Prevents Markdown headers like `## Global Preferences & Principles` from concatenating directly onto preceding bolded tokens (e.g., `**Proactiveness**## ...`), which previously broke Markdown parsing.
   - Ensures trailing prompt text is isolated from subsequent client headers (e.g., `x-anthropic-billing-header`).

2. **Deduplication in Gemini Wrapper**:
   - Added duplicate checking in `wrap_request_v2` to prevent repeated injection of the global system prompt if a request is wrapped multiple times or retried.

3. **Config Synchronization**:
   - In `save_config`, hoisted global static updates (`update_thinking_budget_config`, `update_global_system_prompt_config`, `update_image_thinking_mode`, and compression configs) out of the `instance.is_some()` branch. Settings are now synchronized in memory even when the proxy server instance is currently stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)